### PR TITLE
chore: pin nextjs version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "genkit": "^1.14.1",
         "idb": "^7.1.1",
         "lucide-react": "^0.475.0",
-        "next": "latest",
+        "next": "^15.0.0",
         "next-themes": "^0.3.0",
         "papaparse": "^5.5.3",
         "patch-package": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "genkit": "^1.14.1",
     "idb": "^7.1.1",
     "lucide-react": "^0.475.0",
-    "next": "latest",
+    "next": "^15.0.0",
     "next-themes": "^0.3.0",
     "papaparse": "^5.5.3",
     "patch-package": "^8.0.0",


### PR DESCRIPTION
## Summary
- pin `next` dependency to a ^15.0.0 semver range

## Testing
- `npm install --no-audit --no-fund`
- `npm run build` *(fails: Module not found: Can't resolve '@genkit-ai/googleai')*
- `npm start` *(fails: Could not find a production build in the '.next' directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b04e7a39648331987572ae48b3b5e3