### PR TITLE
feat: make debt occurrence limit configurable

### DIFF
--- a/src/components/debts/DebtCalendar.tsx
+++ b/src/components/debts/DebtCalendar.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Recurrence, Debt } from "@/lib/types"; // Use the unified Debt type
-import { useDebtOccurrences } from "@/hooks/use-debt-occurrences";
+import { useDebtOccurrences, DEFAULT_MAX_OCCURRENCES } from "@/hooks/use-debt-occurrences";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
@@ -65,7 +65,13 @@ export default function DebtCalendar({ onChange, startOn = 0 }: DebtCalendarProp
   const gridFrom = grid[0];
   const gridTo = grid[grid.length - 1];
 
-  const { occurrences, grouped } = useDebtOccurrences(debts, gridFrom, gridTo, query);
+  const { occurrences, grouped } = useDebtOccurrences(
+    debts,
+    gridFrom,
+    gridTo,
+    query,
+    DEFAULT_MAX_OCCURRENCES
+  );
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- expose DEFAULT_MAX_OCCURRENCES constant and allow overriding max occurrences in debt hook
- warn when generated occurrences hit the limit to avoid truncation surprises
- update DebtCalendar and tests to pass and assert custom limits

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b04cee4ccc833185ce328c69792a8a