### PR TITLE
Improve service worker synchronization logic

### DIFF
--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -1,28 +1,31 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { getQueuedTransactions, clearQueuedTransactions } from "@/lib/offline"
 
 export function ServiceWorker() {
+  const debounceId = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   useEffect(() => {
-    if ("serviceWorker" in navigator) {
-      navigator.serviceWorker.register("/sw.js").catch(console.error)
-    }
-
-    let debounceId: ReturnType<typeof setTimeout> | null = null
-
     const handleOnline = () => {
-      if (debounceId) clearTimeout(debounceId)
+      if (debounceId.current) clearTimeout(debounceId.current)
 
-      debounceId = setTimeout(async () => {
+      debounceId.current = setTimeout(async () => {
         const queued = await getQueuedTransactions()
         if (queued.length) {
           try {
-            await fetch("/api/transactions/sync", {
+            const response = await fetch("/api/transactions/sync", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ transactions: queued }),
             })
+            if (!response.ok) {
+              console.error(
+                "Failed to sync queued transactions",
+                await response.text()
+              )
+              return
+            }
             await clearQueuedTransactions()
           } catch (error) {
             console.error("Failed to sync queued transactions", error)
@@ -31,10 +34,24 @@ export function ServiceWorker() {
       }, 1000)
     }
 
-    window.addEventListener("online", handleOnline)
+    const registerAndListen = async () => {
+      if ("serviceWorker" in navigator) {
+        try {
+          await navigator.serviceWorker.register("/sw.js")
+        } catch (error) {
+          console.error(error)
+        }
+      }
+
+      window.addEventListener("online", handleOnline)
+      if (navigator.onLine) handleOnline()
+    }
+
+    registerAndListen()
+
     return () => {
       window.removeEventListener("online", handleOnline)
-      if (debounceId) clearTimeout(debounceId)
+      if (debounceId.current) clearTimeout(debounceId.current)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- persist debounce timers with `useRef` and handle online sync on mount
- validate sync endpoint responses and log failures
- wait for service worker registration before adding online listeners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04cefdbec833198aba9e09919a903