### PR TITLE
Add autocomplete hints and aria-live for auth form

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,6 +48,8 @@ export default function LoginPage() {
         title: isLoginView ? "Sign In Failed" : "Sign Up Failed",
         description: errorMessage,
         variant: "destructive",
+        role: "alert",
+        "aria-live": "assertive",
       })
     } finally {
       setIsLoading(false)
@@ -98,6 +100,7 @@ export default function LoginPage() {
                     type="email"
                     placeholder="nurse@hospital.com"
                     required
+                    autoComplete="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                   />
@@ -108,6 +111,7 @@ export default function LoginPage() {
                     id="password"
                     type="password"
                     required
+                    autoComplete={isLoginView ? "current-password" : "new-password"}
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                   />


### PR DESCRIPTION
## Summary
- add autoComplete attributes for email and password fields on auth page
- add aria-live assertive role alert to error toast for screen reader feedback

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, A `require()` style import is forbidden, Unexpected constant condition)*

------
https://chatgpt.com/codex/tasks/task_e_68b0554f37b083318a022a97dd7b2470