### PR TITLE
feat: add jittered retry options

### DIFF
--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -166,7 +166,7 @@ describe('runWithRetry', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {});
 
-    const promise = runWithRetry(op, 2, 1000);
+    const promise = runWithRetry(op, { retries: 2, baseDelayMs: 1000, jitterPct: 0 });
 
     // allow first rejection to be processed
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- add configurable retry options with jittered exponential backoff
- default to more retry attempts and document params
- adjust tests for new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04fc672a48331afe0adbc232621b4