### PR TITLE
feat: implement Firestore housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Values outside these patterns are ignored to prevent unsafe CSS injection.
 
 ## Housekeeping service
 
-The housekeeping service removes outdated files from Cloud Storage to manage costs and data retention.
+The housekeeping service manages Firestore data by archiving stale transactions,
+removing fully paid debts, and creating a snapshot in a `backups` collection.
+Transactions older than `RETENTION_DAYS` are moved to `transactions_archive`.
 
 ### Running locally
 1. Install dependencies with `npm install`.
@@ -35,9 +37,8 @@ Create a `.env.local` file by copying `.env.example` and populate it with the re
 
 | Variable | Description |
 |----------|-------------|
-| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase project containing the storage bucket. |
-| `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Default Cloud Storage bucket for uploads. |
-| `RETENTION_DAYS` | Number of days to retain files before deletion (default: 30). |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase project containing the Firestore database. |
+| `RETENTION_DAYS` | Number of days to retain transactions before archiving (default: 30). |
 | `CRON_SECRET` | Shared secret expected in the `X-CRON-SECRET` header for housekeeping runs. |
 
 Adjust the retention threshold by setting `RETENTION_DAYS` before running the service or updating the scheduled job configuration.

--- a/src/lib/housekeeping.ts
+++ b/src/lib/housekeeping.ts
@@ -1,10 +1,9 @@
 import { getAuth } from "firebase/auth";
+import { runFirestoreCleanup } from "../services/housekeeping";
 
-// Placeholder housekeeping service that cleans up outdated data.
-// Replace with actual implementation as needed.
+// Executes the Firestore housekeeping routine.
 export async function runHousekeeping(): Promise<void> {
-  // Example: ensure auth SDK is initialized to avoid cold-start costs
-  // and perform cleanup tasks such as removing expired sessions.
+  // Ensure auth SDK is initialized to avoid cold-start costs
   getAuth();
-  console.log("Housekeeping job executed");
+  await runFirestoreCleanup();
 }


### PR DESCRIPTION
## Summary
- archive transactions older than `RETENTION_DAYS` and clean settled debts
- expose Firestore housekeeping runner
- document Firestore cleanup workflow and retention configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b055507f688331aa00114125837588