### PR TITLE
Handle housekeeping errors in cron endpoint

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -21,6 +21,12 @@ if (typeof (global as any).Headers === 'undefined') {
   (global as any).Headers = class {};
 }
 
+// Ensure Response.json helper exists for NextResponse.json in tests
+if (typeof (global as any).Response.json !== 'function') {
+  (global as any).Response.json = (data: any, init?: any) =>
+    new (global as any).Response(JSON.stringify(data), init);
+}
+
 // Stub Firebase environment variables expected by zod validation
 process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'test';
 process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'test';

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -1,0 +1,35 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((data, init) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    })),
+  },
+}));
+
+jest.mock("@/lib/housekeeping", () => ({
+  runHousekeeping: jest.fn(),
+}));
+
+import { GET } from "@/app/api/cron/housekeeping/route";
+import { runHousekeeping } from "@/lib/housekeeping";
+
+describe("housekeeping route", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns ok when housekeeping succeeds", async () => {
+    (runHousekeeping as jest.Mock).mockResolvedValue(undefined);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+
+  it("returns error status when housekeeping fails", async () => {
+    (runHousekeeping as jest.Mock).mockRejectedValue(new Error("boom"));
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "boom" });
+  });
+});

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -3,6 +3,12 @@ import { runHousekeeping } from "@/lib/housekeeping";
 
 // HTTP GET endpoint invoked by Cloud Scheduler or cron job
 export async function GET() {
-  await runHousekeeping();
-  return NextResponse.json({ status: "ok" });
+  try {
+    await runHousekeeping();
+    return NextResponse.json({ status: "ok" });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Housekeeping failed", error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Summary
- handle errors from `runHousekeeping` in cron route and return 500 JSON payload
- polyfill `Response.json` in test setup to support NextResponse in tests
- add tests for cron route success and failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04dc2a3c88331825dc5e5de805cfd