### PR TITLE
Limit parallel threads to input length

### DIFF
--- a/src/__tests__/parallel.test.ts
+++ b/src/__tests__/parallel.test.ts
@@ -5,4 +5,14 @@ describe("parallelSquare", () => {
     const result = await parallelSquare([1, 2, 3, 4])
     expect(result.sort((a, b) => a - b)).toEqual([1, 4, 9, 16])
   })
+
+  it("limits thread count to numbers length", async () => {
+    const result = await parallelSquare([1, 2], 10)
+    expect(result.sort((a, b) => a - b)).toEqual([1, 4])
+  })
+
+  it("handles empty input", async () => {
+    const result = await parallelSquare([])
+    expect(result).toEqual([])
+  })
 })

--- a/src/lib/parallel.ts
+++ b/src/lib/parallel.ts
@@ -2,12 +2,22 @@ import os from "node:os"
 import path from "node:path"
 import { WorkerPool } from "./worker-pool"
 
-export async function parallelSquare(numbers: number[], threads = os.cpus().length): Promise<number[]> {
-  const chunkSize = Math.ceil(numbers.length / threads)
-  const chunks = Array.from({ length: threads }, (_, i) => numbers.slice(i * chunkSize, (i + 1) * chunkSize))
-    .filter(chunk => chunk.length > 0)
+export async function parallelSquare(
+  numbers: number[],
+  threads = Math.min(os.cpus().length, numbers.length)
+): Promise<number[]> {
+  if (numbers.length === 0) return []
 
-  const pool = new WorkerPool<number[], number[]>(path.join(__dirname, "mapWorker.js"), threads)
+  const actualThreads = Math.min(threads, numbers.length)
+  const chunkSize = Math.ceil(numbers.length / actualThreads)
+  const chunks = Array.from({ length: actualThreads }, (_, i) =>
+    numbers.slice(i * chunkSize, (i + 1) * chunkSize)
+  )
+
+  const pool = new WorkerPool<number[], number[]>(
+    path.join(__dirname, "mapWorker.js"),
+    actualThreads
+  )
 
   const promises = chunks.map(chunk => pool.run(chunk))
   const results = await Promise.all(promises)


### PR DESCRIPTION
## Summary
- default parallel threads to `Math.min(os.cpus().length, numbers.length)`
- cap worker pool and chunking to actual thread count, handle empty input
- add tests for thread limiting and empty input

## Testing
- `npx jest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afed06ca9c83318da2a73599132d62