### PR TITLE
refactor: migrate map worker to TypeScript

### DIFF
--- a/src/lib/mapWorker.js
+++ b/src/lib/mapWorker.js
@@ -1,9 +1,0 @@
-const { parentPort } = require("node:worker_threads")
-
-function square(numbers) {
-  return numbers.map(n => n * n)
-}
-
-parentPort.on("message", numbers => {
-  parentPort.postMessage(square(numbers))
-})

--- a/src/lib/mapWorker.ts
+++ b/src/lib/mapWorker.ts
@@ -1,0 +1,9 @@
+import { parentPort } from "node:worker_threads"
+
+export function square(numbers: number[]): number[] {
+  return numbers.map(n => n * n)
+}
+
+parentPort?.on("message", (numbers: number[]) => {
+  parentPort?.postMessage(square(numbers))
+})


### PR DESCRIPTION
## Summary
- convert map worker to TypeScript and ES module syntax
- export square function and keep worker message handling

## Testing
- `npm run lint` *(fails: no-unused-vars, no-require-imports, no-explicit-any)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04dfe60748331ac27f22feedc5ac1