### PR TITLE
feat: make Genkit model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Environment Variables
+
+- `GENKIT_MODEL` – Optional. Overrides the default Genkit model (`googleai/gemini-2.5-flash`).

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -7,3 +7,6 @@ runConfig:
   maxInstances: 1
   cpu: 2
   memoryMiB: 4096
+  env:
+    - name: GENKIT_MODEL
+      value: googleai/gemini-2.5-flash # Optional override for the Genkit model

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,7 +1,9 @@
 import {genkit} from 'genkit';
 import {googleAI} from '@genkit-ai/googleai';
 
+const model = process.env.GENKIT_MODEL ?? 'googleai/gemini-2.5-flash';
+
 export const ai = genkit({
   plugins: [googleAI()],
-  model: 'googleai/gemini-2.5-flash',
+  model,
 });


### PR DESCRIPTION
## Summary
- allow overriding Genkit model with `GENKIT_MODEL`
- document `GENKIT_MODEL` in README and apphosting template
- use nullish coalescing for model environment variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: FirebaseError: auth/invalid-api-key)*


------
https://chatgpt.com/codex/tasks/task_e_68aeb9af61088331a72345b4142445a0