### PR TITLE
Optimize hooks with memoization and add SWR caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "react-hook-form": "^7.54.2",
         "react-window": "^1.8.11",
         "recharts": "^2.15.1",
+        "swr": "^2.3.6",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.24.2"
@@ -10278,6 +10279,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -18096,6 +18106,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
+      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -18981,6 +19004,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-hook-form": "^7.54.2",
     "react-window": "^1.8.11",
     "recharts": "^2.15.1",
+    "swr": "^2.3.6",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.2"

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useState, useMemo, useTransition, useDeferredValue } from "react";
+import { useState, useMemo, useTransition, useDeferredValue, Profiler, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { mockTransactions } from "@/lib/data";
 import type { Transaction } from "@/lib/types";
@@ -47,7 +47,22 @@ export default function TransactionsPage() {
     startTransition(() => setSearchTerm(value));
   };
 
+  const onRender = useCallback(
+    (
+      id: string,
+      phase: "mount" | "update",
+      actualDuration: number,
+      baseDuration: number
+    ) => {
+      console.log(`[Profiler:${id}] ${phase} took ${actualDuration.toFixed(2)}ms`, {
+        baseDuration: baseDuration.toFixed(2),
+      });
+    },
+    []
+  );
+
   return (
+    <Profiler id="transactions-page" onRender={onRender}>
     <div className="space-y-6">
        <div className="flex items-center justify-between gap-4">
         <div>
@@ -86,5 +101,6 @@ export default function TransactionsPage() {
 
       <TransactionsTable transactions={filteredTransactions} />
     </div>
+    </Profiler>
   );
 }

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -5,15 +5,16 @@ const MOBILE_BREAKPOINT = 768
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
+  const onChange = React.useCallback(() => {
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+  }, [])
+
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
     mql.addEventListener("change", onChange)
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
-  }, [])
+  }, [onChange])
 
   return !!isMobile
 }

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -183,12 +183,19 @@ function useToast() {
       listeners.delete(setState)
     }
   }, [])
+  const dismiss = React.useCallback(
+    (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+    []
+  )
 
-  return {
-    ...state,
-    toast,
-    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
-  }
+  return React.useMemo(
+    () => ({
+      ...state,
+      toast,
+      dismiss,
+    }),
+    [state, dismiss]
+  )
 }
 
 export { useToast, toast }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,18 @@
+import useSWR, { SWRConfiguration } from "swr";
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error("Failed to fetch");
+  }
+  return res.json();
+};
+
+export function useApi<T>(url: string, config?: SWRConfiguration) {
+  return useSWR<T>(url, fetcher, {
+    revalidateOnFocus: false,
+    revalidateIfStale: false,
+    dedupingInterval: 1000 * 60 * 5,
+    ...config,
+  });
+}


### PR DESCRIPTION
## Summary
- Memoize mobile breakpoint listener and toast helpers for stable references
- Cache API responses via new `useApi` hook built on SWR
- Instrument transactions page with React Profiler logging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aff5b8501483318471247edc4fc50b