### PR TITLE
chore: handle missing output in analyzeReceipt

### DIFF
--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -11,7 +11,6 @@
 
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
-import { Transaction } from '@/lib/types';
 
 const AnalyzeReceiptInputSchema = z.object({
   receiptImage: z
@@ -50,6 +49,9 @@ const analyzeReceiptFlow = ai.defineFlow(
   },
   async input => {
     const {output} = await prompt(input);
-    return output!;
+    if (!output) {
+      throw new Error('No output returned from analyzeReceiptPrompt');
+    }
+    return output;
   }
 );


### PR DESCRIPTION
## Summary
- remove unused Transaction import
- throw an explicit error when analyzeReceiptPrompt returns no output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afa9b53fd483318024aa04a88a1948