### PR TITLE
Add currency conversion helpers and update transaction models

### DIFF
--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -34,6 +34,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
     const [amount, setAmount] = useState("")
     const [type, setType] = useState<"Income" | "Expense">("Expense")
     const [category, setCategory] = useState("")
+    const [currency, setCurrency] = useState("USD")
     const [isRecurring, setIsRecurring] = useState(false)
 
     const handleSave = () => {
@@ -41,6 +42,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             onSave({
                 description,
                 amount: parseFloat(amount),
+                currency,
                 type,
                 category,
                 isRecurring
@@ -51,6 +53,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             setAmount("")
             setType("Expense")
             setCategory("")
+            setCurrency("USD")
             setIsRecurring(false)
         }
     }
@@ -81,7 +84,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="type" className="text-right">Type</Label>
-             <Select onValueChange={(value: "Income" | "Expense") => setType(value)} defaultValue={type}>
+             <Select onValueChange={(value: "Income" | "Expense") => setType(value)} value={type}>
                 <SelectTrigger className="col-span-3">
                     <SelectValue placeholder="Select type" />
                 </SelectTrigger>
@@ -89,6 +92,19 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
                     <SelectItem value="Income">Income</SelectItem>
                     <SelectItem value="Expense">Expense</SelectItem>
                 </SelectContent>
+            </Select>
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="currency" className="text-right">Currency</Label>
+            <Select onValueChange={setCurrency} value={currency}>
+              <SelectTrigger className="col-span-3">
+                <SelectValue placeholder="Select currency" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="USD">USD</SelectItem>
+                <SelectItem value="EUR">EUR</SelectItem>
+                <SelectItem value="GBP">GBP</SelectItem>
+              </SelectContent>
             </Select>
           </div>
           <div className="grid grid-cols-4 items-center gap-4">

--- a/src/components/transactions/transactions-table.tsx
+++ b/src/components/transactions/transactions-table.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import type { Transaction } from "@/lib/types"
 import { Repeat } from "lucide-react"
+import { formatCurrency } from "@/lib/currency"
 import {
   memo,
   useMemo,
@@ -46,7 +47,7 @@ export const TransactionsTable = memo(function TransactionsTable({
           formattedDate: new Date(transaction.date).toLocaleDateString(),
           formattedAmount: `${
             transaction.type === "Income" ? "+" : "-"
-          }$${transaction.amount.toFixed(2)}`,
+          }${formatCurrency(transaction.amount, transaction.currency)}`,
         })),
     [transactions, page, pageSize],
   )

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,0 +1,22 @@
+export async function getFxRate(from: string, to: string): Promise<number> {
+  if (from === to) return 1;
+  const res = await fetch(`https://api.exchangerate.host/latest?base=${from}&symbols=${to}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch FX rates');
+  }
+  const data = await res.json();
+  const rate = data?.rates?.[to];
+  if (typeof rate !== 'number') {
+    throw new Error('Invalid FX rate data');
+  }
+  return rate;
+}
+
+export async function convertCurrency(amount: number, from: string, to: string): Promise<number> {
+  const rate = await getFxRate(from, to);
+  return amount * rate;
+}
+
+export function formatCurrency(amount: number, currency: string, locale = 'en-US'): string {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount);
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -2,14 +2,14 @@
 import type { Transaction, Goal, Debt } from './types';
 
 export const mockTransactions: Transaction[] = [
-  { id: '1', date: '2024-07-15', description: 'Bi-weekly Paycheck', amount: 2500.00, type: 'Income', category: 'Salary', isRecurring: true },
-  { id: '2', date: '2024-07-14', description: 'Scrubs & Uniforms', amount: 120.50, type: 'Expense', category: 'Uniforms' },
-  { id: '3', date: '2024-07-12', description: 'Groceries', amount: 85.30, type: 'Expense', category: 'Food' },
-  { id: '4', date: '2024-07-10', description: 'BLS Certification Renewal', amount: 75.00, type: 'Expense', category: 'Certifications', isRecurring: true },
-  { id: '5', date: '2024-07-08', description: 'Student Loan Payment', amount: 350.00, type: 'Expense', category: 'Loans', isRecurring: true },
-  { id: '6', date: '2024-07-05', description: 'Gas', amount: 45.00, type: 'Expense', category: 'Transport' },
-  { id: '7', date: '2024-07-01', description: 'Bi-weekly Paycheck', amount: 2500.00, type: 'Income', category: 'Salary', isRecurring: true },
-  { id: '8', date: '2024-07-01', description: 'Rent', amount: 1200.00, type: 'Expense', category: 'Housing', isRecurring: true },
+  { id: '1', date: '2024-07-15', description: 'Bi-weekly Paycheck', amount: 2500.0, currency: 'USD', type: 'Income', category: 'Salary', isRecurring: true },
+  { id: '2', date: '2024-07-14', description: 'Scrubs & Uniforms', amount: 120.5, currency: 'USD', type: 'Expense', category: 'Uniforms' },
+  { id: '3', date: '2024-07-12', description: 'Groceries', amount: 85.3, currency: 'USD', type: 'Expense', category: 'Food' },
+  { id: '4', date: '2024-07-10', description: 'BLS Certification Renewal', amount: 75.0, currency: 'USD', type: 'Expense', category: 'Certifications', isRecurring: true },
+  { id: '5', date: '2024-07-08', description: 'Student Loan Payment', amount: 350.0, currency: 'USD', type: 'Expense', category: 'Loans', isRecurring: true },
+  { id: '6', date: '2024-07-05', description: 'Gas', amount: 45.0, currency: 'USD', type: 'Expense', category: 'Transport' },
+  { id: '7', date: '2024-07-01', description: 'Bi-weekly Paycheck', amount: 2500.0, currency: 'USD', type: 'Income', category: 'Salary', isRecurring: true },
+  { id: '8', date: '2024-07-01', description: 'Rent', amount: 1200.0, currency: 'USD', type: 'Expense', category: 'Housing', isRecurring: true },
 ];
 
 export const mockGoals: Goal[] = [

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export type Transaction = {
   date: string;
   description: string;
   amount: number;
+  currency: string; // ISO currency code
   type: "Income" | "Expense";
   category: string;
   isRecurring?: boolean;


### PR DESCRIPTION
## Summary
- add currency conversion utilities with FX rate lookup
- extend Transaction model to include currency and adjust sample data
- format transaction amounts using currency helpers and allow currency selection when adding

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aff2b924dc8331a81f362567d6568c