### PR TITLE
Use async blob conversion for receipt capture

### DIFF
--- a/src/app/transactions/scan/page.tsx
+++ b/src/app/transactions/scan/page.tsx
@@ -73,17 +73,27 @@ export default function ScanReceiptPage() {
     }
   };
 
-  const captureImage = () => {
+  const captureImage = async () => {
     if (videoRef.current && canvasRef.current) {
       const video = videoRef.current;
       const canvas = canvasRef.current;
       canvas.width = video.videoWidth;
       canvas.height = video.videoHeight;
       const context = canvas.getContext('2d');
-      if(context){
+      if (context) {
         context.drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
-        const dataUri = canvas.toDataURL('image/png');
-        setImagePreview(dataUri);
+        const blob = await new Promise<Blob | null>((resolve) =>
+          canvas.toBlob(resolve, "image/png")
+        );
+        if (blob) {
+          const dataUri = await new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onloadend = () => resolve(reader.result as string);
+            reader.onerror = reject;
+            reader.readAsDataURL(blob);
+          });
+          setImagePreview(dataUri);
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary
- Switch receipt capture from `canvas.toDataURL` to `canvas.toBlob`
- Convert captured blob to data URI asynchronously before updating preview

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afed0552bc833194fc7ab76e847e2f