### PR TITLE
refactor: remove local pagination

### DIFF
--- a/src/components/transactions/transactions-table.tsx
+++ b/src/components/transactions/transactions-table.tsx
@@ -13,14 +13,11 @@ import { Repeat } from "lucide-react"
 import { formatCurrency } from "@/lib/currency"
 import {
   memo,
-  useMemo,
-  useState,
   forwardRef,
   type HTMLAttributes,
   type ComponentType,
 } from "react"
 import { FixedSizeList, type ListChildComponentProps } from "react-window"
-import { Button } from "@/components/ui/button"
 
 interface TransactionsTableProps {
   transactions: Transaction[]
@@ -35,28 +32,17 @@ export const TransactionsTable = memo(function TransactionsTable({
   height = 400,
   rowHeight = 56,
 }: TransactionsTableProps) {
-  const [page, setPage] = useState(0)
-  const [pageSize] = useState(20)
-
-  const currentTransactions = useMemo(
-    () =>
-      transactions
-        .slice(page * pageSize, page * pageSize + pageSize)
-        .map((transaction) => ({
-          ...transaction,
-          formattedDate: new Date(transaction.date).toLocaleDateString(),
-          formattedAmount: `${
-            transaction.type === "Income" ? "+" : "-"
-          }${formatCurrency(transaction.amount, transaction.currency)}`,
-        })),
-    [transactions, page, pageSize],
-  )
 
   const Row = ({ index, style }: ListChildComponentProps) => {
-    const transaction = currentTransactions[index]
+    const transaction = transactions[index]
+    const formattedDate = new Date(transaction.date).toLocaleDateString()
+    const formattedAmount = `${
+      transaction.type === "Income" ? "+" : "-"
+    }${formatCurrency(transaction.amount, transaction.currency)}`
+
     return (
       <TableRow style={style} key={transaction.id}>
-        <TableCell>{transaction.formattedDate}</TableCell>
+        <TableCell>{formattedDate}</TableCell>
         <TableCell className="font-medium">{transaction.description}</TableCell>
         <TableCell>
           <Badge variant="outline">{transaction.category}</Badge>
@@ -73,7 +59,7 @@ export const TransactionsTable = memo(function TransactionsTable({
             "dark:text-inherit",
           )}
         >
-          {transaction.formattedAmount}
+          {formattedAmount}
         </TableCell>
       </TableRow>
     )
@@ -108,35 +94,15 @@ export const TransactionsTable = memo(function TransactionsTable({
       </Table>
       <FixedSizeList
         height={height}
-        itemCount={currentTransactions.length}
+        itemCount={transactions.length}
         itemSize={rowHeight}
         width="100%"
         outerElementType={Outer}
         innerElementType={Inner}
-        itemKey={(index) => currentTransactions[index].id}
+        itemKey={(index) => transactions[index].id}
       >
         {Row}
       </FixedSizeList>
-      <div className="flex justify-between p-4">
-        <Button
-          variant="outline"
-          onClick={() => setPage((p) => Math.max(p - 1, 0))}
-          disabled={page === 0}
-        >
-          Previous
-        </Button>
-        <Button
-          variant="outline"
-          onClick={() =>
-            setPage((p) =>
-              (p + 1) * pageSize >= transactions.length ? p : p + 1,
-            )
-          }
-          disabled={(page + 1) * pageSize >= transactions.length}
-        >
-          Next
-        </Button>
-      </div>
     </div>
   )
 })


### PR DESCRIPTION
## Summary
- simplify transactions table to render the full dataset with virtualization
- compute formatted values in row renderer and key rows by transaction id

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-require-imports, no-constant-condition)*

------
https://chatgpt.com/codex/tasks/task_e_68b055590418833199dc98bf51a4e3f5