### PR TITLE
Extract payroll computations into utilities with tests

### DIFF
--- a/src/__tests__/payroll.test.ts
+++ b/src/__tests__/payroll.test.ts
@@ -1,0 +1,59 @@
+import {
+  getPayPeriodStart,
+  calculateOvertimeDates,
+  calculatePayPeriodSummary,
+  type Shift,
+} from '../lib/payroll';
+import type { DateRange } from 'react-day-picker';
+
+describe('payroll utilities', () => {
+  test('getPayPeriodStart returns beginning Sunday of pay period', () => {
+    const date = new Date('2024-01-15T12:00:00Z'); // Monday in second week
+    const start = getPayPeriodStart(date);
+    expect(start.toISOString().slice(0, 10)).toBe('2024-01-07');
+  });
+
+  test('calculateOvertimeDates identifies shifts after 40 hours', () => {
+    const shifts: Shift[] = [
+      { date: new Date('2024-01-08'), hours: 8, rate: 10 },
+      { date: new Date('2024-01-09'), hours: 8, rate: 10 },
+      { date: new Date('2024-01-10'), hours: 8, rate: 10 },
+      { date: new Date('2024-01-11'), hours: 8, rate: 10 },
+      { date: new Date('2024-01-12'), hours: 10, rate: 10 },
+      { date: new Date('2024-01-13'), hours: 8, rate: 10 },
+    ];
+    const ot = calculateOvertimeDates(shifts);
+    expect(ot.map(d => d.toISOString().slice(0,10))).toEqual([
+      '2024-01-12',
+      '2024-01-13',
+    ]);
+  });
+
+  test('calculatePayPeriodSummary ignores shifts outside the range', () => {
+    const shifts: Shift[] = [
+      { date: new Date('2024-01-08'), hours: 10, rate: 10 },
+      { date: new Date('2024-01-09'), hours: 10, rate: 10 },
+      { date: new Date('2024-01-10'), hours: 10, rate: 10 },
+      { date: new Date('2024-01-11'), hours: 10, rate: 10 },
+      { date: new Date('2024-01-12'), hours: 10, rate: 10 }, // week1: 50h
+      { date: new Date('2024-01-15'), hours: 8, rate: 10 },
+      { date: new Date('2024-01-16'), hours: 8, rate: 10 },
+      { date: new Date('2024-01-17'), hours: 8, rate: 10 },
+      { date: new Date('2024-01-18'), hours: 8, rate: 10 },
+      { date: new Date('2024-01-19'), hours: 8, rate: 10 }, // week2: 40h
+      { date: new Date('2024-01-21'), hours: 8, rate: 10 }, // outside period
+    ];
+    const period: DateRange = {
+      from: new Date('2024-01-07'),
+      to: new Date('2024-01-20'),
+    };
+    const summary = calculatePayPeriodSummary(shifts, period);
+    expect(summary).toEqual({
+      totalIncome: 950,
+      regularHours: 80,
+      overtimeHours: 10,
+      totalHours: 90,
+    });
+  });
+});
+

--- a/src/app/cashflow/page.tsx
+++ b/src/app/cashflow/page.tsx
@@ -10,36 +10,15 @@ import { Loader2, Wallet, TrendingUp, Scale, Calendar as CalendarIcon, DollarSig
 import { useToast } from "@/hooks/use-toast"
 import { Calendar } from "@/components/ui/calendar"
 import type { DateRange } from "react-day-picker"
-
-interface Shift {
-  date: Date;
-  hours: number;
-  rate: number;
-  premiumPay?: number;
-  differentials?: string;
-}
+import {
+  getPayPeriodStart,
+  calculateOvertimeDates,
+  calculatePayPeriodSummary,
+  getShiftsInPayPeriod,
+  type Shift,
+} from "@/lib/payroll"
 
 type ShiftDetails = Omit<Shift, 'date'>;
-
-// Helper to find the start of a 2-week pay period (a Sunday) for any given date.
-const getPayPeriodStart = (date: Date) => {
-    const d = new Date(date);
-    const dayOfWeek = d.getDay(); // Sunday = 0, Saturday = 6
-    const daysSinceLastSunday = dayOfWeek;
-    const lastSunday = new Date(d.setDate(d.getDate() - daysSinceLastSunday));
-    lastSunday.setHours(0,0,0,0);
-
-    // Use a fixed anchor date to determine the "even" or "odd" week period.
-    const anchor = new Date('2024-01-07T00:00:00.000Z'); // A known Sunday
-    const diffWeeks = Math.floor((lastSunday.getTime() - anchor.getTime()) / (1000 * 60 * 60 * 24 * 7));
-
-    if (diffWeeks % 2 !== 0) {
-        // It's in the second week of a pay period, so the start was the *previous* Sunday
-        lastSunday.setDate(lastSunday.getDate() - 7);
-    }
-    
-    return lastSunday;
-};
 
 
 export default function CashflowPage() {
@@ -62,103 +41,12 @@ export default function CashflowPage() {
 
   const { toast } = useToast();
 
-   const overtimeShifts = useMemo(() => {
-    const weeklyShifts: { [weekStart: string]: Shift[] } = {};
+  const overtimeShifts = useMemo(() => calculateOvertimeDates(shifts), [shifts]);
 
-    // Group shifts by week
-    shifts.forEach(shift => {
-        const shiftDay = shift.date.getDay(); // Sunday = 0
-        const weekStart = new Date(shift.date);
-        weekStart.setDate(shift.date.getDate() - shiftDay);
-        weekStart.setHours(0, 0, 0, 0);
-        const weekStartStr = weekStart.toISOString();
-        
-        if (!weeklyShifts[weekStartStr]) {
-            weeklyShifts[weekStartStr] = [];
-        }
-        weeklyShifts[weekStartStr].push(shift);
-    });
-
-    const overtimeDates: Date[] = [];
-    for (const weekStartStr in weeklyShifts) {
-        const week = weeklyShifts[weekStartStr];
-        // Sort shifts chronologically to calculate running total
-        week.sort((a,b) => a.date.getTime() - b.date.getTime());
-
-        let weeklyHours = 0;
-        for (const shift of week) {
-            const previousHours = weeklyHours;
-            weeklyHours += shift.hours;
-            // If the hours *before* this shift were already over 40, this is an extra shift.
-            // Or, if this shift is the one that *crosses* the 40-hour threshold.
-            if (previousHours >= 40 || (previousHours < 40 && weeklyHours > 40)) {
-                 overtimeDates.push(shift.date);
-            }
-        }
-    }
-    return overtimeDates;
-  }, [shifts]);
-  
-  const payPeriodCalculation = useMemo(() => {
-    if (!payPeriod || !payPeriod.from || !payPeriod.to) {
-        return { totalIncome: 0, regularHours: 0, overtimeHours: 0, totalHours: 0 };
-    }
-
-    const week1Start = payPeriod.from;
-    const week1End = new Date(week1Start);
-    week1End.setDate(week1End.getDate() + 6);
-
-    const week2Start = new Date(week1Start);
-    week2Start.setDate(week1Start.getDate() + 7);
-    const week2End = payPeriod.to;
-
-    let totalIncome = 0;
-    let totalRegularHours = 0;
-    let totalOvertimeHours = 0;
-
-    const calculateWeekPay = (start: Date, end: Date) => {
-        const weekShifts = shifts.filter(s => s.date >= start && s.date <= end);
-        let weeklyHours = 0;
-        let weeklyIncome = 0;
-        let weeklyPremiumPay = 0;
-
-        // First pass: Calculate total hours and sum premium pay
-        weekShifts.forEach(shift => {
-            weeklyHours += shift.hours;
-            weeklyPremiumPay += shift.premiumPay || 0;
-        });
-        
-        let regularHours = Math.min(weeklyHours, 40);
-        let overtimeHours = Math.max(0, weeklyHours - 40);
-        
-        totalRegularHours += regularHours;
-        totalOvertimeHours += overtimeHours;
-
-        // Second pass: Apportion pay based on averaged rate if needed, or use a single rate
-        // This simple model assumes rate is consistent across shifts for OT calculation.
-        // A more complex model might need to decide which shift's rate to use for OT.
-        if (weekShifts.length > 0) {
-           const avgRate = weekShifts.reduce((acc, s) => acc + s.rate * s.hours, 0) / weeklyHours;
-           const regularPay = regularHours * avgRate;
-           const overtimePay = overtimeHours * avgRate * 1.5;
-           weeklyIncome = regularPay + overtimePay + weeklyPremiumPay;
-        }
-
-        return weeklyIncome;
-    };
-    
-    const week1Pay = calculateWeekPay(week1Start, week1End);
-    const week2Pay = calculateWeekPay(week2Start, week2End);
-    
-    totalIncome = week1Pay + week2Pay;
-
-    return { 
-        totalIncome, 
-        regularHours: totalRegularHours,
-        overtimeHours: totalOvertimeHours,
-        totalHours: totalRegularHours + totalOvertimeHours
-    };
-  }, [shifts, payPeriod]);
+  const payPeriodCalculation = useMemo(
+    () => calculatePayPeriodSummary(shifts, payPeriod),
+    [shifts, payPeriod]
+  );
 
   const monthlyStats = useMemo(() => {
     const month = cursorDate.getMonth();
@@ -213,12 +101,10 @@ export default function CashflowPage() {
   }, [shifts, cursorDate]);
 
 
-  const shiftsInPayPeriod = useMemo(() => {
-      if (!payPeriod || !payPeriod.from || !payPeriod.to) return [];
-      return shifts
-        .filter(shift => shift.date >= payPeriod!.from! && shift.date <= payPeriod!.to!)
-        .sort((a,b) => a.date.getTime() - b.date.getTime());
-  }, [shifts, payPeriod]);
+  const shiftsInPayPeriod = useMemo(
+    () => getShiftsInPayPeriod(shifts, payPeriod),
+    [shifts, payPeriod]
+  );
 
   const handleCashflowSubmit = async (event: React.FormEvent) => {
     event.preventDefault()

--- a/src/lib/payroll.ts
+++ b/src/lib/payroll.ts
@@ -1,0 +1,142 @@
+import type { DateRange } from 'react-day-picker';
+
+export interface Shift {
+  date: Date;
+  hours: number;
+  rate: number;
+  premiumPay?: number;
+  differentials?: string;
+}
+
+export interface PayPeriodSummary {
+  totalIncome: number;
+  regularHours: number;
+  overtimeHours: number;
+  totalHours: number;
+}
+
+// Helper to find the start of a 2-week pay period (a Sunday) for any given date.
+export const getPayPeriodStart = (date: Date): Date => {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  const dayOfWeek = d.getDay();
+  d.setDate(d.getDate() - dayOfWeek);
+
+  // Use a fixed anchor date to determine the "even" or "odd" week period.
+  const anchor = new Date('2024-01-07T00:00:00.000Z'); // A known Sunday
+  const diffWeeks = Math.floor((d.getTime() - anchor.getTime()) / (1000 * 60 * 60 * 24 * 7));
+
+  if (diffWeeks % 2 !== 0) {
+    // It's in the second week of a pay period, so the start was the *previous* Sunday
+    d.setDate(d.getDate() - 7);
+  }
+
+  return d;
+};
+
+export const calculateOvertimeDates = (shifts: Shift[]): Date[] => {
+  const weeklyShifts: Record<string, Shift[]> = {};
+
+  // Group shifts by week
+  shifts.forEach(shift => {
+    const shiftDay = shift.date.getDay(); // Sunday = 0
+    const weekStart = new Date(shift.date);
+    weekStart.setDate(shift.date.getDate() - shiftDay);
+    weekStart.setHours(0, 0, 0, 0);
+    const weekStartStr = weekStart.toISOString();
+
+    if (!weeklyShifts[weekStartStr]) {
+      weeklyShifts[weekStartStr] = [];
+    }
+    weeklyShifts[weekStartStr].push(shift);
+  });
+
+  const overtimeDates: Date[] = [];
+  for (const weekStartStr in weeklyShifts) {
+    const week = weeklyShifts[weekStartStr].sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    let weeklyHours = 0;
+    for (const shift of week) {
+      const previousHours = weeklyHours;
+      weeklyHours += shift.hours;
+      // If the hours *before* this shift were already over 40, this is an extra shift.
+      // Or, if this shift is the one that *crosses* the 40-hour threshold.
+      if (previousHours >= 40 || (previousHours < 40 && weeklyHours > 40)) {
+        overtimeDates.push(shift.date);
+      }
+    }
+  }
+  return overtimeDates;
+};
+
+export const calculatePayPeriodSummary = (
+  shifts: Shift[],
+  payPeriod: DateRange | undefined
+): PayPeriodSummary => {
+  if (!payPeriod || !payPeriod.from || !payPeriod.to) {
+    return { totalIncome: 0, regularHours: 0, overtimeHours: 0, totalHours: 0 };
+  }
+
+  const week1Start = payPeriod.from;
+  const week1End = new Date(week1Start);
+  week1End.setDate(week1End.getDate() + 6);
+
+  const week2Start = new Date(week1Start);
+  week2Start.setDate(week1Start.getDate() + 7);
+  const week2End = payPeriod.to;
+
+  let totalIncome = 0;
+  let totalRegularHours = 0;
+  let totalOvertimeHours = 0;
+
+  const calculateWeekPay = (start: Date, end: Date) => {
+    const weekShifts = shifts.filter(s => s.date >= start && s.date <= end);
+    if (weekShifts.length === 0) return 0;
+
+    let weeklyHours = 0;
+    let weeklyIncome = 0;
+    let weeklyPremiumPay = 0;
+
+    // First pass: Calculate total hours and sum premium pay
+    weekShifts.forEach(shift => {
+      weeklyHours += shift.hours;
+      weeklyPremiumPay += shift.premiumPay || 0;
+    });
+
+    const regularHours = Math.min(weeklyHours, 40);
+    const overtimeHours = Math.max(0, weeklyHours - 40);
+
+    totalRegularHours += regularHours;
+    totalOvertimeHours += overtimeHours;
+
+    const avgRate = weekShifts.reduce((acc, s) => acc + s.rate * s.hours, 0) / weeklyHours;
+    const regularPay = regularHours * avgRate;
+    const overtimePay = overtimeHours * avgRate * 1.5;
+    weeklyIncome = regularPay + overtimePay + weeklyPremiumPay;
+
+    return weeklyIncome;
+  };
+
+  const week1Pay = calculateWeekPay(week1Start, week1End);
+  const week2Pay = calculateWeekPay(week2Start, week2End);
+
+  totalIncome = week1Pay + week2Pay;
+
+  return {
+    totalIncome,
+    regularHours: totalRegularHours,
+    overtimeHours: totalOvertimeHours,
+    totalHours: totalRegularHours + totalOvertimeHours,
+  };
+};
+
+export const getShiftsInPayPeriod = (
+  shifts: Shift[],
+  payPeriod: DateRange | undefined
+): Shift[] => {
+  if (!payPeriod || !payPeriod.from || !payPeriod.to) return [];
+  return shifts
+    .filter(shift => shift.date >= payPeriod.from && shift.date <= payPeriod.to)
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+};
+


### PR DESCRIPTION
## Summary
- factor out pay-period and overtime logic into `lib/payroll` utilities
- refactor cashflow page to consume payroll helpers
- add unit tests for pay-period start, overtime dates, and pay period summary

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68afaaf488788331ae8ed7165707b7b0