### PR TITLE
Validate and handle errors in API routes

### DIFF
--- a/src/__tests__/api-validation.test.ts
+++ b/src/__tests__/api-validation.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment node
+ */
+import { POST as bankImport } from "@/app/api/bank/import/route"
+import { POST as transactionsSync } from "@/app/api/transactions/sync/route"
+
+describe("/api/bank/import", () => {
+  it("returns 400 for invalid JSON", async () => {
+    const req = new Request("http://localhost", { method: "POST", body: "not json" })
+    const res = await bankImport(req)
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for invalid payload", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ provider: 123, transactions: "oops" }),
+    })
+    const res = await bankImport(req)
+    expect(res.status).toBe(400)
+  })
+})
+
+describe("/api/transactions/sync", () => {
+  it("returns 400 for invalid JSON", async () => {
+    const req = new Request("http://localhost", { method: "POST", body: "nope" })
+    const res = await transactionsSync(req)
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for invalid payload", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ transactions: "not-array" }),
+    })
+    const res = await transactionsSync(req)
+    expect(res.status).toBe(400)
+  })
+})

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,17 +1,40 @@
 import { NextResponse } from "next/server"
+import { z } from "zod"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
  * This endpoint deals with provider-specific payloads and is distinct from the
  * generic transaction syncing endpoint at `/api/transactions/sync`.
  */
-export async function POST(req: Request) {
-  const { provider, transactions } = await req.json()
+const bodySchema = z.object({
+  provider: z.string(),
+  transactions: z.array(z.any()),
+})
 
-  // In a real implementation, the `provider` would be used to retrieve
-  // transactions from the external banking service and persist them.
-  return NextResponse.json({
-    provider,
-    imported: Array.isArray(transactions) ? transactions.length : 0,
-  })
+export async function POST(req: Request) {
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  const parsed = bodySchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+  }
+
+  const { provider, transactions } = parsed.data
+
+  try {
+    return NextResponse.json({
+      provider,
+      imported: transactions.length,
+    })
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    )
+  }
 }

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -1,12 +1,36 @@
 import { NextResponse } from "next/server"
+import { z } from "zod"
 
 /**
  * Generic transaction syncing endpoint.
  * Unlike `/api/bank/import`, this expects transactions already retrieved
  * from any source and persists them to the database.
  */
+const bodySchema = z.object({
+  transactions: z.array(z.any()),
+})
+
 export async function POST(req: Request) {
-  const { transactions } = await req.json()
-  // In a real implementation these transactions would be persisted to a database.
-  return NextResponse.json({ received: Array.isArray(transactions) ? transactions.length : 0 })
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  const parsed = bodySchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+  }
+
+  const { transactions } = parsed.data
+
+  try {
+    return NextResponse.json({ received: transactions.length })
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    )
+  }
 }


### PR DESCRIPTION
## Summary
- Add Zod-based request validation and error handling to bank import and transaction sync API routes
- Return proper 400/500 responses for malformed requests
- Add tests covering invalid JSON and payload shapes

## Testing
- `npm test`
- `npm run lint` *(fails: 'auth-provider.test.tsx:15:15 Error: 'authStub' is assigned a value but never used', ...)*


------
https://chatgpt.com/codex/tasks/task_e_68b04cf10f5c8331a5204916d30b5d8b