### PR TITLE
feat: enforce body size limit for API routes

### DIFF
--- a/src/__tests__/payload-limit.test.ts
+++ b/src/__tests__/payload-limit.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment node
+ */
+import { POST as importPost } from "@/app/api/bank/import/route"
+import { POST as syncPost } from "@/app/api/transactions/sync/route"
+import { verifyFirebaseToken } from "@/lib/server-auth"
+
+jest.mock("@/lib/server-auth", () => ({
+  verifyFirebaseToken: jest.fn().mockResolvedValue(undefined),
+}))
+
+describe("payload size limits", () => {
+  const MAX_BODY_SIZE = 1024 * 1024
+
+  function oversizedRequest() {
+    let bodyRead = false
+    const req: any = new Request("http://localhost", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(MAX_BODY_SIZE + 1),
+      },
+      body: "{}",
+    })
+    req.text = () => {
+      bodyRead = true
+      return Promise.resolve("{}")
+    }
+    return { req: req as Request, wasRead: () => bodyRead }
+  }
+
+  beforeEach(() => {
+    ;(verifyFirebaseToken as jest.Mock).mockClear()
+  })
+
+  it("bank/import rejects oversized payload without reading body", async () => {
+    const { req, wasRead } = oversizedRequest()
+    const res = await importPost(req)
+    expect(res.status).toBe(413)
+    expect(wasRead()).toBe(false)
+    expect(verifyFirebaseToken).toHaveBeenCalledTimes(1)
+  })
+
+  it("transactions/sync rejects oversized payload without reading body", async () => {
+    const { req, wasRead } = oversizedRequest()
+    const res = await syncPost(req)
+    expect(res.status).toBe(413)
+    expect(wasRead()).toBe(false)
+    expect(verifyFirebaseToken).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -22,6 +22,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: message }, { status: 401 })
   }
 
+  const contentLength = req.headers.get("content-length")
+  if (contentLength && Number(contentLength) > MAX_BODY_SIZE) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 })
+  }
+
   let text: string
   try {
     text = await req.text()

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -21,6 +21,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: message }, { status: 401 })
   }
 
+  const contentLength = req.headers.get("content-length")
+  if (contentLength && Number(contentLength) > MAX_BODY_SIZE) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 })
+  }
+
   let text: string
   try {
     text = await req.text()


### PR DESCRIPTION
## Summary
- reject oversized bank import payloads before buffering
- reject oversized transaction sync payloads before buffering
- add tests to ensure API routes return 413 for large bodies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b05689c9048331914e8e3bfeb21cd4