### PR TITLE
Use stateful page size in transactions table

### DIFF
--- a/src/components/transactions/transactions-table.tsx
+++ b/src/components/transactions/transactions-table.tsx
@@ -28,7 +28,7 @@ export const TransactionsTable = memo(function TransactionsTable({
   rowHeight = 56,
 }: TransactionsTableProps) {
   const [page, setPage] = useState(0)
-  const pageSize = 20
+  const [pageSize] = useState(20)
 
   const currentTransactions = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- manage page size via React state to support pagination
- keep current transaction slice memoized and drive virtual list and navigation controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af88d79e0c8331b69aa9fd487c0559