### PR TITLE
Enable TypeScript and ESLint build checks

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,9 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  typescript: { ignoreBuildErrors: true },
-  eslint: { ignoreDuringBuilds: true },
+  // Enforce type checking and linting during builds
+  typescript: { ignoreBuildErrors: false },
+  eslint: { ignoreDuringBuilds: false },
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'placehold.co', pathname: '/**' },


### PR DESCRIPTION
## Summary
- enforce type checking and linting during Next.js builds

## Testing
- `npm run build` (fails: `ssr: false is not allowed with next/dynamic in Server Components`)


------
https://chatgpt.com/codex/tasks/task_e_68af947ba2948331bef65c677e43e87f