### PR TITLE
feat: initialize auth state from persisted credentials

### DIFF
--- a/src/components/auth/auth-provider.tsx
+++ b/src/components/auth/auth-provider.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState, createContext, useContext } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
 import { auth } from "@/lib/firebase";
 import { usePathname, useRouter } from "next/navigation";
-import { Loader2 } from "lucide-react";
 
 interface AuthContextType {
   user: User | null;
@@ -15,68 +14,43 @@ const AuthContext = createContext<AuthContextType>({ user: null });
 export const useAuth = () => useContext(AuthContext);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
+  const getPersistedUser = (): User | null => {
+    if (typeof window === "undefined") return null;
+    try {
+      const key = Object.keys(localStorage).find((k) =>
+        k.startsWith("firebase:authUser")
+      );
+      const stored = key ? localStorage.getItem(key) : null;
+      return stored ? (JSON.parse(stored) as User) : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const [user, setUser] = useState<User | null>(() => auth.currentUser ?? getPersistedUser());
   const router = useRouter();
   const pathname = usePathname();
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user);
-      setLoading(false);
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser);
     });
 
     return () => unsubscribe();
   }, []);
 
   useEffect(() => {
-    if (loading) return;
-
     const isAuthPage = pathname === "/";
     if (!user && !isAuthPage) {
       router.push("/");
     } else if (user && isAuthPage) {
       router.push("/dashboard");
     }
-  }, [user, loading, router, pathname]);
+  }, [user, router, pathname]);
 
-  if (loading) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin" />
-      </div>
-    );
-  }
-  
-  const isAuthPage = pathname === "/";
-  // If the user is not logged in and not on the auth page, don't render anything until redirect happens.
-  if (!user && !isAuthPage) {
-    return null;
-  }
-  // If the user is logged in and on the auth page, don't render anything until redirect happens.
-  if (user && isAuthPage) {
-      return null;
-  }
-
-  // A 404 might occur if the user was on a page that no longer exists (e.g., /shifts)
-  // and the browser tries to navigate back. If the user is logged in but not on the auth page,
-  // we render the children, letting Next.js handle the valid routes.
-  if(user && !isAuthPage) {
-    return (
-      <AuthContext.Provider value={{ user }}>
-          {children}
-      </AuthContext.Provider>
-    );
-  }
-  
-  // Render login page for unauthenticated users
-  if(!user && isAuthPage){
-     return (
-        <AuthContext.Provider value={{ user }}>
-            {children}
-        </AuthContext.Provider>
-    );
-  }
-
-  return null;
+  return (
+    <AuthContext.Provider value={{ user }}>
+      {children}
+    </AuthContext.Provider>
+  );
 }


### PR DESCRIPTION
## Summary
- hydrate auth user from Firebase persistence or current user
- render children immediately and redirect asynchronously

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af785e49ec8331ba0beb876266c7fb