### PR TITLE
refactor: remove demo delay from overview cards

### DIFF
--- a/src/app/dashboard/overview-cards.tsx
+++ b/src/app/dashboard/overview-cards.tsx
@@ -4,9 +4,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { Transaction } from "@/lib/types";
 import { mockTransactions } from "@/lib/data";
 
-// Simulate slow data fetching
+// Optional demo delay; disable in production
+const enableMockDelay = process.env.NEXT_PUBLIC_ENABLE_MOCK_DELAY === "true";
+
 const getTransactions = async (): Promise<Transaction[]> => {
-  await new Promise(resolve => setTimeout(resolve, 1000));
+  if (enableMockDelay) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
   return mockTransactions;
 }
 


### PR DESCRIPTION
## Summary
- guard dashboard overview transactions mock delay behind NEXT_PUBLIC_ENABLE_MOCK_DELAY

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af796529c883319ae0da17108fcf96