### PR TITLE
feat: centralize logging

### DIFF
--- a/src/app/cashflow/page.tsx
+++ b/src/app/cashflow/page.tsx
@@ -17,6 +17,7 @@ import {
   getShiftsInPayPeriod,
   type Shift,
 } from "@/lib/payroll"
+import { logger } from "@/lib/logger"
 
 type ShiftDetails = Omit<Shift, 'date'>;
 
@@ -128,7 +129,7 @@ export default function CashflowPage() {
       })
       setCashflowResult(result)
     } catch (error) {
-      console.error("Error calculating cashflow:", error)
+      logger.error("Error calculating cashflow:", error)
       toast({
         title: "Calculation Failed",
         description: "There was an error calculating your cashflow. Please try again.",

--- a/src/app/debts/page.tsx
+++ b/src/app/debts/page.tsx
@@ -13,6 +13,7 @@ import { useToast } from "@/hooks/use-toast";
 import type { Debt } from "@/lib/types";
 import { deleteDoc } from "firebase/firestore";
 import { debtDoc } from "@/lib/debts";
+import { logger } from "@/lib/logger";
 
 export default function DebtsPage() {
   const [debts, setDebts] = useState<Debt[]>([]);
@@ -37,7 +38,7 @@ export default function DebtsPage() {
       setStrategy(result);
 
     } catch (error) {
-      console.error("Error suggesting debt strategy:", error);
+      logger.error("Error suggesting debt strategy:", error);
       toast({
         title: "Strategy Failed",
         description: "There was an error generating your debt strategy. Please try again.",

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input"
 import { Loader2, Lightbulb, TrendingUp, Sparkles } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from "recharts"
+import { logger } from "@/lib/logger"
 
 export default function InsightsPage() {
   const [userDescription, setUserDescription] = useState("I'm a staff nurse looking to save for a down payment on a house and pay off my student loans within 5 years.")
@@ -30,7 +31,7 @@ export default function InsightsPage() {
         const result = await predictSpending({ transactions: mockTransactions });
         setForecastData(result.forecast);
       } catch (error) {
-        console.error("Error predicting spending:", error);
+        logger.error("Error predicting spending:", error);
       }
     };
     loadForecast();
@@ -67,14 +68,14 @@ export default function InsightsPage() {
 
     try {
       const financialDocuments = await Promise.all(files.map(fileToDataURI));
-      const result = await analyzeSpendingHabits({ 
-          userDescription, 
+      const result = await analyzeSpendingHabits({
+          userDescription,
           financialDocuments,
-          goals 
+          goals
       });
       setAnalysisResult(result);
     } catch (error) {
-      console.error("Error analyzing spending habits:", error);
+      logger.error("Error analyzing spending habits:", error);
       toast({
         title: "Analysis Failed",
         description: "There was an error generating your financial insights. Please try again.",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "firebase/auth"
 import { auth } from "@/lib/firebase"
 import { authErrorMessages, DEFAULT_AUTH_ERROR_MESSAGE } from "@/lib/auth-errors"
+import { logger } from "@/lib/logger"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -42,7 +43,7 @@ export default function LoginPage() {
       const authError = error as AuthError
       const errorMessage = authErrorMessages[authError.code] ?? DEFAULT_AUTH_ERROR_MESSAGE
       if (!authErrorMessages[authError.code]) {
-        console.error(authError.code, authError.message)
+        logger.error(authError.code, authError.message)
       }
       toast({
         title: isLoginView ? "Sign In Failed" : "Sign Up Failed",

--- a/src/app/taxes/page.tsx
+++ b/src/app/taxes/page.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label"
 import { Loader2, Calculator, Percent, FileText } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { logger } from "@/lib/logger"
 
 type FilingStatus = 'single' | 'married_jointly' | 'married_separately' | 'head_of_household';
 
@@ -44,7 +45,7 @@ export default function TaxEstimatorPage() {
       })
       setTaxResult(result)
     } catch (error) {
-      console.error("Error estimating tax:", error)
+      logger.error("Error estimating tax:", error)
       toast({
         title: "Estimation Failed",
         description: "There was an error estimating your taxes. Please try again.",

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -20,6 +20,8 @@ import { parseCsv, downloadCsv } from "@/lib/csv";
 import { validateTransactions, TransactionRowType } from "@/lib/transactions";
 import { addCategory, getCategories } from "@/lib/categories";
 import { Upload, Download, ScanLine, Loader2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { logger } from "@/lib/logger";
 
 export default function TransactionsPage() {
   const [transactions, setTransactions] = useState<Transaction[]>(mockTransactions);
@@ -32,6 +34,7 @@ export default function TransactionsPage() {
   const [filterType, setFilterType] = useState("all");
   const [filterCategory, setFilterCategory] = useState("all");
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { toast } = useToast();
 
   const categories = useMemo(() => {
     // Start with categories stored externally (e.g. in localStorage)
@@ -74,7 +77,12 @@ export default function TransactionsPage() {
       parsed.forEach((t) => addCategory(t.category));
       setTransactions((prev) => [...parsed, ...prev]);
     } catch (err) {
-      console.error(err);
+      logger.error(err);
+      toast({
+        title: "Import Failed",
+        description: "Could not import transactions. Please check the file and try again.",
+        variant: "destructive",
+      });
     } finally {
       e.target.value = "";
     }

--- a/src/app/transactions/scan/page.tsx
+++ b/src/app/transactions/scan/page.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label"
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
 import { Loader2, Camera, Upload, Sparkles, Wand2 } from "lucide-react"
 import Image from "next/image"
+import { logger } from "@/lib/logger"
 
 export default function ScanReceiptPage() {
   const router = useRouter()
@@ -52,7 +53,7 @@ export default function ScanReceiptPage() {
           videoRef.current.srcObject = stream;
         }
       } catch (error) {
-        console.error("Error accessing camera:", error);
+        logger.error("Error accessing camera:", error);
         setHasCameraPermission(false);
         toast({
           variant: "destructive",
@@ -110,7 +111,7 @@ export default function ScanReceiptPage() {
       const result = await analyzeReceipt({ receiptImage: imagePreview });
       setAnalysisResult(result);
     } catch (error) {
-      console.error("Error analyzing receipt:", error);
+      logger.error("Error analyzing receipt:", error);
       toast({ title: "Analysis Failed", description: "Could not analyze the receipt. Please try again.", variant: "destructive" });
     } finally {
       setIsLoading(false);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -28,6 +28,7 @@ import {
 import { NurseFinAILogo } from "@/components/icons"
 import { useToast } from "@/hooks/use-toast"
 import { ThemeToggle } from "@/components/ThemeToggle"
+import { logger } from "@/lib/logger"
 
 export default function AppHeader() {
   const router = useRouter()
@@ -42,7 +43,7 @@ export default function AppHeader() {
         description: "You have been successfully logged out.",
       })
     } catch (error) {
-      console.error("Logout failed:", error)
+      logger.error("Logout failed:", error)
        toast({
         title: "Logout Failed",
         description: "Could not log you out. Please try again.",

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect } from "react"
 import { getQueuedTransactions, clearQueuedTransactions } from "@/lib/offline"
+import { logger } from "@/lib/logger"
 
 export function ServiceWorker() {
   useEffect(() => {
     if ("serviceWorker" in navigator) {
-      navigator.serviceWorker.register("/sw.js").catch(console.error)
+      navigator.serviceWorker.register("/sw.js").catch((err) => logger.error(err))
     }
 
     let debounceId: ReturnType<typeof setTimeout> | null = null
@@ -25,7 +26,7 @@ export function ServiceWorker() {
             })
             await clearQueuedTransactions()
           } catch (error) {
-            console.error("Failed to sync queued transactions", error)
+            logger.error("Failed to sync queued transactions", error)
           }
         }
       }, 1000)

--- a/src/lib/housekeeping.ts
+++ b/src/lib/housekeeping.ts
@@ -1,4 +1,5 @@
 import { getAuth } from "firebase/auth";
+import { logger } from "@/lib/logger";
 
 // Placeholder housekeeping service that cleans up outdated data.
 // Replace with actual implementation as needed.
@@ -6,5 +7,5 @@ export async function runHousekeeping(): Promise<void> {
   // Example: ensure auth SDK is initialized to avoid cold-start costs
   // and perform cleanup tasks such as removing expired sessions.
   getAuth();
-  console.log("Housekeeping job executed");
+  logger.log("Housekeeping job executed");
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,22 @@
+export const logger = {
+  log: (...args: unknown[]) => {
+    if (process.env.NODE_ENV !== "production") {
+      console.log(...args)
+    }
+  },
+  info: (...args: unknown[]) => {
+    if (process.env.NODE_ENV !== "production") {
+      console.info(...args)
+    }
+  },
+  warn: (...args: unknown[]) => {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(...args)
+    }
+  },
+  error: (...args: unknown[]) => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error(...args)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add centralized logger utility
- replace direct console usage with logger or user toast

## Testing
- `npm run lint` *(fails: 'auth-provider.test.tsx' unused vars, 'debt-calendar.test.tsx' unexpected any, 'housekeeping.test.ts' unexpected any, require style imports)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04dfa32ac83319cff9270232cc817