### PR TITLE
feat: cache FX rates with retry and tests

### DIFF
--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -1,0 +1,49 @@
+import {
+  convertCurrency,
+  setFxCacheTTL,
+  __clearFxCache,
+} from '@/lib/currency';
+
+describe('currency caching', () => {
+  beforeEach(() => {
+    __clearFxCache();
+    setFxCacheTTL(1000);
+    jest.resetAllMocks();
+  });
+
+  it('fetches and caches rate on miss', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rates: { EUR: 2 } }),
+    } as any);
+
+    const result = await convertCurrency(10, 'USD', 'EUR');
+    expect(result).toBe(20);
+    expect((global as any).fetch).toHaveBeenCalledTimes(1);
+
+    await convertCurrency(10, 'USD', 'EUR');
+    expect((global as any).fetch).toHaveBeenCalledTimes(1); // cache hit
+  });
+
+  it('uses stale cache when API fails', async () => {
+    setFxCacheTTL(0); // immediately expire
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rates: { EUR: 2 } }),
+    } as any);
+
+    await convertCurrency(10, 'USD', 'EUR'); // prime cache
+
+    ((global as any).fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    const result = await convertCurrency(10, 'USD', 'EUR');
+    expect(result).toBe(20);
+  });
+
+  it('throws when API fails and no cache', async () => {
+    (global as any).fetch = jest.fn().mockRejectedValue(new Error('down'));
+    await expect(convertCurrency(10, 'USD', 'EUR')).rejects.toThrow(
+      'Failed to fetch FX rate',
+    );
+  });
+});
+

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,22 +1,89 @@
-export async function getFxRate(from: string, to: string): Promise<number> {
-  if (from === to) return 1;
-  const res = await fetch(`https://api.exchangerate.host/latest?base=${from}&symbols=${to}`);
-  if (!res.ok) {
-    throw new Error('Failed to fetch FX rates');
-  }
-  const data = await res.json();
-  const rate = data?.rates?.[to];
-  if (typeof rate !== 'number') {
-    throw new Error('Invalid FX rate data');
-  }
-  return rate;
+type CacheEntry = { rate: number; expiry: number };
+
+const fxCache = new Map<string, CacheEntry>();
+
+let CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export function setFxCacheTTL(ttlMs: number) {
+  CACHE_TTL_MS = ttlMs;
 }
 
-export async function convertCurrency(amount: number, from: string, to: string): Promise<number> {
-  const rate = await getFxRate(from, to);
+export function __clearFxCache() {
+  fxCache.clear();
+}
+
+function cacheKey(from: string, to: string): string {
+  return `${from}-${to}`;
+}
+
+function getCachedRate(from: string, to: string): number | undefined {
+  const entry = fxCache.get(cacheKey(from, to));
+  if (entry && entry.expiry > Date.now()) {
+    return entry.rate;
+  }
+}
+
+async function fetchWithRetry(url: string, retries = 3): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`Request failed with status ${res.status}`);
+      }
+      return res;
+    } catch (err) {
+      lastError = err;
+      if (attempt === retries) break;
+    }
+  }
+  throw lastError;
+}
+
+export async function getFxRate(from: string, to: string, retries = 3): Promise<number> {
+  if (from === to) return 1;
+  const key = cacheKey(from, to);
+  try {
+    const res = await fetchWithRetry(
+      `https://api.exchangerate.host/latest?base=${from}&symbols=${to}`,
+      retries,
+    );
+    const data = await res.json();
+    const rate = data?.rates?.[to];
+    if (typeof rate !== 'number') {
+      throw new Error('Invalid FX rate data');
+    }
+    fxCache.set(key, { rate, expiry: Date.now() + CACHE_TTL_MS });
+    return rate;
+  } catch (err: any) {
+    const cached = fxCache.get(key);
+    if (cached) {
+      console.warn(
+        `Using cached FX rate for ${key} due to error: ${err?.message || err}`,
+      );
+      return cached.rate;
+    }
+    throw new Error(
+      `Failed to fetch FX rate for ${from} -> ${to}: ${err?.message || err}`,
+    );
+  }
+}
+
+export async function convertCurrency(
+  amount: number,
+  from: string,
+  to: string,
+): Promise<number> {
+  if (from === to) return amount;
+  const cached = getCachedRate(from, to);
+  const rate = typeof cached === 'number' ? cached : await getFxRate(from, to);
   return amount * rate;
 }
 
-export function formatCurrency(amount: number, currency: string, locale = 'en-US'): string {
+export function formatCurrency(
+  amount: number,
+  currency: string,
+  locale = 'en-US',
+): string {
   return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount);
 }


### PR DESCRIPTION
## Summary
- add in-memory FX rate cache with configurable TTL
- add retry and fallback logic around FX API requests
- test currency conversion cache hits, misses and API failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04f00b01c83319a336d57ef12bac3