### PR TITLE
refactor: leverage date-fns in debt occurrences hook

### DIFF
--- a/src/hooks/use-debt-occurrences.ts
+++ b/src/hooks/use-debt-occurrences.ts
@@ -1,44 +1,43 @@
 
 import { useMemo } from "react";
 import { Recurrence, Debt } from "@/lib/types";
+import {
+  addDays,
+  addMonths,
+  differenceInCalendarDays,
+  differenceInMonths,
+  isAfter,
+  isBefore,
+  isSameDay,
+  parseISO,
+} from "date-fns";
 
 const iso = (d: Date) => d.toISOString().slice(0, 10);
-const parseISO = (s: string) => {
-  const [y, m, dd] = s.split("-").map(Number);
-  return new Date(y, m - 1, dd);
-};
-const addDays = (d: Date, days: number) =>
-  new Date(d.getFullYear(), d.getMonth(), d.getDate() + days);
-const isSameDay = (a: Date, b: Date) =>
-  a.getFullYear() === b.getFullYear() &&
-  a.getMonth() === b.getMonth() &&
-  a.getDate() === b.getDate();
 
-function nextOccurrenceOnOrAfter(anchorISO: string, recurrence: Recurrence, onOrAfter: Date): Date | null {
+function nextOccurrenceOnOrAfter(
+  anchorISO: string,
+  recurrence: Recurrence,
+  onOrAfter: Date
+): Date | null {
   const anchor = parseISO(anchorISO);
-  if (recurrence === "none") return isSameDay(anchor, onOrAfter) || anchor > onOrAfter ? anchor : null;
-  const step = recurrence === "weekly" ? 7 : recurrence === "biweekly" ? 14 : 0;
+  if (recurrence === "none")
+    return isSameDay(anchor, onOrAfter) || isAfter(anchor, onOrAfter)
+      ? anchor
+      : null;
   if (recurrence === "monthly") {
-    let target = new Date(onOrAfter.getFullYear(), onOrAfter.getMonth(), anchor.getDate());
-    // If the calculated target date for this month is already past, move to next month.
-    // The `isSameDay` check is important for when the anchor date is today.
-    if (target < onOrAfter && !isSameDay(target, onOrAfter)) {
-        target = new Date(onOrAfter.getFullYear(), onOrAfter.getMonth() + 1, anchor.getDate());
+    if (isBefore(onOrAfter, anchor)) return anchor;
+    const monthsDiff = differenceInMonths(onOrAfter, anchor);
+    let candidate = addMonths(anchor, monthsDiff);
+    if (isBefore(candidate, onOrAfter)) {
+      candidate = addMonths(candidate, 1);
     }
-    // Now, ensure the final target is not before the original anchor date.
-    if (target < anchor) {
-      target.setFullYear(anchor.getFullYear());
-      target.setMonth(anchor.getMonth());
-      if (target < anchor) {
-         target.setMonth(target.getMonth() + 1);
-      }
-    }
-    return target;
+    return candidate;
   }
-  const diffDays = Math.floor((onOrAfter.getTime() - anchor.getTime()) / 86400000);
+  const step = recurrence === "weekly" ? 7 : 14;
+  const diffDays = differenceInCalendarDays(onOrAfter, anchor);
   const k = diffDays <= 0 ? 0 : Math.ceil(diffDays / step);
   const candidate = addDays(anchor, k * step);
-  return candidate < onOrAfter ? addDays(candidate, step) : candidate;
+  return isBefore(candidate, onOrAfter) ? addDays(candidate, step) : candidate;
 }
 
 function allOccurrencesInRange(debt: Debt, from: Date, to: Date): Date[] {
@@ -46,29 +45,21 @@ function allOccurrencesInRange(debt: Debt, from: Date, to: Date): Date[] {
   const maxIter = 400; // Safety break
   if (debt.recurrence === "none") {
     const d = parseISO(debt.dueDate);
-    if (d >= from && d <= to) out.push(d);
+    if (!isBefore(d, from) && !isAfter(d, to)) out.push(d);
     return out;
   }
   let cur = nextOccurrenceOnOrAfter(debt.dueDate, debt.recurrence, from);
   let iter = 0;
   const stepDays =
     debt.recurrence === "weekly" ? 7 : debt.recurrence === "biweekly" ? 14 : 0;
-    
-  while (cur && cur <= to && iter < maxIter) {
-    out.push(new Date(cur));
+
+  while (cur && !isAfter(cur, to) && iter < maxIter) {
+    out.push(cur);
     iter++;
-    if (debt.recurrence === "monthly") {
-      const nextDate = new Date(cur.getFullYear(), cur.getMonth() + 1, cur.getDate());
-      // Handle month-end issues by advancing at least one day
-      if(nextDate <= cur) {
-          cur.setDate(cur.getDate() + 1); // Move to next day before calculating next month
-          cur = new Date(cur.getFullYear(), cur.getMonth() + 1, debt.dueDate ? parseISO(debt.dueDate).getDate() : cur.getDate());
-      } else {
-          cur = nextDate;
-      }
-    } else {
-      cur = addDays(cur, stepDays);
-    }
+    cur =
+      debt.recurrence === "monthly"
+        ? addMonths(cur, 1)
+        : addDays(cur, stepDays);
   }
   return out;
 }
@@ -98,10 +89,12 @@ export function useDebtOccurrences(
   to: Date,
   query: string
 ) {
+  const fromTime = from.getTime();
+  const toTime = to.getTime();
   const { occurrences, grouped } = useMemo(
-    () => computeDebtOccurrences(debts, from, to),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [debts, from.toISOString(), to.toISOString()]
+    () =>
+      computeDebtOccurrences(debts, new Date(fromTime), new Date(toTime)),
+    [debts, fromTime, toTime]
   );
 
   const filtered = useMemo(() => {


### PR DESCRIPTION
## Summary
- refactor debt occurrence calculations to use date-fns helpers
- memoize date inputs to satisfy exhaustive-deps without disabling lint
- clean up recurrence logic

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afa9b870d4833190e8b6aa5e75930c