### PR TITLE
fix: link to settings

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -67,11 +67,11 @@ export default function AppSidebar() {
           <Tooltip>
             <TooltipTrigger asChild>
               <Link
-                href="#"
-                className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground md:h-8 md:w-8"
+                href="/settings"
+                aria-label="Settings"
+                className="flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground md:h-8 md:w-8"
               >
                 <Settings className="h-5 w-5" />
-                <span className="sr-only">Settings</span>
               </Link>
             </TooltipTrigger>
             <TooltipContent side="right">Settings</TooltipContent>


### PR DESCRIPTION
## Summary
- route settings icon to /settings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Firebase: Error (auth/invalid-api-key))

------
https://chatgpt.com/codex/tasks/task_e_68aeb9addd788331a01dd729b086f139