### PR TITLE
Gate dashboard mock delays behind debug flag

### DIFF
--- a/src/app/dashboard/dashboard-charts.tsx
+++ b/src/app/dashboard/dashboard-charts.tsx
@@ -4,23 +4,29 @@ import RecentTransactions from "@/components/dashboard/recent-transactions";
 import { mockTransactions } from "@/lib/data";
 import type { Transaction } from "@/lib/types";
 
+// Optional demo delay; disable in production
+const enableMockDelay = process.env.NEXT_PUBLIC_ENABLE_MOCK_DELAY === "true";
 
 const getTransactions = async (): Promise<Transaction[]> => {
-  await new Promise(resolve => setTimeout(resolve, 1000));
+  if (enableMockDelay) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
   return mockTransactions;
 }
 
 const getChartData = async () => {
+  if (enableMockDelay) {
     await new Promise(resolve => setTimeout(resolve, 1500));
-    return [
-      { month: "Jan", income: 4000, expenses: 2400 },
-      { month: "Feb", income: 3000, expenses: 1398 },
-      { month: "Mar", income: 5000, expenses: 3800 },
-      { month: "Apr", income: 2780, expenses: 3908 },
-      { month: "May", income: 1890, expenses: 4800 },
-      { month: "Jun", income: 4390, expenses: 3800 },
-      { month: "Jul", income: 5100, expenses: 2550 },
-    ]
+  }
+  return [
+    { month: "Jan", income: 4000, expenses: 2400 },
+    { month: "Feb", income: 3000, expenses: 1398 },
+    { month: "Mar", income: 5000, expenses: 3800 },
+    { month: "Apr", income: 2780, expenses: 3908 },
+    { month: "May", income: 1890, expenses: 4800 },
+    { month: "Jun", income: 4390, expenses: 3800 },
+    { month: "Jul", income: 5100, expenses: 2550 },
+  ]
 }
 
 


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC_ENABLE_MOCK_DELAY flag to optionally simulate latency
- remove default setTimeouts in dashboard chart helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af7857f478833184213e58149ccd02