### PR TITLE
chore: enforce TypeScript type checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
       "dom.iterable",
       "esnext"
     ],
-    "allowJs": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- remove `allowJs` option from tsconfig
- enable library type checking with `skipLibCheck: false`

## Testing
- `npm test`
- `./node_modules/.bin/tsc --noEmit --project tsconfig.json` *(fails: Cannot find module '@genkit-ai/googleai', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b04dfc58c0833187fba45cc026c9d3