### PR TITLE
Add reusable error and suspense boundaries

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import { Toaster } from "@/components/ui/toaster"
 import { AuthProvider } from '@/components/auth/auth-provider';
 import { ThemeProvider } from '@/components/layout/theme-provider';
+import { ErrorBoundary, SuspenseBoundary } from '@/components/layout/boundaries';
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -27,7 +28,11 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <AuthProvider>
-              {children}
+            <ErrorBoundary>
+              <SuspenseBoundary>
+                {children}
+              </SuspenseBoundary>
+            </ErrorBoundary>
           </AuthProvider>
           <Toaster />
         </ThemeProvider>

--- a/src/components/layout/boundaries.tsx
+++ b/src/components/layout/boundaries.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React, { PropsWithChildren, Suspense } from 'react';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class RootErrorBoundary extends React.Component<PropsWithChildren, ErrorBoundaryState> {
+  constructor(props: PropsWithChildren) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p>Something went wrong.</p>;
+    }
+    return this.props.children;
+  }
+}
+
+export function ErrorBoundary({ children }: PropsWithChildren) {
+  return <RootErrorBoundary>{children}</RootErrorBoundary>;
+}
+
+export function SuspenseBoundary({ children }: PropsWithChildren) {
+  return <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>;
+}


### PR DESCRIPTION
## Summary
- introduce ErrorBoundary and SuspenseBoundary components with minimal UI
- wrap root layout content with reusable boundaries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afa9ba2370833181c6fd00e78cfdc1