### PR TITLE
Handle missing output in AI flows

### DIFF
--- a/src/ai/flows/__tests__/no-output.test.ts
+++ b/src/ai/flows/__tests__/no-output.test.ts
@@ -1,0 +1,47 @@
+function setupNoOutputMocks() {
+  const definePromptMock = jest.fn().mockReturnValue(async () => ({ output: undefined }));
+  const defineFlowMock = jest.fn((_config: any, handler: any) => handler);
+  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+}
+
+describe('calculateCashflowFlow', () => {
+  it('throws an error when prompt returns no output', async () => {
+    jest.resetModules();
+    setupNoOutputMocks();
+    const { calculateCashflow } = await import('@/ai/flows/calculate-cashflow');
+    await expect(
+      calculateCashflow({
+        annualIncome: 50000,
+        estimatedAnnualTaxes: 10000,
+        totalMonthlyDeductions: 2000,
+      })
+    ).rejects.toThrow('No output returned from calculateCashflowFlow');
+  });
+});
+
+describe('suggestDebtStrategyFlow', () => {
+  it('throws an error when prompt returns no output', async () => {
+    jest.resetModules();
+    setupNoOutputMocks();
+    const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
+    await expect(
+      suggestDebtStrategy({ debts: [] })
+    ).rejects.toThrow('No output returned from suggestDebtStrategyFlow');
+  });
+});
+
+describe('taxEstimationFlow', () => {
+  it('throws an error when prompt returns no output', async () => {
+    jest.resetModules();
+    setupNoOutputMocks();
+    const { estimateTax } = await import('@/ai/flows/tax-estimation');
+    await expect(
+      estimateTax({
+        income: 50000,
+        deductions: 10000,
+        location: 'NY',
+        filingStatus: 'single',
+      })
+    ).rejects.toThrow('No output returned from taxEstimationFlow');
+  });
+});

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -67,6 +67,9 @@ const calculateCashflowFlow = ai.defineFlow(
   },
   async input => {
     const {output} = await prompt(input);
-    return output!;
+    if (!output) {
+      throw new Error('No output returned from calculateCashflowFlow');
+    }
+    return output;
   }
 );

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -72,6 +72,9 @@ const suggestDebtStrategyFlow = ai.defineFlow(
   },
   async input => {
     const {output} = await prompt(input);
-    return output!;
+    if (!output) {
+      throw new Error('No output returned from suggestDebtStrategyFlow');
+    }
+    return output;
   }
 );

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -72,6 +72,9 @@ const taxEstimationFlow = ai.defineFlow(
   },
   async input => {
     const {output} = await taxEstimationPrompt(input);
-    return output!;
+    if (!output) {
+      throw new Error('No output returned from taxEstimationFlow');
+    }
+    return output;
   }
 );


### PR DESCRIPTION
## Summary
- Guard against missing output in calculateCashflow, suggestDebtStrategy, and taxEstimation flows
- Add unit tests ensuring flows throw descriptive errors when no output is returned

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04cf28508833184630c5daf3634c4