### PR TITLE
Ensure categories are stored trimmed

### DIFF
--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -43,9 +43,10 @@ export function getCategories(): string[] {
   const categories = load();
   const map = new Map<string, string>();
   for (const cat of categories) {
-    const key = normalize(cat);
+    const trimmed = cat.trim();
+    const key = normalize(trimmed);
     if (!map.has(key)) {
-      map.set(key, cat);
+      map.set(key, trimmed);
     }
   }
   const unique = Array.from(map.values());
@@ -60,10 +61,11 @@ export function getCategories(): string[] {
  */
 export function addCategory(category: string): string[] {
   const categories = getCategories();
-  const key = normalize(category);
+  const trimmed = category.trim();
+  const key = normalize(trimmed);
   const exists = categories.some((c) => normalize(c) === key);
   if (!exists) {
-    categories.push(category);
+    categories.push(trimmed);
     save(categories);
   }
   return categories;


### PR DESCRIPTION
## Summary
- Trim category strings when loading and saving to avoid stray whitespace
- Normalize added categories by trimming before saving

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04f7f570483319972bbfe72ee9aec