### PR TITLE
Validate transaction amount and add tests

### DIFF
--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AddTransactionDialog } from '@/components/transactions/add-transaction-dialog';
+
+const onSave = jest.fn();
+const toastMock = jest.fn();
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+jest.mock('lucide-react', () => ({ PlusCircle: () => null }));
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogTrigger: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <div>{children}</div>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+}));
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: ({ children }: any) => <div>{children}</div>,
+}));
+jest.mock('@/components/ui/switch', () => ({
+  Switch: ({ onCheckedChange, ...props }: any) => (
+    <input type="checkbox" onChange={onCheckedChange} {...props} />
+  ),
+}));
+
+beforeEach(() => {
+  onSave.mockClear();
+  toastMock.mockClear();
+});
+
+function openAndFill(amount: string) {
+  render(<AddTransactionDialog onSave={onSave} />);
+  fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'Test' } });
+  fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: amount } });
+  fireEvent.change(screen.getByLabelText(/category/i), { target: { value: 'Misc' } });
+  fireEvent.click(screen.getByText(/save transaction/i));
+}
+
+describe('AddTransactionDialog', () => {
+  it.each(['abc', 'Infinity'])(
+    'shows toast and prevents save for invalid amount "%s"',
+    (amount) => {
+      openAndFill(amount);
+      expect(onSave).not.toHaveBeenCalled();
+      expect(toastMock).toHaveBeenCalled();
+    }
+  );
+});

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -23,6 +23,7 @@ import {
 import { Switch } from "@/components/ui/switch"
 import { PlusCircle } from "lucide-react"
 import type { Transaction } from "@/lib/types"
+import { useToast } from "@/hooks/use-toast"
 
 interface AddTransactionDialogProps {
   onSave: (transaction: Omit<Transaction, 'id' | 'date'>) => void;
@@ -36,26 +37,32 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
     const [category, setCategory] = useState("")
     const [currency, setCurrency] = useState("USD")
     const [isRecurring, setIsRecurring] = useState(false)
+    const { toast } = useToast()
 
     const handleSave = () => {
-        if(description && amount && type && category) {
-            onSave({
-                description,
-                amount: parseFloat(amount),
-                currency,
-                type,
-                category,
-                isRecurring
-            })
-            setOpen(false)
-            // Reset form
-            setDescription("")
-            setAmount("")
-            setType("Expense")
-            setCategory("")
-            setCurrency("USD")
-            setIsRecurring(false)
+        const numericAmount = Number(amount)
+
+        if (!description || !amount || !type || !category || !Number.isFinite(numericAmount)) {
+            toast({ title: "Invalid amount", description: "Please enter a valid amount.", variant: "destructive" })
+            return
         }
+
+        onSave({
+            description,
+            amount: numericAmount,
+            currency,
+            type,
+            category,
+            isRecurring
+        })
+        setOpen(false)
+        // Reset form
+        setDescription("")
+        setAmount("")
+        setType("Expense")
+        setCategory("")
+        setCurrency("USD")
+        setIsRecurring(false)
     }
 
   return (


### PR DESCRIPTION
## Summary
- ensure AddTransactionDialog validates numeric amount and shows toast on invalid input
- cover invalid transaction amount scenarios with new component tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04dc3c50c83319cfa67e0a45d8dcc