### PR TITLE
chore: log profiler data only in development

### DIFF
--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,7 +1,15 @@
 
 "use client";
 
-import { useState, useMemo, useTransition, useDeferredValue, useRef } from "react";
+import {
+  useState,
+  useMemo,
+  useTransition,
+  useDeferredValue,
+  useRef,
+  Profiler,
+  type ProfilerOnRenderCallback,
+} from "react";
 import { useRouter } from "next/navigation";
 import { mockTransactions } from "@/lib/data";
 import type { Transaction } from "@/lib/types";
@@ -73,6 +81,12 @@ export default function TransactionsPage() {
     startTransition(() => setSearchTerm(value));
   };
 
+  const onRender: ProfilerOnRenderCallback = (...params) => {
+    if (process.env.NODE_ENV === "development") {
+      console.log(...params);
+    }
+  };
+
   return (
     <div className="space-y-6">
        <div className="flex items-center justify-between gap-4">
@@ -121,7 +135,9 @@ export default function TransactionsPage() {
         </p>
       )}
 
-      <TransactionsTable transactions={filteredTransactions} />
+      <Profiler id="transactions-table" onRender={onRender}>
+        <TransactionsTable transactions={filteredTransactions} />
+      </Profiler>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use React Profiler to track Transactions table renders
- guard console logging so it only fires during development

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in existing test files)*
- `npm run build` *(fails: Can't resolve 'framer-motion', 'papaparse')*


------
https://chatgpt.com/codex/tasks/task_e_68b019d2fccc8331b8c55852925091ba