### PR TITLE
Add aria labels to search inputs

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -119,6 +119,7 @@ export default function AppHeader() {
         <Input
           type="search"
           placeholder="Search..."
+          aria-label="Search"
           className="w-full rounded-lg bg-secondary pl-8 md:w-[200px] lg:w-[336px] dark:bg-secondary"
         />
       </div>

--- a/src/components/transactions/transactions-filter.tsx
+++ b/src/components/transactions/transactions-filter.tsx
@@ -30,6 +30,7 @@ export function TransactionsFilter({
             <Input
             type="search"
             placeholder="Search by description..."
+            aria-label="Search transactions"
             className="pl-8"
             value={searchTerm}
             onChange={(e) => onSearchChange(e.target.value)}


### PR DESCRIPTION
## Summary
- provide `aria-label="Search"` for header search field
- add `aria-label="Search transactions"` in `TransactionsFilter`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b05544f1ac83318c84f059a166331e