### PR TITLE
refactor: persist workers in pool

### DIFF
--- a/src/lib/mapWorker.js
+++ b/src/lib/mapWorker.js
@@ -1,7 +1,9 @@
-const { parentPort, workerData } = require("node:worker_threads")
+const { parentPort } = require("node:worker_threads")
 
 function square(numbers) {
   return numbers.map(n => n * n)
 }
 
-parentPort.postMessage(square(workerData))
+parentPort.on("message", numbers => {
+  parentPort.postMessage(square(numbers))
+})

--- a/src/lib/parallel.ts
+++ b/src/lib/parallel.ts
@@ -11,6 +11,6 @@ export async function parallelSquare(numbers: number[], threads = os.cpus().leng
 
   const promises = chunks.map(chunk => pool.run(chunk))
   const results = await Promise.all(promises)
-
+  await pool.destroy()
   return results.flat()
 }

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -1,58 +1,65 @@
-import { Worker } from "node:worker_threads";
+import { Worker } from "node:worker_threads"
 
 interface Task<T, R> {
-  data: T;
-  resolve: (value: R) => void;
-  reject: (reason: unknown) => void;
+  data: T
+  resolve: (value: R) => void
+  reject: (reason: unknown) => void
 }
 
 export class WorkerPool<T = unknown, R = unknown> {
-  private readonly file: string;
-  private readonly size: number;
-  private queue: Task<T, R>[] = [];
-  private active = 0;
+  private readonly workers: Worker[] = []
+  private readonly idle: Worker[] = []
+  private queue: Task<T, R>[] = []
 
-  constructor(file: string, size: number) {
-    this.file = file;
-    this.size = size;
+  constructor(private readonly file: string, size: number) {
+    for (let i = 0; i < size; i++) {
+      const worker = new Worker(file)
+      this.workers.push(worker)
+      this.idle.push(worker)
+    }
   }
 
   run(data: T): Promise<R> {
     return new Promise((resolve, reject) => {
-      this.queue.push({ data, resolve, reject });
-      this.process();
-    });
+      this.queue.push({ data, resolve, reject })
+      this.process()
+    })
   }
 
   private process() {
-    while (this.active < this.size && this.queue.length > 0) {
-      const task = this.queue.shift()!;
-      this.active++;
-      const worker = new Worker(this.file, { workerData: task.data });
+    while (this.queue.length > 0 && this.idle.length > 0) {
+      const worker = this.idle.shift()!
+      const task = this.queue.shift()!
 
       const finalize = () => {
-        worker.terminate().finally(() => {
-          this.active--;
-          this.process();
-        });
-      };
+        this.idle.push(worker)
+        this.process()
+      }
 
       worker.once("message", (result: R) => {
-        task.resolve(result);
-        finalize();
-      });
+        task.resolve(result)
+        finalize()
+      })
 
       worker.once("error", err => {
-        task.reject(err);
-        finalize();
-      });
+        task.reject(err)
+        finalize()
+      })
 
       worker.once("exit", code => {
         if (code !== 0) {
-          task.reject(new Error(`Worker stopped with exit code ${code}`));
+          task.reject(new Error(`Worker stopped with exit code ${code}`))
         }
-      });
+      })
+
+      worker.postMessage(task.data)
     }
+  }
+
+  async destroy(): Promise<void> {
+    await Promise.all(this.workers.map(worker => worker.terminate()))
+    this.queue = []
+    this.idle.length = 0
   }
 }
 


### PR DESCRIPTION
## Summary
- Initialize worker threads in the pool constructor and keep idle workers in a queue
- Dispatch tasks via `postMessage` and recycle workers instead of terminating them
- Add pool shutdown method and update worker/parallel utilities accordingly

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afed00e7f48331b638fcd33b8b185e