### PR TITLE
refactor: fetch backup collections in parallel

### DIFF
--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -81,9 +81,11 @@ export async function backupData(): Promise<{
   debts: Debt[];
   goals: Goal[];
 }> {
-  const transactionsSnap = await getDocs(collection(db, "transactions"));
-  const debtsSnap = await getDocs(collection(db, "debts"));
-  const goalsSnap = await getDocs(collection(db, "goals"));
+  const [transactionsSnap, debtsSnap, goalsSnap] = await Promise.all([
+    getDocs(collection(db, "transactions")),
+    getDocs(collection(db, "debts")),
+    getDocs(collection(db, "goals")),
+  ]);
 
   const data = {
     transactions: transactionsSnap.docs.map((d) => d.data() as Transaction),


### PR DESCRIPTION
## Summary
- speed up backups by fetching transactions, debts, and goals in parallel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04f7c55b083318d4a11d009cd204f