### PR TITLE
chore: guard debt deletion delay behind debug flag

### DIFF
--- a/src/components/debts/debt-card.tsx
+++ b/src/components/debts/debt-card.tsx
@@ -14,6 +14,9 @@ import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
 import type { Debt } from "@/lib/types";
 
+// Optional demo delay; disable in production
+const enableMockDelay = process.env.NEXT_PUBLIC_ENABLE_MOCK_DELAY === "true";
+
 interface DebtCardProps {
   debt: Debt;
   onDelete: (id: string) => void;
@@ -26,8 +29,11 @@ export function DebtCard({ debt, onDelete, onUpdate }: DebtCardProps) {
   const progress = (debt.currentAmount / debt.initialAmount) * 100;
   const remainingAmount = debt.initialAmount - debt.currentAmount;
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     setIsDeleting(true);
+    if (enableMockDelay) {
+      await new Promise(res => setTimeout(res, 500));
+    }
     onDelete(debt.id);
     setIsDeleting(false);
   };


### PR DESCRIPTION
## Summary
- guard debt deletion delay with `NEXT_PUBLIC_ENABLE_MOCK_DELAY`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af7ad26aa88331a9e135992e1fb520