### PR TITLE
Handle clean worker exits in WorkerPool

### DIFF
--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -9,11 +9,16 @@ jest.mock("node:worker_threads", () => {
       postMessage(data: unknown) {
         if (data === "crash") {
           this.emit("error", new Error("boom"))
+          this.emit("exit", 1)
+        } else if (data === "exitAfterMessage") {
+          this.emit("message", 10)
+          this.emit("exit", 0)
         } else {
           this.emit("message", (data as number) * 2)
         }
       }
       terminate() {
+        this.emit("exit", 0)
         return Promise.resolve()
       }
     },
@@ -31,6 +36,16 @@ describe("WorkerPool", () => {
 
     await expect(fail).rejects.toThrow("boom")
     await expect(success).resolves.toBe(10)
+
+    await pool.destroy()
+  })
+
+  it("does not reject when worker exits cleanly", async () => {
+    const pool = new WorkerPool<number | string, number>("fake", 1)
+
+    const result = pool.run("exitAfterMessage" as any)
+
+    await expect(result).resolves.toBe(10)
 
     await pool.destroy()
   })


### PR DESCRIPTION
## Summary
- avoid rejecting tasks when workers exit cleanly by tracking completion state
- remove per-task exit listeners to avoid stale references
- add tests for worker crash and clean exit scenarios

## Testing
- `npm test src/__tests__/worker-pool.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b05687f218833199ba3762c166e897