### PR TITLE
Protect housekeeping cron endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ The housekeeping service removes outdated files from Cloud Storage to manage cos
 ### Scheduled deployment
 - Deploy the service with `firebase deploy --only run.housekeeping`.
 - A Cloud Scheduler job triggers the service nightly at 03:00 UTC.
+- Include an `X-CRON-SECRET` header in the job using the `CRON_SECRET` value to authenticate requests.
 - Update the schedule in the Firebase console if a different cadence is required.
+- The endpoint enforces a rate limit and rejects rapid repeated calls with HTTP 429.
 
 ## Environment variables
 
@@ -26,5 +28,6 @@ The housekeeping service removes outdated files from Cloud Storage to manage cos
 | `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase project containing the storage bucket. |
 | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Default Cloud Storage bucket for uploads. |
 | `RETENTION_DAYS` | Number of days to retain files before deletion (default: 30). |
+| `CRON_SECRET` | Shared secret expected in the `X-CRON-SECRET` header for housekeeping runs. |
 
 Adjust the retention threshold by setting `RETENTION_DAYS` before running the service or updating the scheduled job configuration.

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -40,6 +40,10 @@ env:
     availability:
       - BUILD
       - RUNTIME
+  - variable: CRON_SECRET
+    value: ${CRON_SECRET}
+    availability:
+      - RUNTIME
 scheduler:
   jobs:
     - name: housekeeping
@@ -47,3 +51,5 @@ scheduler:
       httpTarget:
         uri: /api/cron/housekeeping
         httpMethod: GET
+        headers:
+          X-CRON-SECRET: ${CRON_SECRET}

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment node
+ */
+import { GET, resetRateLimit } from "@/app/api/cron/housekeeping/route";
+import { runHousekeeping } from "@/lib/housekeeping";
+
+jest.mock("@/lib/housekeeping", () => ({
+  runHousekeeping: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe("/api/cron/housekeeping", () => {
+  const secret = "test-secret";
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = secret;
+    resetRateLimit();
+    (runHousekeeping as jest.Mock).mockClear();
+  });
+
+  it("returns 401 when secret is missing or invalid", async () => {
+    const req1 = new Request("http://localhost");
+    const res1 = await GET(req1);
+    expect(res1.status).toBe(401);
+
+    const req2 = new Request("http://localhost", {
+      headers: { "x-cron-secret": "wrong" },
+    });
+    const res2 = await GET(req2);
+    expect(res2.status).toBe(401);
+    expect(runHousekeeping).not.toHaveBeenCalled();
+  });
+
+  it("runs housekeeping with valid secret and enforces rate limit", async () => {
+    const req = new Request("http://localhost", {
+      headers: { "x-cron-secret": secret },
+    });
+    const res1 = await GET(req);
+    expect(res1.status).toBe(200);
+    expect(runHousekeeping).toHaveBeenCalledTimes(1);
+
+    const res2 = await GET(req);
+    expect(res2.status).toBe(429);
+    expect(runHousekeeping).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -1,8 +1,28 @@
 import { NextResponse } from "next/server";
 import { runHousekeeping } from "@/lib/housekeeping";
 
+const HEADER_NAME = "x-cron-secret";
+const WINDOW_MS = 60_000; // 1 minute
+let lastInvocation = 0;
+
+// Exposed for tests to reset the in-memory rate limiter
+export function resetRateLimit() {
+  lastInvocation = 0;
+}
+
 // HTTP GET endpoint invoked by Cloud Scheduler or cron job
-export async function GET() {
+export async function GET(req: Request) {
+  const secret = req.headers.get(HEADER_NAME);
+  if (!secret || secret !== process.env.CRON_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = Date.now();
+  if (now - lastInvocation < WINDOW_MS) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+  lastInvocation = now;
+
   await runHousekeeping();
   return NextResponse.json({ status: "ok" });
 }


### PR DESCRIPTION
## Summary
- require `X-CRON-SECRET` header and add simple rate limiting to housekeeping endpoint
- document cron authentication header and new `CRON_SECRET` environment variable
- configure scheduler job to send secret header and add tests for auth and rate limit

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any & forbidden require in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b04e8a2e248331b0c89e070d287afa