### PR TITLE
Lazy load Recharts in dashboard charts

### DIFF
--- a/src/app/dashboard/dashboard-charts.tsx
+++ b/src/app/dashboard/dashboard-charts.tsx
@@ -1,8 +1,36 @@
 
-import IncomeExpenseChart from "@/components/dashboard/income-expense-chart";
+import dynamic from "next/dynamic";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import RecentTransactions from "@/components/dashboard/recent-transactions";
 import { mockTransactions } from "@/lib/data";
 import type { Transaction } from "@/lib/types";
+
+const IncomeExpenseChart = dynamic(
+  () => import("@/components/dashboard/income-expense-chart"),
+  {
+    ssr: false,
+    loading: () => (
+      <Card>
+        <CardHeader>
+          <CardTitle>Income vs. Expenses</CardTitle>
+          <CardDescription>
+            A look at your cash flow for the last 7 months.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-[300px] w-full" />
+        </CardContent>
+      </Card>
+    ),
+  }
+);
 
 // Optional demo delay; disable in production
 const enableMockDelay = process.env.NEXT_PUBLIC_ENABLE_MOCK_DELAY === "true";

--- a/src/components/dashboard/income-expense-chart.tsx
+++ b/src/components/dashboard/income-expense-chart.tsx
@@ -1,8 +1,47 @@
 "use client"
 
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import dynamic from "next/dynamic";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { useTheme } from "next-themes";
+
+const BarChart = dynamic(
+  () => import("recharts").then((mod) => mod.BarChart),
+  { ssr: false }
+);
+const Bar = dynamic(
+  () => import("recharts").then((mod) => mod.Bar),
+  { ssr: false }
+);
+const CartesianGrid = dynamic(
+  () => import("recharts").then((mod) => mod.CartesianGrid),
+  { ssr: false }
+);
+const XAxis = dynamic(
+  () => import("recharts").then((mod) => mod.XAxis),
+  { ssr: false }
+);
+const YAxis = dynamic(
+  () => import("recharts").then((mod) => mod.YAxis),
+  { ssr: false }
+);
+const Tooltip = dynamic(
+  () => import("recharts").then((mod) => mod.Tooltip),
+  { ssr: false }
+);
+const Legend = dynamic(
+  () => import("recharts").then((mod) => mod.Legend),
+  { ssr: false }
+);
+const ResponsiveContainer = dynamic(
+  () => import("recharts").then((mod) => mod.ResponsiveContainer),
+  { ssr: false }
+);
 
 interface IncomeExpenseChartProps {
   data: { month: string; income: number; expenses: number; }[];


### PR DESCRIPTION
## Summary
- dynamically import dashboard chart to avoid bundling Recharts server-side
- show skeleton card while chart module loads
- switch chart component to load Recharts primitives via `next/dynamic`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af7966dff0833197edf1beb01824b5