### PR TITLE
feat: add goal editing and persistence

### DIFF
--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -1,19 +1,49 @@
 "use client"
 
-import { useState } from "react";
-import { mockGoals } from "@/lib/data";
+import { useEffect, useState } from "react";
 import type { Goal } from "@/lib/types";
 import { GoalCard } from "@/components/goals/goal-card";
 import { AddGoalDialog } from "@/components/goals/add-goal-dialog";
+import { collection, addDoc, getDocs, updateDoc, deleteDoc, doc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
 
 export default function GoalsPage() {
-  const [goals, setGoals] = useState<Goal[]>(mockGoals);
+  const [goals, setGoals] = useState<Goal[]>([]);
 
-  const addGoal = (goal: Omit<Goal, 'id'>) => {
-    setGoals(prev => [
-      { ...goal, id: (prev.length + 1).toString() },
-      ...prev
-    ]);
+  useEffect(() => {
+    const fetchGoals = async () => {
+      const snap = await getDocs(collection(db, "goals"));
+      const data = snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Goal, "id">) })) as Goal[];
+      setGoals(data);
+    };
+    fetchGoals();
+  }, []);
+
+  const handleSaveGoal = async (goal: Goal) => {
+    if (goal.id) {
+      await updateDoc(doc(db, "goals", goal.id), {
+        name: goal.name,
+        targetAmount: goal.targetAmount,
+        currentAmount: goal.currentAmount,
+        deadline: goal.deadline,
+        importance: goal.importance,
+      });
+      setGoals(prev => prev.map(g => g.id === goal.id ? goal : g));
+    } else {
+      const docRef = await addDoc(collection(db, "goals"), {
+        name: goal.name,
+        targetAmount: goal.targetAmount,
+        currentAmount: goal.currentAmount,
+        deadline: goal.deadline,
+        importance: goal.importance,
+      });
+      setGoals(prev => [{ ...goal, id: docRef.id }, ...prev]);
+    }
+  };
+
+  const handleDeleteGoal = async (id: string) => {
+    await deleteDoc(doc(db, "goals", id));
+    setGoals(prev => prev.filter(g => g.id !== id));
   };
 
   return (
@@ -23,11 +53,11 @@ export default function GoalsPage() {
             <h1 className="text-3xl font-bold tracking-tight">Financial Goals</h1>
             <p className="text-muted-foreground">Set and track your financial goals to stay motivated.</p>
         </div>
-        <AddGoalDialog onSave={addGoal} />
+        <AddGoalDialog onSave={handleSaveGoal} />
       </div>
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {goals.map(goal => (
-          <GoalCard key={goal.id} goal={goal} />
+          <GoalCard key={goal.id} goal={goal} onDelete={handleDeleteGoal} onUpdate={handleSaveGoal} />
         ))}
       </div>
     </div>

--- a/src/components/goals/add-goal-dialog.tsx
+++ b/src/components/goals/add-goal-dialog.tsx
@@ -1,7 +1,7 @@
 
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState, type ReactNode } from "react"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -19,10 +19,12 @@ import { PlusCircle } from "lucide-react"
 import type { Goal } from "@/lib/types"
 
 interface AddGoalDialogProps {
-  onSave: (goal: Omit<Goal, 'id'>) => void;
+  onSave: (goal: Goal) => void;
+  goal?: Goal;
+  trigger?: ReactNode;
 }
 
-export function AddGoalDialog({ onSave }: AddGoalDialogProps) {
+export function AddGoalDialog({ onSave, goal, trigger }: AddGoalDialogProps) {
     const [open, setOpen] = useState(false)
     const [name, setName] = useState("")
     const [targetAmount, setTargetAmount] = useState("")
@@ -30,9 +32,20 @@ export function AddGoalDialog({ onSave }: AddGoalDialogProps) {
     const [deadline, setDeadline] = useState("")
     const [importance, setImportance] = useState([3]) // Default importance
 
+    useEffect(() => {
+        if (open) {
+            setName(goal?.name ?? "")
+            setTargetAmount(goal?.targetAmount?.toString() ?? "")
+            setCurrentAmount(goal?.currentAmount?.toString() ?? "")
+            setDeadline(goal?.deadline ?? "")
+            setImportance([goal?.importance ?? 3])
+        }
+    }, [goal, open])
+
     const handleSave = () => {
         if(name && targetAmount && currentAmount && deadline) {
             onSave({
+                id: goal?.id ?? "",
                 name,
                 targetAmount: parseFloat(targetAmount),
                 currentAmount: parseFloat(currentAmount),
@@ -40,28 +53,24 @@ export function AddGoalDialog({ onSave }: AddGoalDialogProps) {
                 importance: importance[0]
             })
             setOpen(false)
-            // Reset form
-            setName("")
-            setTargetAmount("")
-            setCurrentAmount("")
-            setDeadline("")
-            setImportance([3])
         }
     }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
-          <PlusCircle className="mr-2 h-4 w-4" />
-          Add New Goal
-        </Button>
+        {trigger ?? (
+          <Button>
+            <PlusCircle className="mr-2 h-4 w-4" />
+            Add New Goal
+          </Button>
+        )}
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>Add New Financial Goal</DialogTitle>
+          <DialogTitle>{goal ? "Edit Goal" : "Add New Financial Goal"}</DialogTitle>
           <DialogDescription>
-            What financial milestone are you aiming for?
+            {goal ? "Update your goal details" : "What financial milestone are you aiming for?"}
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
@@ -97,7 +106,7 @@ export function AddGoalDialog({ onSave }: AddGoalDialogProps) {
           </div>
         </div>
         <DialogFooter>
-          <Button type="submit" onClick={handleSave}>Save Goal</Button>
+          <Button type="submit" onClick={handleSave}>{goal ? "Save Changes" : "Save Goal"}</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/goals/goal-card.tsx
+++ b/src/components/goals/goal-card.tsx
@@ -1,15 +1,27 @@
 
-import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
-import type { Goal } from "@/lib/types"
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
+import type { Goal } from "@/lib/types";
 import { Badge } from "../ui/badge";
+import { AddGoalDialog } from "./add-goal-dialog";
 
 interface GoalCardProps {
   goal: Goal;
+  onDelete: (id: string) => Promise<void> | void;
+  onUpdate: (goal: Goal) => Promise<void> | void;
 }
 
-export function GoalCard({ goal }: GoalCardProps) {
-  const progress = (goal.currentAmount / goal.targetAmount) * 100;
+export function GoalCard({ goal, onDelete, onUpdate }: GoalCardProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const progress = goal.targetAmount > 0 ? (goal.currentAmount / goal.targetAmount) * 100 : 0;
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    await onDelete(goal.id);
+    setIsDeleting(false);
+  };
 
   const importanceMap: {[key: number]: string} = {
       1: "Very Low",
@@ -39,10 +51,20 @@ export function GoalCard({ goal }: GoalCardProps) {
         </div>
         <Progress value={progress} aria-label={`${goal.name} progress`} />
       </CardContent>
-      <CardFooter>
+      <CardFooter className="flex items-center justify-between">
         <p className="text-muted-foreground">
             <span className="font-bold text-foreground">${goal.currentAmount.toLocaleString()}</span> of ${goal.targetAmount.toLocaleString()}
         </p>
+        <div className="flex gap-2">
+          <AddGoalDialog
+            goal={goal}
+            onSave={onUpdate}
+            trigger={<Button variant="ghost" size="sm">Edit</Button>}
+          />
+          <Button variant="destructive" size="sm" onClick={handleDelete} disabled={isDeleting}>
+            {isDeleting ? "Deleting..." : "Delete"}
+          </Button>
+        </div>
       </CardFooter>
     </Card>
   )

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
 import { z } from "zod";
 
 const envSchema = z.object({
@@ -25,5 +26,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const auth = getAuth(app);
+const db = getFirestore(app);
 
-export { app, auth };
+export { app, auth, db };


### PR DESCRIPTION
## Summary
- allow goal editing and deletion from cards
- persist goals in Firestore
- expose Firestore db utility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afe7a49ef48331822230dffa293842