### PR TITLE
Batch save transactions in Firestore batches

### DIFF
--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -51,20 +51,26 @@ export function validateTransactions(rows: TransactionRowType[]): Transaction[] 
 
 export async function saveTransactions(transactions: Transaction[]): Promise<void> {
   const colRef = collection(db, "transactions");
-  const batch = writeBatch(db);
-  transactions.forEach((tx) => {
-    const docRef = doc(colRef);
-    batch.set(docRef, tx);
-  });
+  const BATCH_SIZE = 500;
 
-  try {
-    await batch.commit();
-  } catch (err) {
-    throw new Error(
-      `Failed to save transactions batch: ${
-        err instanceof Error ? err.message : String(err)
-      }`
-    );
+  for (let i = 0; i < transactions.length; i += BATCH_SIZE) {
+    const batch = writeBatch(db);
+    const slice = transactions.slice(i, i + BATCH_SIZE);
+
+    slice.forEach((tx) => {
+      const docRef = doc(colRef);
+      batch.set(docRef, tx);
+    });
+
+    try {
+      await batch.commit();
+    } catch (err) {
+      throw new Error(
+        `Failed to save transactions batch: ${
+          err instanceof Error ? err.message : String(err)
+        }. Some transactions may have been saved from index ${i}.`
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- batch Firestore writes in groups of 500 when saving transactions
- add sequential commit loop with descriptive error message

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68b0555c01f08331b720a3d34fc25dc4