### PR TITLE
defer transactions filtering while typing

### DIFF
--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useState, useMemo, useTransition } from "react";
+import { useState, useMemo, useDeferredValue } from "react";
 import { useRouter } from "next/navigation";
 import { mockTransactions } from "@/lib/data";
 import type { Transaction } from "@/lib/types";
@@ -16,7 +16,7 @@ export default function TransactionsPage() {
   const router = useRouter();
 
   const [searchTerm, setSearchTerm] = useState("");
-  const [isPending, startTransition] = useTransition();
+  const deferredSearchTerm = useDeferredValue(searchTerm);
   const [filterType, setFilterType] = useState("all");
   const [filterCategory, setFilterCategory] = useState("all");
 
@@ -35,18 +35,18 @@ export default function TransactionsPage() {
 
   const filteredTransactions = useMemo(() => {
     return transactions.filter(transaction => {
-        const matchesSearch = transaction.description.toLowerCase().includes(searchTerm.toLowerCase());
+        const matchesSearch = transaction.description.toLowerCase().includes(deferredSearchTerm.toLowerCase());
         const matchesType = filterType === 'all' || transaction.type === filterType;
         const matchesCategory = filterCategory === 'all' || transaction.category === filterCategory;
         return matchesSearch && matchesType && matchesCategory;
     });
-  }, [transactions, searchTerm, filterType, filterCategory]);
+  }, [transactions, deferredSearchTerm, filterType, filterCategory]);
 
   const handleSearchChange = (value: string) => {
-    startTransition(() => {
-      setSearchTerm(value);
-    });
+    setSearchTerm(value);
   };
+
+  const isSearching = deferredSearchTerm !== searchTerm;
 
   return (
     <div className="space-y-6">
@@ -78,7 +78,7 @@ export default function TransactionsPage() {
         categories={categories}
       />
 
-      {isPending && (
+      {isSearching && (
         <p className="text-sm text-muted-foreground">Filtering…</p>
       )}
 


### PR DESCRIPTION
## Summary
- use `useDeferredValue` for transactions search to delay filtering until typing pauses
- show a pending state while deferred search updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af7ad7d5748331956e29664a3d6895