### PR TITLE
feat: validate firebase env vars

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,14 +1,29 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-};
+function getEnvVar(key: string, defaultValue?: string): string {
+  const value = process.env[key];
+  if (value === undefined || value === "") {
+    if (defaultValue !== undefined) {
+      return defaultValue;
+    }
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+  return value;
+}
+
+function getFirebaseConfig() {
+  return {
+    apiKey: getEnvVar("NEXT_PUBLIC_FIREBASE_API_KEY"),
+    authDomain: getEnvVar("NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN"),
+    projectId: getEnvVar("NEXT_PUBLIC_FIREBASE_PROJECT_ID"),
+    storageBucket: getEnvVar("NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET"),
+    messagingSenderId: getEnvVar("NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID"),
+    appId: getEnvVar("NEXT_PUBLIC_FIREBASE_APP_ID"),
+  };
+}
+
+const firebaseConfig = getFirebaseConfig();
 
 // Initialize Firebase
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();


### PR DESCRIPTION
## Summary
- ensure required Firebase env vars are present before init

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Found 12 errors in 4 files)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb9aac2b083319394b586b4e289f5