### PR TITLE
feat: list uploaded files on insights page

### DIFF
--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -115,8 +115,18 @@ export default function InsightsPage() {
                 id="financial-documents"
                 type="file"
                 multiple
+                accept=".pdf,.jpg,.png"
                 onChange={handleFileChange}
               />
+              {files.length > 0 && (
+                <ul className="list-disc pl-5 text-sm">
+                  {files.map((file) => (
+                    <li key={file.name}>
+                      {file.name} ({(file.size / 1024).toFixed(1)} KB)
+                    </li>
+                  ))}
+                </ul>
+              )}
               <p className="text-sm text-muted-foreground">Upload documents like pay stubs or bank statements.</p>
             </div>
             <Button type="submit" disabled={isLoading} size="lg">


### PR DESCRIPTION
## Summary
- show selected file names and sizes on Insights file uploader
- restrict uploads to pdf and image formats

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / require import errors in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b04fe8512c83319b3ad628aa499d81