### PR TITLE
Reduce toast removal delay and optimize listener registration

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- lower `TOAST_REMOVE_DELAY` to 5 seconds so toasts disappear in a reasonable time
- register toast listeners only once with a stable `useEffect` dependency array and keep cleanup on unmount

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: FirebaseError: Error (auth/invalid-api-key))*

------
https://chatgpt.com/codex/tasks/task_e_68aeb9ab94fc8331ad3d9c5c3721e93d