### PR TITLE
Add resilient offline queue with size cap and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.5.2",
+        "fake-indexeddb": "^6.1.0",
         "genkit-cli": "^1.14.1",
         "jest": "^30.1.0",
         "jest-environment-jsdom": "^30.1.1",
@@ -11771,6 +11772,16 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.1.0.tgz",
+      "integrity": "sha512-gOzajWIhEug/CQHUIxigKT9Zilh5/I6WvUBez6/UdUtT/YVEHM9r572Os8wfvhp7TkmgBtRNdqSM7YoCXWMzZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/farmhash-modern": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "^8.41.0",
     "@typescript-eslint/parser": "^8.41.0",
+    "fake-indexeddb": "^6.1.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.5.2",

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,6 +2,7 @@ importScripts("https://cdn.jsdelivr.net/npm/idb@7/build/iife/index-min.js")
 
 const DB_NAME = "offline-db"
 const STORE_NAME = "transactions"
+const MAX_RECORDS = 100
 
 const dbPromise = idb.openDB(DB_NAME, 1, {
   upgrade(db) {
@@ -24,7 +25,25 @@ self.addEventListener("fetch", event => {
           const clone = request.clone()
           const body = await clone.json()
           const db = await dbPromise
-          await db.add(STORE_NAME, body)
+          try {
+            await db.add(STORE_NAME, body)
+            const count = await db.count(STORE_NAME)
+            if (count > MAX_RECORDS) {
+              const deleteCount = count - MAX_RECORDS
+              const tx = db.transaction(STORE_NAME, "readwrite")
+              let cursor = await tx.store.openCursor()
+              let removed = 0
+              while (cursor && removed < deleteCount) {
+                await cursor.delete()
+                cursor = await cursor.continue()
+                removed++
+              }
+              await tx.done
+            }
+          } catch (dbErr) {
+            console.error("Failed to store offline transaction", dbErr)
+            return new Response(null, { status: 500 })
+          }
           return new Response(JSON.stringify({ offline: true }), {
             status: 202,
             headers: { "Content-Type": "application/json" },

--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -1,0 +1,64 @@
+jest.mock("idb", () => {
+  const actual = jest.requireActual("idb")
+  return { ...actual, openDB: jest.fn() }
+})
+
+let openDB: jest.Mock
+
+describe("offline db", () => {
+  beforeEach(() => {
+    jest.resetModules()
+    openDB = require("idb").openDB as jest.Mock
+    openDB.mockReset()
+  })
+
+  it("returns error when queueTransaction fails", async () => {
+    openDB.mockResolvedValue({
+      add: jest.fn().mockRejectedValue(new Error("fail")),
+      count: jest.fn(),
+    })
+    const { queueTransaction } = await import("../lib/offline")
+    const result = await queueTransaction({})
+    expect(result.ok).toBe(false)
+  })
+
+  it("returns error when getQueuedTransactions fails", async () => {
+    openDB.mockResolvedValue({
+      getAll: jest.fn().mockRejectedValue(new Error("fail")),
+    })
+    const { getQueuedTransactions } = await import("../lib/offline")
+    const result = await getQueuedTransactions()
+    expect(result.ok).toBe(false)
+  })
+
+  it("returns error when clearQueuedTransactions fails", async () => {
+    openDB.mockResolvedValue({
+      clear: jest.fn().mockRejectedValue(new Error("fail")),
+    })
+    const { clearQueuedTransactions } = await import("../lib/offline")
+    const result = await clearQueuedTransactions()
+    expect(result.ok).toBe(false)
+  })
+
+  it("trims oldest entries when exceeding max records", async () => {
+    openDB.mockImplementation(jest.requireActual("idb").openDB)
+    await import("fake-indexeddb/auto")
+    if (typeof (globalThis as any).structuredClone !== "function") {
+      ;(globalThis as any).structuredClone = (val: unknown) =>
+        JSON.parse(JSON.stringify(val))
+    }
+    const { queueTransaction, getQueuedTransactions } = await import(
+      "../lib/offline"
+    )
+    const max = 100
+    for (let i = 0; i < max + 5; i++) {
+      const res = await queueTransaction(i)
+      expect(res.ok).toBe(true)
+    }
+    const result = await getQueuedTransactions<number>()
+    expect(result.ok).toBe(true)
+    expect(result.value.length).toBe(max)
+    expect(result.value[0]).toBe(5)
+  })
+})
+

--- a/src/lib/offline.ts
+++ b/src/lib/offline.ts
@@ -2,6 +2,9 @@ import { openDB } from "idb"
 
 const DB_NAME = "offline-db"
 const STORE_NAME = "transactions"
+const MAX_RECORDS = 100
+
+export type Result<T> = { ok: true; value: T } | { ok: false; error: unknown }
 
 const dbPromise = openDB(DB_NAME, 1, {
   upgrade(db) {
@@ -9,17 +12,47 @@ const dbPromise = openDB(DB_NAME, 1, {
   },
 })
 
-export async function queueTransaction(tx: unknown) {
-  const db = await dbPromise
-  await db.add(STORE_NAME, tx)
+export async function queueTransaction(tx: unknown): Promise<Result<void>> {
+  try {
+    const db = await dbPromise
+    await db.add(STORE_NAME, tx)
+
+    const count = await db.count(STORE_NAME)
+    if (count > MAX_RECORDS) {
+      const deleteCount = count - MAX_RECORDS
+      const txObj = db.transaction(STORE_NAME, "readwrite")
+      let cursor = await txObj.store.openCursor()
+      let removed = 0
+      while (cursor && removed < deleteCount) {
+        await cursor.delete()
+        cursor = await cursor.continue()
+        removed++
+      }
+      await txObj.done
+    }
+
+    return { ok: true, value: undefined }
+  } catch (error) {
+    return { ok: false, error }
+  }
 }
 
-export async function getQueuedTransactions<T = unknown>() {
-  const db = await dbPromise
-  return db.getAll(STORE_NAME) as Promise<T[]>
+export async function getQueuedTransactions<T = unknown>(): Promise<Result<T[]>> {
+  try {
+    const db = await dbPromise
+    const all = (await db.getAll(STORE_NAME)) as T[]
+    return { ok: true, value: all }
+  } catch (error) {
+    return { ok: false, error }
+  }
 }
 
-export async function clearQueuedTransactions() {
-  const db = await dbPromise
-  await db.clear(STORE_NAME)
+export async function clearQueuedTransactions(): Promise<Result<void>> {
+  try {
+    const db = await dbPromise
+    await db.clear(STORE_NAME)
+    return { ok: true, value: undefined }
+  } catch (error) {
+    return { ok: false, error }
+  }
 }


### PR DESCRIPTION
## Summary
- wrap IndexedDB interactions with Result-based error handling
- enforce a maximum offline queue size and trim oldest entries
- add unit tests for DB failures and queue overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04dc1c7208331a60f53d55558de47