### PR TITLE
feat: add parallel computation helper

### DIFF
--- a/src/__tests__/parallel.test.ts
+++ b/src/__tests__/parallel.test.ts
@@ -1,0 +1,8 @@
+import { parallelSquare } from "../lib/parallel"
+
+describe("parallelSquare", () => {
+  it("computes squares in parallel", async () => {
+    const result = await parallelSquare([1, 2, 3, 4])
+    expect(result.sort((a, b) => a - b)).toEqual([1, 4, 9, 16])
+  })
+})

--- a/src/lib/mapWorker.js
+++ b/src/lib/mapWorker.js
@@ -1,0 +1,7 @@
+const { parentPort, workerData } = require("node:worker_threads")
+
+function square(numbers) {
+  return numbers.map(n => n * n)
+}
+
+parentPort.postMessage(square(workerData))

--- a/src/lib/parallel.ts
+++ b/src/lib/parallel.ts
@@ -1,0 +1,37 @@
+import { Worker } from "node:worker_threads"
+import os from "node:os"
+import path from "node:path"
+
+export async function parallelSquare(numbers: number[], threads = os.cpus().length): Promise<number[]> {
+  const chunkSize = Math.ceil(numbers.length / threads)
+  const chunks = Array.from({ length: threads }, (_, i) => numbers.slice(i * chunkSize, (i + 1) * chunkSize))
+
+  return new Promise((resolve, reject) => {
+    const results: number[] = []
+    let completed = 0
+
+    chunks.forEach(chunk => {
+      if (chunk.length === 0) {
+        completed++
+        if (completed === chunks.length) {
+          resolve(results)
+        }
+        return
+      }
+
+      const worker = new Worker(path.join(__dirname, "mapWorker.js"), {
+        workerData: chunk,
+      })
+
+      worker.on("message", (data: number[]) => {
+        results.push(...data)
+        completed++
+        if (completed === chunks.length) {
+          resolve(results)
+        }
+      })
+
+      worker.on("error", reject)
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- add worker-thread based helper for parallel number processing
- cover helper with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aec660a4e483319ab8f8ee8f55f4db