### PR TITLE
feat: validate firebase env vars

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,13 +2,21 @@ import { initializeApp, getApps, getApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { z } from "zod";
 
+const nonPlaceholder = z
+  .string()
+  .min(1)
+  .refine(
+    (v) => v !== "REPLACE_WITH_VALUE",
+    "Set this Firebase env var in .env.local"
+  );
+
 const envSchema = z.object({
-  NEXT_PUBLIC_FIREBASE_API_KEY: z.string(),
-  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: z.string(),
-  NEXT_PUBLIC_FIREBASE_PROJECT_ID: z.string(),
-  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: z.string(),
-  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: z.string(),
-  NEXT_PUBLIC_FIREBASE_APP_ID: z.string()
+  NEXT_PUBLIC_FIREBASE_API_KEY: nonPlaceholder,
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: nonPlaceholder,
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: nonPlaceholder,
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: nonPlaceholder,
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: nonPlaceholder,
+  NEXT_PUBLIC_FIREBASE_APP_ID: nonPlaceholder,
 });
 
 const env = envSchema.parse(process.env);


### PR DESCRIPTION
## Summary
- validate Firebase env vars to ensure placeholders are rejected

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Type error: Unused '@ts-expect-error' directive)*
- `node -e "require('./src/lib/firebase.ts')"` *(fails: Set this Firebase env var in .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_68b00f74ef24833191e9c11188e64d1a