### PR TITLE
fix: avoid useLayoutEffect on server

### DIFF
--- a/src/__tests__/use-mobile.test.tsx
+++ b/src/__tests__/use-mobile.test.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { render, screen, act } from "@testing-library/react";
 import { useIsMobile, MOBILE_BREAKPOINT } from "../hooks/use-mobile";
+import ReactDOMServer from "react-dom/server";
+import { SidebarProvider, Sidebar } from "@/components/ui/sidebar";
+
+jest.mock("lucide-react", () => ({ PanelLeft: () => null }));
 
 describe("useIsMobile", () => {
   let listeners: Array<() => void>;
@@ -39,5 +43,34 @@ describe("useIsMobile", () => {
     });
 
     expect(screen.getByText("mobile")).toBeInTheDocument();
+  });
+
+  it("renders on the server without warnings", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    function TestComponent() {
+      useIsMobile();
+      return null;
+    }
+
+    ReactDOMServer.renderToString(<TestComponent />);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("Sidebar renders on the server without warnings", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    ReactDOMServer.renderToString(
+      <SidebarProvider>
+        <Sidebar>
+          <div />
+        </Sidebar>
+      </SidebarProvider>
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -9,7 +9,7 @@ export const MOBILE_BREAKPOINT = 768
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState(false)
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)


### PR DESCRIPTION
## Summary
- switch `useIsMobile` hook from `useLayoutEffect` to `useEffect`
- add SSR tests verifying no warnings for the hook and Sidebar component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b056869db483319f6acd399c9e08bb