### PR TITLE
feat: optimize debt occurrence generation

### DIFF
--- a/src/__tests__/use-debt-occurrences.test.ts
+++ b/src/__tests__/use-debt-occurrences.test.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import { renderToString } from "react-dom/server";
-import { useDebtOccurrences, DEFAULT_MAX_OCCURRENCES } from "../hooks/use-debt-occurrences";
+import { useDebtOccurrences } from "../hooks/use-debt-occurrences";
 import { Debt } from "../lib/types";
 
 type HookReturn = ReturnType<typeof useDebtOccurrences>;
@@ -11,7 +11,7 @@ function renderUseDebtOccurrences(
   from: Date,
   to: Date,
   query = "",
-  maxOccurrences = DEFAULT_MAX_OCCURRENCES
+  maxOccurrences?: number
 ): HookReturn {
   let result: HookReturn = { occurrences: [], grouped: new Map() } as HookReturn;
   function TestComponent() {

--- a/src/components/debts/DebtCalendar.tsx
+++ b/src/components/debts/DebtCalendar.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Recurrence, Debt } from "@/lib/types"; // Use the unified Debt type
-import { useDebtOccurrences, DEFAULT_MAX_OCCURRENCES } from "@/hooks/use-debt-occurrences";
+import { useDebtOccurrences } from "@/hooks/use-debt-occurrences";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
@@ -69,8 +69,7 @@ export default function DebtCalendar({ onChange, startOn = 0 }: DebtCalendarProp
     debts,
     gridFrom,
     gridTo,
-    query,
-    DEFAULT_MAX_OCCURRENCES
+    query
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- compute dynamic iteration limits and lazily generate debt occurrences
- cache debt occurrence results per range and reuse within `useDebtOccurrences`
- update DebtCalendar and tests to use new hook defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0555a4bc88331822b7da345209131