### PR TITLE
feat: support configurable genkit model

### DIFF
--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,7 +1,9 @@
 import {genkit} from 'genkit';
 import {googleAI} from '@genkit-ai/googleai';
 
+const model = process.env.GENKIT_MODEL || 'googleai/gemini-2.5-flash';
+
 export const ai = genkit({
   plugins: [googleAI()],
-  model: 'googleai/gemini-2.5-flash',
+  model,
 });


### PR DESCRIPTION
## Summary
- allow specifying Genkit model via `GENKIT_MODEL` environment variable with default `googleai/gemini-2.5-flash`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afa9b703908331ae7cc208c5da0d82