### PR TITLE
Add offline persistence fallback

### DIFF
--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -1,0 +1,30 @@
+jest.mock('idb', () => ({
+  openDB: jest.fn(),
+}));
+
+describe('offline fallback', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('uses in-memory store when persistence fails', async () => {
+    const { openDB } = await import('idb');
+    (openDB as jest.Mock).mockRejectedValue(new Error('fail'));
+
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const offline = await import('../lib/offline');
+    const tx = { foo: 'bar' };
+
+    await offline.queueTransaction(tx);
+    expect(offline.isPersistenceAvailable()).toBe(false);
+    await expect(offline.getQueuedTransactions()).resolves.toEqual([tx]);
+
+    await offline.clearQueuedTransactions();
+    await expect(offline.getQueuedTransactions()).resolves.toEqual([]);
+
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+

--- a/src/lib/offline.ts
+++ b/src/lib/offline.ts
@@ -3,23 +3,61 @@ import { openDB } from "idb"
 const DB_NAME = "offline-db"
 const STORE_NAME = "transactions"
 
-const dbPromise = openDB(DB_NAME, 1, {
-  upgrade(db) {
-    db.createObjectStore(STORE_NAME, { autoIncrement: true })
-  },
-})
+let memoryQueue: unknown[] = []
+let persistenceAvailable = true
+
+const dbPromise = (async () => {
+  try {
+    return await openDB(DB_NAME, 1, {
+      upgrade(db) {
+        db.createObjectStore(STORE_NAME, { autoIncrement: true })
+      },
+    })
+  } catch (err) {
+    console.warn("IndexedDB unavailable, falling back to in-memory store", err)
+    persistenceAvailable = false
+    return undefined
+  }
+})()
 
 export async function queueTransaction(tx: unknown) {
-  const db = await dbPromise
-  await db.add(STORE_NAME, tx)
+  try {
+    const db = await dbPromise
+    if (!db) throw new Error("no db")
+    await db.add(STORE_NAME, tx)
+  } catch (err) {
+    console.warn("Failed to queue transaction; using in-memory store", err)
+    memoryQueue.push(tx)
+    persistenceAvailable = false
+  }
 }
 
 export async function getQueuedTransactions<T = unknown>() {
-  const db = await dbPromise
-  return db.getAll(STORE_NAME) as Promise<T[]>
+  try {
+    const db = await dbPromise
+    if (!db) throw new Error("no db")
+    return (await db.getAll(STORE_NAME)) as T[]
+  } catch (err) {
+    console.warn("Failed to get queued transactions; using in-memory store", err)
+    return memoryQueue as T[]
+  }
 }
 
 export async function clearQueuedTransactions() {
-  const db = await dbPromise
-  await db.clear(STORE_NAME)
+  try {
+    const db = await dbPromise
+    if (!db) throw new Error("no db")
+    await db.clear(STORE_NAME)
+    memoryQueue = []
+  } catch (err) {
+    console.warn(
+      "Failed to clear queued transactions; clearing in-memory store",
+      err,
+    )
+    memoryQueue = []
+  }
+}
+
+export function isPersistenceAvailable() {
+  return persistenceAvailable
 }


### PR DESCRIPTION
## Summary
- wrap IndexedDB open and operations in try/catch with in-memory queue fallback
- expose `isPersistenceAvailable` helper
- test fallback behavior when persistence fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04fc891708331af23fd45ffe8d343