### PR TITLE
chore: pin Next.js version and document upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ The housekeeping service removes outdated files from Cloud Storage to manage cos
 | `RETENTION_DAYS` | Number of days to retain files before deletion (default: 30). |
 
 Adjust the retention threshold by setting `RETENTION_DAYS` before running the service or updating the scheduled job configuration.
+
+## Upgrading Next.js
+
+This project pins Next.js to a specific version. When upgrading, follow the steps in [docs/next-upgrade.md](docs/next-upgrade.md) to review releases, update the version, and verify the changes.

--- a/docs/next-upgrade.md
+++ b/docs/next-upgrade.md
@@ -1,0 +1,11 @@
+# Upgrading Next.js
+
+This project pins the Next.js version to avoid unintended updates. To upgrade deliberately:
+
+1. Review [Next.js release notes](https://nextjs.org/docs/changelog) and security advisories for relevant changes.
+2. Edit `package.json` to set `next` to the desired version.
+3. Run `npm update next@<version>` (or `npm install`) to update `package-lock.json`.
+4. Execute `npm run lint` and `npm test` to verify the update.
+5. Commit the changes with a clear message referencing the new version.
+
+Repeat these steps whenever updating Next.js.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "genkit": "^1.14.1",
         "idb": "^7.1.1",
         "lucide-react": "^0.475.0",
-        "next": "latest",
+        "next": "15.5.2",
         "next-themes": "^0.3.0",
         "papaparse": "^5.5.3",
         "patch-package": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "genkit": "^1.14.1",
     "idb": "^7.1.1",
     "lucide-react": "^0.475.0",
-    "next": "latest",
+    "next": "15.5.2",
     "next-themes": "^0.3.0",
     "papaparse": "^5.5.3",
     "patch-package": "^8.0.0",


### PR DESCRIPTION
## Summary
- replace `next`'s `latest` tag with explicit `15.5.2`
- lock dependency in `package-lock.json`
- document how maintainers should upgrade Next.js deliberately

## Testing
- ❌ `npm run lint` (fails: A `require()` style import is forbidden, Unexpected any. Specify a different type.)
- ✅ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04e8ce864833183d923f952d68019