### PR TITLE
feat: compute overview totals from provided transactions

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -40,7 +40,7 @@ export default async function DashboardPage() {
         <p className="text-muted-foreground">Here's a high-level overview of your finances.</p>
       </div>
       <Suspense fallback={<Skeleton className="h-[126px] w-full" />}>
-        <OverviewCards />
+        <OverviewCards transactions={transactions} />
       </Suspense>
       <Suspense fallback={<Skeleton className="h-[436px] w-full" />}>
         <DashboardCharts transactions={transactions} chartData={chartData} />

--- a/src/components/dashboard/overview-cards.tsx
+++ b/src/components/dashboard/overview-cards.tsx
@@ -1,16 +1,20 @@
 
 "use client"
 
-import { DollarSign, TrendingUp, TrendingDown, PiggyBank } from "lucide-react"
+import { TrendingUp, TrendingDown, PiggyBank } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { mockTransactions } from "@/lib/data"
+import type { Transaction } from "@/lib/types"
 
-export default function OverviewCards() {
-  const totalIncome = mockTransactions
+interface OverviewCardsProps {
+  transactions: Transaction[];
+}
+
+export default function OverviewCards({ transactions }: OverviewCardsProps) {
+  const totalIncome = transactions
     .filter(t => t.type === 'Income')
     .reduce((acc, t) => acc + t.amount, 0);
 
-  const totalExpenses = mockTransactions
+  const totalExpenses = transactions
     .filter(t => t.type === 'Expense')
     .reduce((acc, t) => acc + t.amount, 0);
 


### PR DESCRIPTION
## Summary
- accept a `transactions` prop in `OverviewCards` and compute totals from the provided data
- update dashboard page to supply the fetched transactions to `OverviewCards`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afaaf0a1b083318bbfffea031339ca