### PR TITLE
Remove artificial delete delay in production

### DIFF
--- a/src/__tests__/debt-card.test.ts
+++ b/src/__tests__/debt-card.test.ts
@@ -1,0 +1,25 @@
+import { shouldDelay } from "../lib/mock-delay";
+
+describe("shouldDelay", () => {
+  const env = process.env;
+
+  beforeEach(() => {
+    process.env = { ...env };
+  });
+
+  afterAll(() => {
+    process.env = env;
+  });
+
+  it("bypasses delay in production", () => {
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_ENABLE_MOCK_DELAY = "true";
+    expect(shouldDelay()).toBe(false);
+  });
+
+  it("allows delay in development when flag set", () => {
+    process.env.NODE_ENV = "development";
+    process.env.NEXT_PUBLIC_ENABLE_MOCK_DELAY = "true";
+    expect(shouldDelay()).toBe(true);
+  });
+});

--- a/src/components/debts/debt-card.tsx
+++ b/src/components/debts/debt-card.tsx
@@ -13,9 +13,7 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
 import type { Debt } from "@/lib/types";
-
-// Optional demo delay; disable in production
-const enableMockDelay = process.env.NEXT_PUBLIC_ENABLE_MOCK_DELAY === "true";
+import { shouldDelay } from "@/lib/mock-delay";
 
 interface DebtCardProps {
   debt: Debt;
@@ -42,8 +40,8 @@ export function DebtCard({ debt, onDelete, onUpdate }: DebtCardProps) {
 
   const handleDelete = async () => {
     setIsDeleting(true);
-    if (enableMockDelay) {
-      await new Promise(res => setTimeout(res, 500));
+    if (shouldDelay()) {
+      await new Promise((res) => setTimeout(res, 500));
     }
     onDelete(debt.id);
     setIsDeleting(false);

--- a/src/lib/mock-delay.ts
+++ b/src/lib/mock-delay.ts
@@ -1,0 +1,6 @@
+export function shouldDelay() {
+  return (
+    process.env.NODE_ENV !== "production" &&
+    process.env.NEXT_PUBLIC_ENABLE_MOCK_DELAY === "true"
+  );
+}


### PR DESCRIPTION
## Summary
- gate the mock delete delay behind `shouldDelay` so production builds execute deletes immediately
- add tests covering `shouldDelay` behavior

## Testing
- `npx jest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afed03e7fc83319cb253b74f4c5044