### PR TITLE
test: add flow success and validation tests

### DIFF
--- a/src/ai/flows/__tests__/calculate-cashflow.test.ts
+++ b/src/ai/flows/__tests__/calculate-cashflow.test.ts
@@ -1,0 +1,52 @@
+function setupMocks(mockOutput: any) {
+  const definePromptMock = jest.fn().mockImplementation(({ input, output }) => {
+    return async (inputData: any) => {
+      input.schema.parse(inputData);
+      const parsed = output.schema.parse(mockOutput);
+      return { output: parsed };
+    };
+  });
+  const defineFlowMock = jest.fn((_config: any, handler: any) => handler);
+  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+}
+
+describe('calculateCashflowFlow', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('resolves with expected data', async () => {
+    const mockOutput = {
+      grossMonthlyIncome: 5000,
+      netMonthlyIncome: 3500,
+      analysis: 'You have a healthy surplus.',
+    };
+    setupMocks(mockOutput);
+    const { calculateCashflow } = await import('@/ai/flows/calculate-cashflow');
+    await expect(
+      calculateCashflow({
+        annualIncome: 60000,
+        estimatedAnnualTaxes: 12000,
+        totalMonthlyDeductions: 1500,
+      })
+    ).resolves.toEqual(mockOutput);
+  });
+
+  it('throws a validation error for mismatched fields', async () => {
+    const invalidOutput = {
+      grossMonthlyIncome: '5000', // should be number
+      netMonthlyIncome: 3500,
+      analysis: 'Invalid data',
+    } as any;
+    setupMocks(invalidOutput);
+    const { calculateCashflow } = await import('@/ai/flows/calculate-cashflow');
+    await expect(
+      calculateCashflow({
+        annualIncome: 60000,
+        estimatedAnnualTaxes: 12000,
+        totalMonthlyDeductions: 1500,
+      })
+    ).rejects.toThrow();
+  });
+});
+

--- a/src/ai/flows/__tests__/suggest-debt-strategy.test.ts
+++ b/src/ai/flows/__tests__/suggest-debt-strategy.test.ts
@@ -1,0 +1,57 @@
+function setupMocks(mockOutput: any) {
+  const definePromptMock = jest.fn().mockImplementation(({ input, output }) => {
+    return async (inputData: any) => {
+      input.schema.parse(inputData);
+      const parsed = output.schema.parse(mockOutput);
+      return { output: parsed };
+    };
+  });
+  const defineFlowMock = jest.fn((_config: any, handler: any) => handler);
+  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+}
+
+describe('suggestDebtStrategyFlow', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  const sampleInput = {
+    debts: [
+      {
+        id: '1',
+        name: 'Loan A',
+        initialAmount: 1000,
+        currentAmount: 900,
+        interestRate: 5,
+        minimumPayment: 50,
+        dueDate: '2023-12-01',
+        recurrence: 'monthly',
+      },
+    ],
+  } as const;
+
+  it('resolves with expected data', async () => {
+    const mockOutput = {
+      recommendedStrategy: 'avalanche',
+      strategyReasoning: 'Highest interest first saves more money.',
+      payoffOrder: [{ debtName: 'Loan A', priority: 1 }],
+      summary: 'You can do it!',
+    };
+    setupMocks(mockOutput);
+    const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
+    await expect(suggestDebtStrategy(sampleInput)).resolves.toEqual(mockOutput);
+  });
+
+  it('throws a validation error for mismatched fields', async () => {
+    const invalidOutput = {
+      recommendedStrategy: 'avalanche',
+      strategyReasoning: 'Highest interest first saves more money.',
+      payoffOrder: [{ debtName: 'Loan A', priority: '1' }], // priority should be number
+      summary: 'You can do it!',
+    } as any;
+    setupMocks(invalidOutput);
+    const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
+    await expect(suggestDebtStrategy(sampleInput)).rejects.toThrow();
+  });
+});
+

--- a/src/ai/flows/__tests__/tax-estimation.test.ts
+++ b/src/ai/flows/__tests__/tax-estimation.test.ts
@@ -1,0 +1,47 @@
+function setupMocks(mockOutput: any) {
+  const definePromptMock = jest.fn().mockImplementation(({ input, output }) => {
+    return async (inputData: any) => {
+      input.schema.parse(inputData);
+      const parsed = output.schema.parse(mockOutput);
+      return { output: parsed };
+    };
+  });
+  const defineFlowMock = jest.fn((_config: any, handler: any) => handler);
+  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+}
+
+describe('taxEstimationFlow', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  const sampleInput = {
+    income: 50000,
+    deductions: 10000,
+    location: 'NY',
+    filingStatus: 'single',
+  } as const;
+
+  it('resolves with expected data', async () => {
+    const mockOutput = {
+      estimatedTax: 8000,
+      taxRate: 0.16,
+      breakdown: 'Detailed breakdown.',
+    };
+    setupMocks(mockOutput);
+    const { estimateTax } = await import('@/ai/flows/tax-estimation');
+    await expect(estimateTax(sampleInput)).resolves.toEqual(mockOutput);
+  });
+
+  it('throws a validation error for mismatched fields', async () => {
+    const invalidOutput = {
+      estimatedTax: '8000', // should be number
+      taxRate: 0.16,
+      breakdown: 'Detailed breakdown.',
+    } as any;
+    setupMocks(invalidOutput);
+    const { estimateTax } = await import('@/ai/flows/tax-estimation');
+    await expect(estimateTax(sampleInput)).rejects.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests validating calculateCashflow flow handles valid and invalid outputs
- add tests validating suggestDebtStrategy flow with schema enforcement
- add tests validating taxEstimation flow and mismatched field detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0554de80c8331b3d6ce19847321d0