### PR TITLE
Implement exponential backoff for offline sync

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -1,0 +1,85 @@
+import { act, render } from "@testing-library/react"
+import { ServiceWorker } from "@/components/service-worker"
+
+jest.mock("@/lib/offline", () => ({
+  getQueuedTransactions: jest.fn(),
+  clearQueuedTransactions: jest.fn(),
+}))
+
+const toastMock = jest.fn()
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}))
+
+describe("ServiceWorker", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    ;(toastMock as jest.Mock).mockClear()
+    ;(global.fetch as unknown) = jest.fn()
+    Object.defineProperty(navigator, "onLine", {
+      value: false,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.resetAllMocks()
+  })
+
+  it("syncs queued transactions and notifies on success", async () => {
+    const { getQueuedTransactions, clearQueuedTransactions } = require("@/lib/offline")
+    ;(getQueuedTransactions as jest.Mock).mockResolvedValue([{ id: 1 }])
+    ;(clearQueuedTransactions as jest.Mock).mockResolvedValue(undefined)
+    ;(global.fetch as jest.Mock).mockResolvedValue({ ok: true })
+
+    render(<ServiceWorker />)
+
+    Object.defineProperty(navigator, "onLine", { value: true })
+    window.dispatchEvent(new Event("online"))
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000)
+    })
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(clearQueuedTransactions).toHaveBeenCalled()
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Transactions synced" })
+    )
+  })
+
+  it("retries with exponential backoff and notifies on failure", async () => {
+    const { getQueuedTransactions, clearQueuedTransactions } = require("@/lib/offline")
+    ;(getQueuedTransactions as jest.Mock).mockResolvedValue([{ id: 1 }])
+    ;(clearQueuedTransactions as jest.Mock).mockResolvedValue(undefined)
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: false, text: async () => "err" })
+      .mockResolvedValueOnce({ ok: true })
+
+    render(<ServiceWorker />)
+
+    Object.defineProperty(navigator, "onLine", { value: true })
+    window.dispatchEvent(new Event("online"))
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000)
+    })
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Sync failed" })
+    )
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000)
+    })
+
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+    expect(clearQueuedTransactions).toHaveBeenCalled()
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Transactions synced" })
+    )
+  })
+})
+

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -2,36 +2,48 @@
 
 import { useEffect, useRef } from "react"
 import { getQueuedTransactions, clearQueuedTransactions } from "@/lib/offline"
+import { useToast } from "@/hooks/use-toast"
 
 export function ServiceWorker() {
   const debounceId = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { toast } = useToast()
 
   useEffect(() => {
     const handleOnline = () => {
       if (debounceId.current) clearTimeout(debounceId.current)
 
-      debounceId.current = setTimeout(async () => {
+      let attempt = 0
+
+      const sync = async () => {
         const queued = await getQueuedTransactions()
-        if (queued.length) {
-          try {
-            const response = await fetch("/api/transactions/sync", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ transactions: queued }),
-            })
-            if (!response.ok) {
-              console.error(
-                "Failed to sync queued transactions",
-                await response.text()
-              )
-              return
-            }
-            await clearQueuedTransactions()
-          } catch (error) {
-            console.error("Failed to sync queued transactions", error)
+        if (!queued.length) return
+        try {
+          const response = await fetch("/api/transactions/sync", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ transactions: queued }),
+          })
+          if (!response.ok) {
+            throw new Error(await response.text())
           }
+          await clearQueuedTransactions()
+          toast({
+            title: "Transactions synced",
+            description: "Queued transactions have been synced.",
+          })
+        } catch (error) {
+          toast({
+            title: "Sync failed",
+            description: "Failed to sync queued transactions.",
+            variant: "destructive",
+          })
+          attempt += 1
+          const delay = Math.min(1000 * 2 ** attempt, 30000)
+          debounceId.current = setTimeout(sync, delay)
         }
-      }, 1000)
+      }
+
+      debounceId.current = setTimeout(sync, 1000)
     }
 
     const registerAndListen = async () => {


### PR DESCRIPTION
## Summary
- retry queued transaction sync with exponential backoff
- notify users of sync success or failure via toasts
- add tests covering success and retry paths

## Testing
- `npm test src/__tests__/service-worker.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b04f017308833184a6ee63f53d3634