### PR TITLE
Respawn workers on exit and retry task

### DIFF
--- a/src/__tests__/crash-worker.js
+++ b/src/__tests__/crash-worker.js
@@ -1,0 +1,13 @@
+const { parentPort } = require("node:worker_threads");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const flag = path.join(__dirname, "crash-flag");
+
+parentPort.on("message", numbers => {
+  if (fs.existsSync(flag)) {
+    fs.unlinkSync(flag);
+    process.exit(1);
+  }
+  parentPort.postMessage(numbers.map(n => n * n));
+});

--- a/src/__tests__/parallel.test.ts
+++ b/src/__tests__/parallel.test.ts
@@ -1,4 +1,7 @@
 import { parallelSquare } from "../lib/parallel"
+import { WorkerPool } from "../lib/worker-pool"
+import path from "node:path"
+import fs from "node:fs"
 
 describe("parallelSquare", () => {
   it("computes squares in parallel", async () => {
@@ -14,5 +17,16 @@ describe("parallelSquare", () => {
   it("handles empty input", async () => {
     const result = await parallelSquare([])
     expect(result).toEqual([])
+  })
+
+  it("recovers from worker failure", async () => {
+    const file = path.join(__dirname, "crash-worker.js")
+    const flag = path.join(__dirname, "crash-flag")
+    fs.writeFileSync(flag, "")
+
+    const pool = new WorkerPool<number[], number[]>(file, 1)
+    const result = await pool.run([1, 2])
+    expect(result.sort((a, b) => a - b)).toEqual([1, 4])
+    await pool.destroy()
   })
 })


### PR DESCRIPTION
## Summary
- Replace crashed workers with fresh instances and retry their tasks
- Clean up worker listeners after each task to avoid leaks
- Add test simulating worker crash to verify pool recovery

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04f02a980833187e7f3a60a02a602