### PR TITLE
refactor parallel computation with worker pool

### DIFF
--- a/src/lib/parallel.ts
+++ b/src/lib/parallel.ts
@@ -1,37 +1,16 @@
-import { Worker } from "node:worker_threads"
 import os from "node:os"
 import path from "node:path"
+import { WorkerPool } from "./worker-pool"
 
 export async function parallelSquare(numbers: number[], threads = os.cpus().length): Promise<number[]> {
   const chunkSize = Math.ceil(numbers.length / threads)
   const chunks = Array.from({ length: threads }, (_, i) => numbers.slice(i * chunkSize, (i + 1) * chunkSize))
+    .filter(chunk => chunk.length > 0)
 
-  return new Promise((resolve, reject) => {
-    const results: number[] = []
-    let completed = 0
+  const pool = new WorkerPool<number[], number[]>(path.join(__dirname, "mapWorker.js"), threads)
 
-    chunks.forEach(chunk => {
-      if (chunk.length === 0) {
-        completed++
-        if (completed === chunks.length) {
-          resolve(results)
-        }
-        return
-      }
+  const promises = chunks.map(chunk => pool.run(chunk))
+  const results = await Promise.all(promises)
 
-      const worker = new Worker(path.join(__dirname, "mapWorker.js"), {
-        workerData: chunk,
-      })
-
-      worker.on("message", (data: number[]) => {
-        results.push(...data)
-        completed++
-        if (completed === chunks.length) {
-          resolve(results)
-        }
-      })
-
-      worker.on("error", reject)
-    })
-  })
+  return results.flat()
 }

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -1,0 +1,58 @@
+import { Worker } from "node:worker_threads";
+
+interface Task<T, R> {
+  data: T;
+  resolve: (value: R) => void;
+  reject: (reason: unknown) => void;
+}
+
+export class WorkerPool<T = unknown, R = unknown> {
+  private readonly file: string;
+  private readonly size: number;
+  private queue: Task<T, R>[] = [];
+  private active = 0;
+
+  constructor(file: string, size: number) {
+    this.file = file;
+    this.size = size;
+  }
+
+  run(data: T): Promise<R> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ data, resolve, reject });
+      this.process();
+    });
+  }
+
+  private process() {
+    while (this.active < this.size && this.queue.length > 0) {
+      const task = this.queue.shift()!;
+      this.active++;
+      const worker = new Worker(this.file, { workerData: task.data });
+
+      const finalize = () => {
+        worker.terminate().finally(() => {
+          this.active--;
+          this.process();
+        });
+      };
+
+      worker.once("message", (result: R) => {
+        task.resolve(result);
+        finalize();
+      });
+
+      worker.once("error", err => {
+        task.reject(err);
+        finalize();
+      });
+
+      worker.once("exit", code => {
+        if (code !== 0) {
+          task.reject(new Error(`Worker stopped with exit code ${code}`));
+        }
+      });
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable worker pool implementation for node worker threads
- update parallelSquare to use worker pool and Promise.all for ordered results

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afa9b955808331b4713489d22b6eed