### PR TITLE
Handle FX rate fetch network errors

### DIFF
--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,6 +1,15 @@
 export async function getFxRate(from: string, to: string): Promise<number> {
   if (from === to) return 1;
-  const res = await fetch(`https://api.exchangerate.host/latest?base=${from}&symbols=${to}`);
+  let res: Response;
+  try {
+    res = await fetch(
+      `https://api.exchangerate.host/latest?base=${from}&symbols=${to}`,
+    );
+  } catch (err) {
+    throw new Error(
+      `Network error while fetching FX rates: ${err instanceof Error ? err.message : err}`,
+    );
+  }
   if (!res.ok) {
     throw new Error('Failed to fetch FX rates');
   }
@@ -12,9 +21,18 @@ export async function getFxRate(from: string, to: string): Promise<number> {
   return rate;
 }
 
-export async function convertCurrency(amount: number, from: string, to: string): Promise<number> {
-  const rate = await getFxRate(from, to);
-  return amount * rate;
+export async function convertCurrency(
+  amount: number,
+  from: string,
+  to: string,
+): Promise<number> {
+  try {
+    const rate = await getFxRate(from, to);
+    return amount * rate;
+  } catch (err) {
+    console.error('Currency conversion failed', err);
+    return amount;
+  }
 }
 
 export function formatCurrency(amount: number, currency: string, locale = 'en-US'): string {


### PR DESCRIPTION
## Summary
- wrap FX rate API call in try/catch and surface descriptive network error
- return original amount when currency conversion fails

## Testing
- `npm test`
- `npm run lint` *(fails: existing ESLint errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b04dff19188331b9bca05dd4c7cb51