### PR TITLE
Improve auth form accessibility and behavior

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,6 +96,7 @@ export default function LoginPage() {
                   <Input
                     id="email"
                     type="email"
+                    autoComplete="email"
                     placeholder="nurse@hospital.com"
                     required
                     value={email}
@@ -107,6 +108,7 @@ export default function LoginPage() {
                   <Input
                     id="password"
                     type="password"
+                    autoComplete="current-password"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
@@ -127,7 +129,11 @@ export default function LoginPage() {
               </form>
               <div className="mt-6 text-center text-sm">
                 {isLoginView ? "Don't have an account?" : "Already have an account?"}{" "}
-                <button onClick={() => setIsLoginView(!isLoginView)} className="underline font-semibold text-primary">
+                <button
+                  type="button"
+                  onClick={() => setIsLoginView(!isLoginView)}
+                  className="underline font-semibold text-primary"
+                >
                   {isLoginView ? "Sign up" : "Sign in"}
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- add explicit autocomplete attributes for email and password fields on the login page
- set toggle button type to avoid accidental form submission

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, require import errors in existing tests and services)*

------
https://chatgpt.com/codex/tasks/task_e_68b055458cc483319ba6ea0362582acf