### PR TITLE
refactor overview card totals

### DIFF
--- a/src/components/dashboard/overview-cards.tsx
+++ b/src/components/dashboard/overview-cards.tsx
@@ -4,19 +4,25 @@
 import { TrendingUp, TrendingDown, PiggyBank } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { Transaction } from "@/lib/types"
+import { useMemo } from "react"
 
 interface OverviewCardsProps {
   transactions: Transaction[];
 }
 
 export default function OverviewCards({ transactions }: OverviewCardsProps) {
-  const totalIncome = transactions
-    .filter(t => t.type === 'Income')
-    .reduce((acc, t) => acc + t.amount, 0);
-
-  const totalExpenses = transactions
-    .filter(t => t.type === 'Expense')
-    .reduce((acc, t) => acc + t.amount, 0);
+  const { totalIncome, totalExpenses } = useMemo(
+    () =>
+      transactions.reduce(
+        (acc, t) => {
+          if (t.type === "Income") acc.totalIncome += t.amount
+          else if (t.type === "Expense") acc.totalExpenses += t.amount
+          return acc
+        },
+        { totalIncome: 0, totalExpenses: 0 }
+      ),
+    [transactions]
+  );
 
   const savings = totalIncome - totalExpenses;
 


### PR DESCRIPTION
## Summary
- combine income and expense aggregation into one memoized reduce
- recalc totals only when transactions change

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afed04e6888331b5830aa436f7d01b