### PR TITLE
feat: case-insensitive category handling

### DIFF
--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,0 +1,88 @@
+// Utility functions for managing transaction categories
+// Categories are compared in a case-insensitive manner while preserving
+// the original casing for display purposes.
+
+const STORAGE_KEY = "categories";
+
+// In non-browser environments (e.g. during testing) `localStorage` is not
+// available.  We keep an in-memory fallback so the functions still work.
+let memoryStore: string[] = [];
+
+const hasLocalStorage = () =>
+  typeof window !== "undefined" && !!window.localStorage;
+
+const normalize = (value: string) => value.trim().toLowerCase();
+
+function load(): string[] {
+  if (hasLocalStorage()) {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    try {
+      return JSON.parse(raw) as string[];
+    } catch {
+      return [];
+    }
+  }
+  return memoryStore;
+}
+
+function save(categories: string[]) {
+  if (hasLocalStorage()) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(categories));
+  } else {
+    memoryStore = [...categories];
+  }
+}
+
+/**
+ * Return the list of categories with duplicates removed in a
+ * case-insensitive manner. The first occurrence of a category determines
+ * the casing that will be preserved for display.
+ */
+export function getCategories(): string[] {
+  const categories = load();
+  const map = new Map<string, string>();
+  for (const cat of categories) {
+    const key = normalize(cat);
+    if (!map.has(key)) {
+      map.set(key, cat);
+    }
+  }
+  const unique = Array.from(map.values());
+  // Persist the de-duplicated list
+  save(unique);
+  return unique;
+}
+
+/**
+ * Add a category if it does not already exist (case-insensitive).
+ * Returns the updated list of categories.
+ */
+export function addCategory(category: string): string[] {
+  const categories = getCategories();
+  const key = normalize(category);
+  const exists = categories.some((c) => normalize(c) === key);
+  if (!exists) {
+    categories.push(category);
+    save(categories);
+  }
+  return categories;
+}
+
+/**
+ * Remove a category regardless of casing. Returns the updated list.
+ */
+export function removeCategory(category: string): string[] {
+  const key = normalize(category);
+  const categories = getCategories().filter(
+    (c) => normalize(c) !== key
+  );
+  save(categories);
+  return categories;
+}
+
+/** Clear all categories. */
+export function clearCategories() {
+  save([]);
+}
+


### PR DESCRIPTION
## Summary
- add category helpers that compare entries in a case-insensitive way
- normalize category usage in transactions page for adding, importing and filtering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm ci` *(fails: 404 Not Found - @genkit-ai/openai@1.17.0)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01bd244b88331b65bfbf523b2b7bf