### PR TITLE
feat: add loading spinners for main routes

### DIFF
--- a/src/app/cashflow/loading.tsx
+++ b/src/app/cashflow/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/src/app/debts/loading.tsx
+++ b/src/app/debts/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/src/app/goals/loading.tsx
+++ b/src/app/goals/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/src/app/insights/loading.tsx
+++ b/src/app/insights/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/src/app/taxes/loading.tsx
+++ b/src/app/taxes/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/src/app/transactions/loading.tsx
+++ b/src/app/transactions/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add route-level `loading.tsx` components using a shared `Loader2` spinner

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af7b6cb1b88331ac979a0abf7bc4c6