### PR TITLE
feat: add security headers

### DIFF
--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -1,0 +1,17 @@
+# Security Headers
+
+This project defines security headers in `next.config.ts` for all routes. Any additional routes or middleware must continue to apply these headers.
+
+## Required Headers
+
+- **Content-Security-Policy**: `default-src 'self'; script-src 'self' 'nonce-<nonce>' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'`
+- **X-Frame-Options**: `DENY`
+- **X-Content-Type-Options**: `nosniff`
+- **Referrer-Policy**: `strict-origin-when-cross-origin`
+- **Strict-Transport-Security**: `max-age=63072000; includeSubDomains; preload`
+
+### Using the CSP Nonce
+
+The Content-Security-Policy includes a nonce. When adding inline scripts, apply this nonce to the `<script>` tag's `nonce` attribute or replace the inline script with an external file. Middleware that generates HTML should propagate the same nonce in the response headers.
+
+Always verify headers locally when introducing new routes or middleware to ensure functionality remains intact.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,31 @@
 import type { NextConfig } from 'next'
+import crypto from 'crypto'
+
+const cspNonce = crypto.randomBytes(16).toString('base64')
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: [
+      "default-src 'self'",
+      `script-src 'self' 'nonce-${cspNonce}' 'unsafe-inline' 'unsafe-eval'`,
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      "font-src 'self'",
+      "connect-src 'self' https:",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+    ].join('; '),
+  },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+]
 
 const nextConfig: NextConfig = {
   // Enforce type checking and linting during builds
@@ -9,6 +36,15 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'placehold.co', pathname: '/**' },
       { protocol: 'https', hostname: 'picsum.photos', pathname: '/**' },
     ],
+  },
+
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ]
   },
 
   // Allow Firebase Studio / Cloud Workstations preview host to fetch /_next/*


### PR DESCRIPTION
## Summary
- add security headers with CSP, frame and referrer policies
- document required headers for future routes and middleware

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any. Specify a different type.)*
- `npm run build` *(fails: Module not found: Can't resolve '@genkit-ai/googleai')*
- `curl -I http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_68b04e8debe08331aee7bcc1de10f0fb