### PR TITLE
feat: add spending forecast flow and chart

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -1,0 +1,2 @@
+export { predictSpending } from './spendingForecast';
+export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -1,0 +1,71 @@
+// This file uses server-side code.
+'use server';
+
+/**
+ * @fileOverview Generates a spending forecast based on past transactions.
+ *
+ * - predictSpending - A function that predicts future spending.
+ * - SpendingForecastInput - The input type for the predictSpending function.
+ * - SpendingForecastOutput - The return type for the predictSpending function.
+ */
+
+import {ai} from '@/ai/genkit';
+import {z} from 'genkit';
+
+const TransactionSchema = z.object({
+  date: z.string().describe('ISO date of the transaction.'),
+  amount: z.number().describe('Transaction amount in USD.'),
+  category: z.string().describe('Category for the transaction.'),
+  description: z.string().optional().describe('Optional description of the transaction.'),
+});
+
+const SpendingForecastInputSchema = z.object({
+  transactions: z.array(TransactionSchema).describe('Historical transaction data to analyze.'),
+});
+export type SpendingForecastInput = z.infer<typeof SpendingForecastInputSchema>;
+
+const ForecastPointSchema = z.object({
+  month: z.string().describe('Month for the forecasted spending (e.g., 2024-08).'),
+  amount: z.number().describe('Predicted total spending for the month in USD.'),
+});
+
+const SpendingForecastOutputSchema = z.object({
+  forecast: z.array(ForecastPointSchema).describe('Predicted spending for upcoming months.'),
+  analysis: z.string().describe('Brief analysis of expected spending trends.'),
+});
+export type SpendingForecastOutput = z.infer<typeof SpendingForecastOutputSchema>;
+
+export async function predictSpending(input: SpendingForecastInput): Promise<SpendingForecastOutput> {
+  return spendingForecastFlow(input);
+}
+
+const prompt = ai.definePrompt({
+  name: 'spendingForecastPrompt',
+  input: {schema: SpendingForecastInputSchema},
+  output: {schema: SpendingForecastOutputSchema},
+  prompt: `You are a financial analyst. Review the user's past transactions and predict the total spending for the next three months.
+
+Transactions:
+{{#each transactions}}
+- Date: {{date}}, Amount: \${{amount}}, Category: {{category}}
+{{/each}}
+
+Return:
+1. forecast: an array with three objects, each having 'month' and 'amount'.
+2. analysis: a short summary of the predicted spending trend.`,
+});
+
+const spendingForecastFlow = ai.defineFlow(
+  {
+    name: 'spendingForecastFlow',
+    inputSchema: SpendingForecastInputSchema,
+    outputSchema: SpendingForecastOutputSchema,
+  },
+  async input => {
+    const {output} = await prompt(input);
+    if (!output) {
+      throw new Error('No output returned from spendingForecastPrompt');
+    }
+    return output;
+  }
+);

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,9 +1,10 @@
 
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { analyzeSpendingHabits, type AnalyzeSpendingHabitsOutput } from "@/ai/flows/analyze-spending-habits"
-import { mockGoals } from "@/lib/data"; // Import mock goals
+import { predictSpending } from "@/ai/flows"
+import { mockGoals, mockTransactions } from "@/lib/data"; // Import mock data
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
@@ -11,16 +12,30 @@ import { Textarea } from "@/components/ui/textarea"
 import { Input } from "@/components/ui/input"
 import { Loader2, Lightbulb, TrendingUp, Sparkles } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from "recharts"
 
 export default function InsightsPage() {
   const [userDescription, setUserDescription] = useState("I'm a staff nurse looking to save for a down payment on a house and pay off my student loans within 5 years.")
   const [files, setFiles] = useState<File[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [analysisResult, setAnalysisResult] = useState<AnalyzeSpendingHabitsOutput | null>(null)
+  const [forecastData, setForecastData] = useState<{ month: string; amount: number }[]>([])
   const { toast } = useToast();
-  
-  // For this demo, we'll use the mockGoals. In a real app, this would be fetched.
+
+  // For this demo, we'll use mock data. In a real app, this would be fetched.
   const goals = mockGoals;
+
+  useEffect(() => {
+    const loadForecast = async () => {
+      try {
+        const result = await predictSpending({ transactions: mockTransactions });
+        setForecastData(result.forecast);
+      } catch (error) {
+        console.error("Error predicting spending:", error);
+      }
+    };
+    loadForecast();
+  }, []);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files) {
@@ -121,7 +136,28 @@ export default function InsightsPage() {
           </form>
         </CardContent>
       </Card>
-      
+
+      {forecastData.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Spending Forecast</CardTitle>
+            <CardDescription>Projected spending for the next 3 months.</CardDescription>
+          </CardHeader>
+          <CardContent className="py-6">
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={forecastData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="month" />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="amount" stroke="var(--color-expenses)" name="Spending" />
+              </LineChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      )}
+
       {analysisResult && (
         <div className="grid gap-6">
           <Card>


### PR DESCRIPTION
## Summary
- add Genkit spendingForecast flow for predicting future spending
- export predictSpending from AI flows index
- show spending forecast chart on insights page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aff5b3230483318a4d281708cb93e4