### PR TITLE
Validate transaction amount parsing and handle invalid inputs

### DIFF
--- a/src/__tests__/transactions.test.ts
+++ b/src/__tests__/transactions.test.ts
@@ -1,0 +1,17 @@
+import { validateTransactions } from "../lib/transactions";
+
+const baseRow = {
+  date: "2024-01-01",
+  description: "Test",
+  type: "Income" as const,
+  category: "Misc",
+};
+
+describe("validateTransactions", () => {
+  it.each(["abc", "", "NaN"])("throws for invalid amount '%s'", (amount) => {
+    const rows = [{ ...baseRow, amount }];
+    expect(() => validateTransactions(rows)).toThrow(
+      /Invalid amount in row 1/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- preprocess transaction amount values as strings
- validate parsed amounts and throw descriptive errors for invalid numbers
- add tests covering invalid transaction amounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b046c647fc83318f6111b3eee04afc