### PR TITLE
Centralize AI flow exports and document flows

### DIFF
--- a/src/ai/dev.ts
+++ b/src/ai/dev.ts
@@ -1,8 +1,4 @@
 import { config } from 'dotenv';
 config();
 
-import '@/ai/flows/analyze-spending-habits.ts';
-import '@/ai/flows/tax-estimation.ts';
-import '@/ai/flows/analyze-receipt.ts';
-import '@/ai/flows/suggest-debt-strategy.ts';
-import '@/ai/flows/calculate-cashflow.ts';
+import '@/ai/flows';

--- a/src/ai/flows/README.md
+++ b/src/ai/flows/README.md
@@ -1,0 +1,35 @@
+# AI Flows
+
+Central exports for all AI-powered flows. Import flows and their input/output types from the index:
+
+```ts
+import {
+  analyzeReceipt,
+  type AnalyzeReceiptInput,
+  type AnalyzeReceiptOutput,
+  estimateTax,
+  type TaxEstimationInput,
+  type TaxEstimationOutput,
+  analyzeSpendingHabits,
+  type AnalyzeSpendingHabitsInput,
+  type AnalyzeSpendingHabitsOutput,
+  suggestDebtStrategy,
+  type SuggestDebtStrategyInput,
+  type SuggestDebtStrategyOutput,
+  calculateCashflow,
+  type CalculateCashflowInput,
+  type CalculateCashflowOutput,
+  predictSpending,
+  type SpendingForecastInput,
+  type SpendingForecastOutput,
+} from "@/ai/flows";
+```
+
+## Available flows
+
+- `analyzeReceipt` – analyze receipt images and extract transaction details.
+- `estimateTax` – estimate annual tax obligations.
+- `analyzeSpendingHabits` – evaluate spending patterns and opportunities.
+- `suggestDebtStrategy` – recommend an optimal debt payoff plan.
+- `calculateCashflow` – compute gross and net monthly cashflow.
+- `predictSpending` – forecast future spending.

--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -1,2 +1,27 @@
+/**
+ * Central exports for AI flows and their associated types.
+ *
+ * Consumers should import flows from this module rather than individual files:
+ *
+ * ```ts
+ * import { analyzeReceipt, estimateTax } from '@/ai/flows';
+ * ```
+ */
+
+export { analyzeReceipt } from './analyze-receipt';
+export type { AnalyzeReceiptInput, AnalyzeReceiptOutput } from './analyze-receipt';
+
+export { estimateTax } from './tax-estimation';
+export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
+
+export { analyzeSpendingHabits } from './analyze-spending-habits';
+export type { AnalyzeSpendingHabitsInput, AnalyzeSpendingHabitsOutput } from './analyze-spending-habits';
+
+export { suggestDebtStrategy } from './suggest-debt-strategy';
+export type { SuggestDebtStrategyInput, SuggestDebtStrategyOutput } from './suggest-debt-strategy';
+
+export { calculateCashflow } from './calculate-cashflow';
+export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculate-cashflow';
+
 export { predictSpending } from './spendingForecast';
 export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';

--- a/src/app/cashflow/page.tsx
+++ b/src/app/cashflow/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useMemo } from "react"
-import { calculateCashflow, type CalculateCashflowOutput } from "@/ai/flows/calculate-cashflow"
+import { calculateCashflow, type CalculateCashflowOutput } from "@/ai/flows"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"

--- a/src/app/debts/page.tsx
+++ b/src/app/debts/page.tsx
@@ -8,10 +8,9 @@ const DebtCalendar = dynamic(() => import("@/components/debts/DebtCalendar"), { 
 import { DebtCard } from "@/components/debts/debt-card";
 import { DebtStrategyPlan } from "@/components/debts/debt-strategy-plan";
 import { Button } from "@/components/ui/button";
-import type { SuggestDebtStrategyOutput } from "@/ai/flows/suggest-debt-strategy";
+import { suggestDebtStrategy, type SuggestDebtStrategyOutput } from "@/ai/flows";
 import { useToast } from "@/hooks/use-toast";
 import type { Debt } from "@/lib/types";
-import { suggestDebtStrategy } from "@/ai/flows/suggest-debt-strategy";
 import { deleteDoc } from "firebase/firestore";
 import { debtDoc } from "@/lib/debts";
 

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -2,8 +2,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { analyzeSpendingHabits, type AnalyzeSpendingHabitsOutput } from "@/ai/flows/analyze-spending-habits"
-import { predictSpending } from "@/ai/flows"
+import { analyzeSpendingHabits, type AnalyzeSpendingHabitsOutput, predictSpending } from "@/ai/flows"
 import { mockGoals, mockTransactions } from "@/lib/data"; // Import mock data
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"

--- a/src/app/taxes/page.tsx
+++ b/src/app/taxes/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { estimateTax, type TaxEstimationOutput } from "@/ai/flows/tax-estimation"
+import { estimateTax, type TaxEstimationOutput } from "@/ai/flows"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"

--- a/src/app/transactions/scan/page.tsx
+++ b/src/app/transactions/scan/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react"
 import { useRouter } from "next/navigation"
-import { analyzeReceipt, type AnalyzeReceiptOutput } from "@/ai/flows/analyze-receipt"
+import { analyzeReceipt, type AnalyzeReceiptOutput } from "@/ai/flows"
 import { useToast } from "@/hooks/use-toast"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"

--- a/src/components/debts/debt-strategy-plan.tsx
+++ b/src/components/debts/debt-strategy-plan.tsx
@@ -4,7 +4,7 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { type SuggestDebtStrategyOutput } from "@/ai/flows/suggest-debt-strategy";
+import { type SuggestDebtStrategyOutput } from "@/ai/flows";
 
 interface DebtStrategyPlanProps {
   strategy: SuggestDebtStrategyOutput;


### PR DESCRIPTION
## Summary
- Export all AI flows and their types from `src/ai/flows/index.ts`
- Switch consumers to import flows from the central index
- Add documentation for available flows

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b046ca878c833195e44fa8d65d38f3