### PR TITLE
feat: improve layout boundaries

### DIFF
--- a/src/components/layout/boundaries.tsx
+++ b/src/components/layout/boundaries.tsx
@@ -1,6 +1,11 @@
-'use client';
+"use client";
 
-import React, { PropsWithChildren, Suspense } from 'react';
+import React, { PropsWithChildren, Suspense } from "react";
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -18,7 +23,26 @@ class RootErrorBoundary extends React.Component<PropsWithChildren, ErrorBoundary
 
   render() {
     if (this.state.hasError) {
-      return <p>Something went wrong.</p>;
+      return (
+        <Alert
+          variant="destructive"
+          className="flex flex-col items-start gap-4 p-6"
+        >
+          <div>
+            <AlertTitle>Something went wrong</AlertTitle>
+            <AlertDescription>
+              An unexpected error occurred. Try reloading the page or go back
+              to the dashboard.
+            </AlertDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button onClick={() => window.location.reload()}>Retry</Button>
+            <Button asChild variant="outline">
+              <Link href="/">Go Home</Link>
+            </Button>
+          </div>
+        </Alert>
+      );
     }
     return this.props.children;
   }
@@ -29,5 +53,15 @@ export function ErrorBoundary({ children }: PropsWithChildren) {
 }
 
 export function SuspenseBoundary({ children }: PropsWithChildren) {
-  return <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full w-full items-center justify-center p-4">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      {children}
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- replace plain error and loading fallbacks with UI components
- add retry and navigation options to error boundary
- show spinner while suspense content loads

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / no-require-imports in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b05544d448833198a5016f19cb0472