### PR TITLE
Handle zero weekly hours in payroll calculation

### DIFF
--- a/src/lib/payroll.ts
+++ b/src/lib/payroll.ts
@@ -109,6 +109,10 @@ export const calculatePayPeriodSummary = (
     totalRegularHours += regularHours;
     totalOvertimeHours += overtimeHours;
 
+    if (weeklyHours === 0) {
+      return weeklyPremiumPay;
+    }
+
     const avgRate = weekShifts.reduce((acc, s) => acc + s.rate * s.hours, 0) / weeklyHours;
     const regularPay = regularHours * avgRate;
     const overtimePay = overtimeHours * avgRate * 1.5;


### PR DESCRIPTION
## Summary
- Avoid divide-by-zero in calculateWeekPay by returning early when weekly hours total to 0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04f7d1d7483318cf8a839439c182f