### PR TITLE
Add banking provider import endpoint

### DIFF
--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server"
+
+/**
+ * Imports transactions from a banking provider (e.g., Plaid, Finicity).
+ * This endpoint deals with provider-specific payloads and is distinct from the
+ * generic transaction syncing endpoint at `/api/transactions/sync`.
+ */
+export async function POST(req: Request) {
+  const { provider, transactions } = await req.json()
+
+  // In a real implementation, the `provider` would be used to retrieve
+  // transactions from the external banking service and persist them.
+  return NextResponse.json({
+    provider,
+    imported: Array.isArray(transactions) ? transactions.length : 0,
+  })
+}

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server"
 
+/**
+ * Generic transaction syncing endpoint.
+ * Unlike `/api/bank/import`, this expects transactions already retrieved
+ * from any source and persists them to the database.
+ */
 export async function POST(req: Request) {
   const { transactions } = await req.json()
-  // Here you would normally persist transactions to a database
+  // In a real implementation these transactions would be persisted to a database.
   return NextResponse.json({ received: Array.isArray(transactions) ? transactions.length : 0 })
 }


### PR DESCRIPTION
## Summary
- add `/api/bank/import` route for banking-provider imports
- clarify `/api/transactions/sync` comments to distinguish from provider imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01e5e9d788331968150fea5701e2d