### PR TITLE
Export mobile breakpoint and add mobile hook test

### DIFF
--- a/src/__tests__/use-mobile.test.tsx
+++ b/src/__tests__/use-mobile.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { useIsMobile, MOBILE_BREAKPOINT } from "../hooks/use-mobile";
+
+describe("useIsMobile", () => {
+  let listeners: Array<() => void>;
+
+  beforeEach(() => {
+    listeners = [];
+    window.innerWidth = MOBILE_BREAKPOINT + 100;
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: window.innerWidth < MOBILE_BREAKPOINT,
+      media: "",
+      addEventListener: (_event: string, cb: () => void) => {
+        listeners.push(cb);
+      },
+      removeEventListener: (_event: string, cb: () => void) => {
+        listeners = listeners.filter((l) => l !== cb);
+      },
+    }));
+  });
+
+  function triggerChange() {
+    listeners.forEach((cb) => cb());
+  }
+
+  it("returns false initially and updates on resize", () => {
+    function TestComponent() {
+      const mobile = useIsMobile();
+      return <span>{mobile ? "mobile" : "desktop"}</span>;
+    }
+
+    render(<TestComponent />);
+    expect(screen.getByText("desktop")).toBeInTheDocument();
+
+    act(() => {
+      window.innerWidth = MOBILE_BREAKPOINT - 50;
+      triggerChange();
+    });
+
+    expect(screen.getByText("mobile")).toBeInTheDocument();
+  });
+});

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,11 +1,15 @@
 import * as React from "react"
 
-const MOBILE_BREAKPOINT = 768
+/**
+ * Screen width (in pixels) below which layout is considered mobile.
+ * Exported for reuse to ensure consistent breakpoint behavior.
+ */
+export const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState(false)
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
@@ -15,5 +19,5 @@ export function useIsMobile() {
     return () => mql.removeEventListener("change", onChange)
   }, [])
 
-  return !!isMobile
+  return isMobile
 }


### PR DESCRIPTION
## Summary
- export `MOBILE_BREAKPOINT` with JSDoc
- update `useIsMobile` to use deterministic state and `useLayoutEffect`
- add unit test verifying initial and resize behavior

## Testing
- `npm test src/__tests__/use-mobile.test.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04f05084c83318eb5378e283784da