### PR TITLE
refactor: check analyze spending output

### DIFF
--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -13,7 +13,6 @@
 
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
-import { Goal } from '@/lib/types';
 
 const GoalSchema = z.object({
     id: z.string(),
@@ -84,6 +83,9 @@ const analyzeSpendingHabitsFlow = ai.defineFlow(
   },
   async input => {
     const {output} = await prompt(input);
-    return output!;
+    if (!output) {
+      throw new Error('No output returned from analyzeSpendingHabitsPrompt');
+    }
+    return output;
   }
 );


### PR DESCRIPTION
## Summary
- remove unused Goal import
- guard against undefined output in analyzeSpendingHabits flow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aeb9aeecf883319c4e3d909d122c67