### PR TITLE
Use Firestore batches for housekeeping operations

### DIFF
--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -44,6 +44,20 @@ jest.mock('firebase/firestore', () => ({
     dataStore[colRef.name].set(id, data);
     return { id };
   }),
+  writeBatch: (_db: any) => {
+    const ops: (() => void)[] = [];
+    return {
+      set: (docRef: any, data: any) => {
+        ops.push(() => dataStore[docRef.name].set(docRef.id, data));
+      },
+      delete: (docRef: any) => {
+        ops.push(() => dataStore[docRef.name].delete(docRef.id));
+      },
+      commit: jest.fn(async () => {
+        ops.forEach((op) => op());
+      }),
+    };
+  },
   __dataStore: dataStore,
 }));
 


### PR DESCRIPTION
## Summary
- batch transaction archiving and debt cleanup with Firestore write batches
- log affected document IDs on commit failures
- extend Firestore mocks for writeBatch in housekeeping tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04fc715748331a92e541142e4815d