### PR TITLE
refactor: memoize transaction callbacks

### DIFF
--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useState, useMemo, useTransition, useDeferredValue, useRef } from "react";
+import { useState, useMemo, useTransition, useDeferredValue, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { mockTransactions } from "@/lib/data";
 import type { Transaction } from "@/lib/types";
@@ -30,12 +30,19 @@ export default function TransactionsPage() {
     return ['all', ...Array.from(new Set(allCategories))];
   }, [transactions]);
 
-  const addTransaction = (transaction: Omit<Transaction, 'id' | 'date'>) => {
-    setTransactions(prev => [
-      { ...transaction, id: crypto.randomUUID(), date: new Date().toISOString().split('T')[0] },
-      ...prev
-    ]);
-  };
+  const addTransaction = useCallback(
+    (transaction: Omit<Transaction, "id" | "date">) => {
+      setTransactions(prev => [
+        {
+          ...transaction,
+          id: crypto.randomUUID(),
+          date: new Date().toISOString().split("T")[0],
+        },
+        ...prev,
+      ]);
+    },
+    [setTransactions]
+  );
 
   const handleUploadClick = () => fileInputRef.current?.click();
 
@@ -69,9 +76,12 @@ export default function TransactionsPage() {
     });
   }, [transactions, deferredSearchTerm, filterType, filterCategory]);
 
-  const handleSearchChange = (value: string) => {
-    startTransition(() => setSearchTerm(value));
-  };
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      startTransition(() => setSearchTerm(value));
+    },
+    [startTransition, setSearchTerm]
+  );
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- memoize addTransaction with useCallback
- memoize search input handler with useCallback
- ensure stable function references for children

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b019d2e6a88331b0c31e954d167b1a