### PR TITLE
feat: add housekeeping service with firebase integration

### DIFF
--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -1,0 +1,153 @@
+process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'test';
+process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'test';
+process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'test';
+process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'test';
+process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'test';
+process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'test';
+
+const dataStore: Record<string, Map<string, any>> = {
+  transactions: new Map(),
+  transactions_archive: new Map(),
+  debts: new Map(),
+  goals: new Map(),
+  backups: new Map(),
+};
+
+jest.mock('firebase/app', () => ({
+  initializeApp: jest.fn(() => ({})),
+  getApps: jest.fn(() => []),
+  getApp: jest.fn(() => ({})),
+}));
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(() => ({})),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(() => ({})),
+  collection: (_db: any, name: string) => ({ name }),
+  doc: (_db: any, name: string, id: string) => ({ name, id }),
+  getDocs: jest.fn(async (colRef: any) => ({
+    docs: Array.from(dataStore[colRef.name].entries()).map(([id, data]) => ({
+      id,
+      data: () => data,
+    })),
+  })),
+  setDoc: jest.fn(async (docRef: any, data: any) => {
+    dataStore[docRef.name].set(docRef.id, data);
+  }),
+  deleteDoc: jest.fn(async (docRef: any) => {
+    dataStore[docRef.name].delete(docRef.id);
+  }),
+  addDoc: jest.fn(async (colRef: any, data: any) => {
+    const id = Math.random().toString(36).slice(2);
+    dataStore[colRef.name].set(id, data);
+    return { id };
+  }),
+  __dataStore: dataStore,
+}));
+
+const { archiveOldTransactions, cleanupDebts, backupData } = require('../services/housekeeping');
+const firestore = require('firebase/firestore');
+const store = firestore.__dataStore as typeof dataStore;
+
+beforeEach(() => {
+  for (const col of Object.values(store)) {
+    col.clear();
+  }
+});
+
+describe('housekeeping services', () => {
+  test('archiveOldTransactions moves old records', async () => {
+    store.transactions.set('t1', {
+      id: 't1',
+      date: '2020-01-01',
+      description: 'old',
+      amount: 1,
+      type: 'Income',
+      category: 'Salary',
+    });
+    store.transactions.set('t2', {
+      id: 't2',
+      date: '2024-01-01',
+      description: 'new',
+      amount: 2,
+      type: 'Expense',
+      category: 'Food',
+    });
+
+    await archiveOldTransactions('2021-01-01');
+
+    expect(store.transactions.has('t1')).toBe(false);
+    expect(store.transactions.has('t2')).toBe(true);
+    expect(store.transactions_archive.has('t1')).toBe(true);
+  });
+
+  test('cleanupDebts removes settled debts', async () => {
+    store.debts.set('d1', {
+      id: 'd1',
+      name: 'Paid',
+      initialAmount: 100,
+      currentAmount: 0,
+      interestRate: 0,
+      minimumPayment: 0,
+      dueDate: '2024-01-01',
+      recurrence: 'none',
+      autopay: false,
+    });
+    store.debts.set('d2', {
+      id: 'd2',
+      name: 'Active',
+      initialAmount: 100,
+      currentAmount: 50,
+      interestRate: 0,
+      minimumPayment: 0,
+      dueDate: '2024-01-01',
+      recurrence: 'none',
+      autopay: false,
+    });
+
+    await cleanupDebts();
+
+    expect(store.debts.has('d1')).toBe(false);
+    expect(store.debts.has('d2')).toBe(true);
+  });
+
+  test('backupData stores snapshot', async () => {
+    store.transactions.set('t1', {
+      id: 't1',
+      date: '2024-01-01',
+      description: 'test',
+      amount: 1,
+      type: 'Income',
+      category: 'Salary',
+    });
+    store.debts.set('d1', {
+      id: 'd1',
+      name: 'Debt',
+      initialAmount: 100,
+      currentAmount: 50,
+      interestRate: 0,
+      minimumPayment: 0,
+      dueDate: '2024-01-01',
+      recurrence: 'none',
+      autopay: false,
+    });
+    store.goals.set('g1', {
+      id: 'g1',
+      name: 'Goal',
+      targetAmount: 100,
+      currentAmount: 10,
+      deadline: '2024-12-31',
+      importance: 3,
+    });
+
+    const backup = await backupData();
+
+    expect(backup.transactions).toHaveLength(1);
+    expect(backup.debts).toHaveLength(1);
+    expect(backup.goals).toHaveLength(1);
+    expect(store.backups.size).toBe(1);
+  });
+});
+

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
 import { z } from "zod";
 
 const envSchema = z.object({
@@ -25,5 +26,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const auth = getAuth(app);
+const db = getFirestore(app);
 
-export { app, auth };
+export { app, auth, db };

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -1,0 +1,65 @@
+import { collection, getDocs, setDoc, deleteDoc, doc, addDoc } from "firebase/firestore";
+import { db } from "../lib/firebase";
+import type { Transaction, Debt, Goal } from "../lib/types";
+
+/**
+ * Moves transactions older than the provided cutoff date to an archive collection
+ * and removes them from the main transactions collection.
+ */
+export async function archiveOldTransactions(cutoffDate: string): Promise<void> {
+  const cutoff = new Date(cutoffDate);
+  const transCol = collection(db, "transactions");
+  const snapshot = await getDocs(transCol);
+
+  for (const snap of snapshot.docs) {
+    const data = snap.data() as Transaction;
+    if (new Date(data.date) < cutoff) {
+      await setDoc(doc(db, "transactions_archive", snap.id), data);
+      await deleteDoc(doc(db, "transactions", snap.id));
+    }
+  }
+}
+
+/**
+ * Removes debts that have been fully paid off (currentAmount <= 0).
+ */
+export async function cleanupDebts(): Promise<void> {
+  const debtsCol = collection(db, "debts");
+  const snapshot = await getDocs(debtsCol);
+
+  for (const snap of snapshot.docs) {
+    const data = snap.data() as Debt;
+    if (data.currentAmount <= 0) {
+      await deleteDoc(doc(db, "debts", snap.id));
+    }
+  }
+}
+
+/**
+ * Creates a backup snapshot of current transactions, debts, and goals.
+ * The snapshot is stored in the `backups` collection with a timestamp and
+ * also returned to the caller for convenience.
+ */
+export async function backupData(): Promise<{
+  transactions: Transaction[];
+  debts: Debt[];
+  goals: Goal[];
+}> {
+  const transactionsSnap = await getDocs(collection(db, "transactions"));
+  const debtsSnap = await getDocs(collection(db, "debts"));
+  const goalsSnap = await getDocs(collection(db, "goals"));
+
+  const data = {
+    transactions: transactionsSnap.docs.map((d) => d.data() as Transaction),
+    debts: debtsSnap.docs.map((d) => d.data() as Debt),
+    goals: goalsSnap.docs.map((d) => d.data() as Goal),
+  };
+
+  await addDoc(collection(db, "backups"), {
+    ...data,
+    createdAt: new Date().toISOString(),
+  });
+
+  return data;
+}
+


### PR DESCRIPTION
## Summary
- integrate Firestore into firebase helper
- implement housekeeping service for archiving transactions, cleaning debts, and backups
- add unit tests covering housekeeping behaviors

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68afece01cec8331a594cb1e5a2ce861