### PR TITLE
Guard mock transaction delay to development

### DIFF
--- a/src/app/dashboard/overview-cards.tsx
+++ b/src/app/dashboard/overview-cards.tsx
@@ -4,11 +4,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { Transaction } from "@/lib/types";
 import { mockTransactions } from "@/lib/data";
 
-// Optional demo delay; disable in production
-const enableMockDelay = process.env.NEXT_PUBLIC_ENABLE_MOCK_DELAY === "true";
-
+// Optional demo delay for development only
 const getTransactions = async (): Promise<Transaction[]> => {
-  if (enableMockDelay) {
+  if (process.env.NODE_ENV === "development") {
     await new Promise(resolve => setTimeout(resolve, 1000));
   }
   return mockTransactions;


### PR DESCRIPTION
## Summary
- remove environment variable for mock transaction delay
- run mock delay only in development using NODE_ENV

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af7acf93308331b0fe3cd9decd7c22