### PR TITLE
feat: purge outdated files from storage buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ The housekeeping service removes outdated files from Cloud Storage to manage cos
 
 ### Running locally
 1. Install dependencies with `npm install`.
-2. Provide the environment variables listed below.
-3. Start the service with `npm run housekeeping` or `node scripts/housekeeping.ts`.
+2. Authenticate with Google Cloud so the service can access your storage
+   bucket, e.g. run `gcloud auth application-default login` or set the
+   `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+3. Provide the environment variables listed below.
+4. Start the service with `npm run housekeeping` or `node scripts/housekeeping.ts`.
 
 ### Scheduled deployment
 - Deploy the service with `firebase deploy --only run.housekeeping`.
@@ -25,6 +28,6 @@ The housekeeping service removes outdated files from Cloud Storage to manage cos
 |----------|-------------|
 | `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase project containing the storage bucket. |
 | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Default Cloud Storage bucket for uploads. |
-| `RETENTION_DAYS` | Number of days to retain files before deletion (default: 30). |
+| `RETENTION_DAYS` | Number of days to retain files before deletion. Must be a non‑negative integer. Defaults to 30. |
 
 Adjust the retention threshold by setting `RETENTION_DAYS` before running the service or updating the scheduled job configuration.

--- a/src/__tests__/runHousekeeping.test.ts
+++ b/src/__tests__/runHousekeeping.test.ts
@@ -1,0 +1,45 @@
+process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'bucket';
+
+const deleteOld = jest.fn().mockResolvedValue(undefined);
+const deleteNew = jest.fn().mockResolvedValue(undefined);
+
+const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+const newDate = new Date().toISOString();
+
+const files = [
+  {
+    getMetadata: jest.fn().mockResolvedValue([{ updated: oldDate }]),
+    delete: deleteOld,
+  },
+  {
+    getMetadata: jest.fn().mockResolvedValue([{ updated: newDate }]),
+    delete: deleteNew,
+  },
+];
+
+const getFiles = jest.fn().mockResolvedValue([files]);
+
+jest.mock('firebase/auth', () => ({ getAuth: jest.fn() }));
+
+jest.mock('@google-cloud/storage', () => ({
+  Storage: jest.fn().mockImplementation(() => ({
+    bucket: jest.fn().mockReturnValue({ getFiles }),
+  })),
+}));
+
+import { runHousekeeping } from '@/lib/housekeeping';
+
+describe('runHousekeeping', () => {
+  beforeEach(() => {
+    delete process.env.RETENTION_DAYS;
+    deleteOld.mockClear();
+    deleteNew.mockClear();
+  });
+
+  test('deletes files older than retention days', async () => {
+    await runHousekeeping();
+    expect(deleteOld).toHaveBeenCalledTimes(1);
+    expect(deleteNew).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/lib/housekeeping.ts
+++ b/src/lib/housekeeping.ts
@@ -1,10 +1,48 @@
 import { getAuth } from "firebase/auth";
+import { Storage } from "@google-cloud/storage";
+import { z } from "zod";
 
-// Placeholder housekeeping service that cleans up outdated data.
-// Replace with actual implementation as needed.
+/**
+ * Lists objects in the configured storage bucket and deletes any that are
+ * older than the retention period. The retention period defaults to 30 days
+ * if the RETENTION_DAYS environment variable is not set. The value is
+ * validated to ensure it is a non‑negative integer.
+ */
 export async function runHousekeeping(): Promise<void> {
-  // Example: ensure auth SDK is initialized to avoid cold-start costs
-  // and perform cleanup tasks such as removing expired sessions.
+  // Ensure Firebase auth is initialized to prevent cold‑start penalties
   getAuth();
-  console.log("Housekeeping job executed");
+
+  const envSchema = z.object({
+    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: z.string().min(1),
+    RETENTION_DAYS: z
+      .string()
+      .optional()
+      .transform((v) => (v ? Number(v) : 30))
+      .refine((v) => Number.isInteger(v) && v >= 0, {
+        message: "RETENTION_DAYS must be a non-negative integer",
+      }),
+  });
+
+  const env = envSchema.parse(process.env);
+  const retentionMs = env.RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const cutoff = Date.now() - retentionMs;
+
+  const storage = new Storage();
+  const bucket = storage.bucket(env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET);
+  const [files] = await bucket.getFiles();
+
+  const deletions: Promise<unknown>[] = [];
+
+  for (const file of files) {
+    const [metadata] = await file.getMetadata();
+    const updated = metadata.updated || metadata.timeCreated;
+    if (updated && new Date(updated).getTime() < cutoff) {
+      deletions.push(file.delete());
+    }
+  }
+
+  await Promise.all(deletions);
+  console.log(
+    `Housekeeping job executed, deleted ${deletions.length} file(s)`
+  );
 }


### PR DESCRIPTION
## Summary
- clean up storage buckets by deleting files older than the RETENTION_DAYS threshold
- validate RETENTION_DAYS env value and use a 30 day default
- document setup for housekeeping service and add unit test for cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04e7fe61c833194981a0145f9b13a