### PR TITLE
Ensure worker pool destroyed on errors

### DIFF
--- a/src/lib/parallel.ts
+++ b/src/lib/parallel.ts
@@ -14,13 +14,17 @@ export async function parallelSquare(
     numbers.slice(i * chunkSize, (i + 1) * chunkSize)
   )
 
-  const pool = new WorkerPool<number[], number[]>(
-    path.join(__dirname, "mapWorker.js"),
-    actualThreads
-  )
+  let pool: WorkerPool<number[], number[]> | undefined
+  try {
+    pool = new WorkerPool<number[], number[]>(
+      path.join(__dirname, "mapWorker.js"),
+      actualThreads
+    )
 
-  const promises = chunks.map(chunk => pool.run(chunk))
-  const results = await Promise.all(promises)
-  await pool.destroy()
-  return results.flat()
+    const promises = chunks.map(chunk => pool.run(chunk))
+    const results = await Promise.all(promises)
+    return results.flat()
+  } finally {
+    await pool?.destroy()
+  }
 }


### PR DESCRIPTION
## Summary
- ensure WorkerPool is always destroyed in parallelSquare by wrapping in try/finally

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-require-imports in several test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b04f79b894833182448ceca620b25e