### PR TITLE
Guard useIsMobile for server rendering

### DIFF
--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -6,16 +6,26 @@ import * as React from "react"
  */
 export const MOBILE_BREAKPOINT = 768
 
+/**
+ * React hook that reports whether the viewport width is below `MOBILE_BREAKPOINT`.
+ *
+ * During server-side rendering the hook always returns `false` since `window`
+ * is not available. On the client it checks the viewport on mount and listens
+ * for subsequent resizes.
+ */
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState(false)
 
   React.useLayoutEffect(() => {
+    if (typeof window === "undefined") return
+
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
+      if (typeof window === "undefined") return
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    onChange()
     return () => mql.removeEventListener("change", onChange)
   }, [])
 


### PR DESCRIPTION
## Summary
- Guard `useIsMobile` against missing `window`
- Document server vs client behavior and ensure mobile state initializes false

## Testing
- `npm test src/__tests__/use-mobile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0554c74408331a3587be6ed86dba9