### PR TITLE
Use Next.js Image component for receipt preview

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,6 @@ const nextConfig: NextConfig = {
   },
 
   // Allow Firebase Studio / Cloud Workstations preview host to fetch /_next/*
-  // @ts-expect-error - not typed in NextConfig yet
   allowedDevOrigins: [
     '*.cloudworkstations.dev',
     // Add the specific origin from the error log for stability

--- a/src/app/transactions/scan/page.tsx
+++ b/src/app/transactions/scan/page.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
 import { Loader2, Camera, Upload, Sparkles, Wand2 } from "lucide-react"
+import Image from "next/image"
 
 export default function ScanReceiptPage() {
   const router = useRouter()
@@ -173,8 +174,14 @@ export default function ScanReceiptPage() {
           <CardContent className="space-y-4">
             {imagePreview && (
               <div className="space-y-4">
-                  <div className="aspect-video w-full bg-muted rounded-md overflow-hidden border">
-                    <img src={imagePreview} alt="Receipt preview" className="w-full h-full object-contain" />
+                  <div className="relative aspect-video w-full bg-muted rounded-md overflow-hidden border">
+                    <Image
+                      src={imagePreview}
+                      alt="Receipt preview"
+                      fill
+                      sizes="(max-width: 768px) 100vw, 50vw"
+                      className="object-contain"
+                    />
                   </div>
                   <Button onClick={analyzeImage} disabled={isLoading} className="w-full">
                     {isLoading ? (


### PR DESCRIPTION
## Summary
- switch receipt preview to Next.js `Image` with responsive `fill` and `sizes`
- clean up next.js config to remove obsolete `ts-expect-error`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Type error in src/app/cashflow/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68afe7d9df04833198826b593deff0f0