### PR TITLE
Align debt recurrence types with unified schema

### DIFF
--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -11,7 +11,7 @@
 
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
-import { Debt } from '@/lib/types';
+import { RecurrenceValues } from '@/lib/types';
 
 const DebtSchema = z.object({
     id: z.string(),
@@ -21,7 +21,7 @@ const DebtSchema = z.object({
     interestRate: z.number(),
     minimumPayment: z.number(),
     dueDate: z.string(),
-    recurrence: z.enum(['once', 'monthly']),
+    recurrence: z.enum(RecurrenceValues),
 });
 
 const SuggestDebtStrategyInputSchema = z.object({

--- a/src/app/debts/page.tsx
+++ b/src/app/debts/page.tsx
@@ -34,13 +34,7 @@ export default function DebtsPage() {
     setStrategy(null);
     try {
       // The AI flow expects the full debt details, which our unified `Debt` type now provides.
-      // We need to ensure the recurrence maps correctly.
-      const strategyInput = debts.map(d => ({
-        ...d,
-        recurrence: d.recurrence === 'none' ? 'once' : 'monthly',
-      }));
-
-      const result = await suggestDebtStrategy({ debts: strategyInput });
+      const result = await suggestDebtStrategy({ debts });
       setStrategy(result);
 
     } catch (error) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,7 +19,8 @@ export type Goal = {
   importance: number; // New field: 1-5 rating
 };
 
-export type Recurrence = "none" | "weekly" | "biweekly" | "monthly";
+export const RecurrenceValues = ["none", "weekly", "biweekly", "monthly"] as const;
+export type Recurrence = typeof RecurrenceValues[number];
 
 // This is the unified, authoritative Debt type used across the app.
 export type Debt = {


### PR DESCRIPTION
## Summary
- Export RecurrenceValues constant in types and use across debt strategy flow
- Remove once/monthly mapping when requesting AI payoff plan
- Validate debt recurrence using shared values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b046c7ee7483318782250a451afffe