### PR TITLE
test: add offline and worker pool failure tests

### DIFF
--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -1,0 +1,34 @@
+jest.mock("idb", () => {
+  const store: unknown[] = []
+  return {
+    openDB: jest.fn(async () => ({
+      add: async (_store: string, value: unknown) => {
+        store.push(value)
+      },
+      getAll: async () => [...store],
+      clear: async () => {
+        store.length = 0
+      },
+    })),
+  }
+})
+
+import {
+  queueTransaction,
+  getQueuedTransactions,
+  clearQueuedTransactions,
+} from "../lib/offline"
+
+describe("offline fallbacks", () => {
+  it("uses in-memory store when IndexedDB fails", async () => {
+    await queueTransaction({ id: 1 })
+    await queueTransaction({ id: 2 })
+
+    const queued = await getQueuedTransactions<{ id: number }>()
+    expect(queued).toEqual([{ id: 1 }, { id: 2 }])
+
+    await clearQueuedTransactions()
+    const empty = await getQueuedTransactions()
+    expect(empty).toEqual([])
+  })
+})

--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("node:worker_threads", () => {
+  const { EventEmitter } = require("events")
+  return {
+    Worker: class MockWorker extends EventEmitter {
+      postMessage(data: unknown) {
+        if (data === "crash") {
+          this.emit("error", new Error("boom"))
+        } else {
+          this.emit("message", (data as number) * 2)
+        }
+      }
+      terminate() {
+        return Promise.resolve()
+      }
+    },
+  }
+})
+
+import { WorkerPool } from "../lib/worker-pool"
+
+describe("WorkerPool", () => {
+  it("continues processing after a worker crash", async () => {
+    const pool = new WorkerPool<number | string, number>("fake", 1)
+
+    const fail = pool.run("crash" as any)
+    const success = pool.run(5)
+
+    await expect(fail).rejects.toThrow("boom")
+    await expect(success).resolves.toBe(10)
+
+    await pool.destroy()
+  })
+})


### PR DESCRIPTION
## Summary
- test offline queue functions with mocked IndexedDB fallback
- test worker pool handling of worker crashes and continued processing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04fca9e288331a0d45e783cb05af7