### PR TITLE
Handle invalid service worker payloads gracefully

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -9,6 +9,39 @@ const dbPromise = idb.openDB(DB_NAME, 1, {
   },
 })
 
+async function queueRequest(request) {
+  const clone = request.clone()
+  const contentType = clone.headers.get("Content-Type") || ""
+  let body = null
+  let text = null
+
+  try {
+    text = await clone.text()
+  } catch (textErr) {
+    console.warn("Failed to read request body", textErr)
+  }
+
+  if (text !== null) {
+    if (contentType.includes("application/json")) {
+      try {
+        body = JSON.parse(text)
+      } catch (parseErr) {
+        console.warn("Failed to parse JSON body", parseErr)
+        body = { raw: text }
+      }
+    } else {
+      body = { raw: text }
+    }
+  }
+
+  if (body) {
+    const db = await dbPromise
+    await db.add(STORE_NAME, body)
+  }
+}
+
+self.__queueRequest = queueRequest
+
 self.addEventListener("fetch", event => {
   const { request } = event
   if (
@@ -21,10 +54,7 @@ self.addEventListener("fetch", event => {
         try {
           return await fetch(request)
         } catch (err) {
-          const clone = request.clone()
-          const body = await clone.json()
-          const db = await dbPromise
-          await db.add(STORE_NAME, body)
+          await queueRequest(request)
           return new Response(JSON.stringify({ offline: true }), {
             status: 202,
             headers: { "Content-Type": "application/json" },

--- a/src/__tests__/service-worker.test.ts
+++ b/src/__tests__/service-worker.test.ts
@@ -1,0 +1,32 @@
+// @jest-environment node
+
+describe('service worker', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('queues raw payload when JSON parsing fails', async () => {
+    const addMock = jest.fn().mockResolvedValue(undefined);
+    (global as any).idb = { openDB: jest.fn().mockResolvedValue({ add: addMock }) };
+    (global as any).importScripts = jest.fn();
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (global as any).self = { addEventListener: jest.fn() } as any;
+    require('../../public/sw.js');
+
+    const request = {
+      clone: () => ({
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+        text: () => Promise.resolve('not json'),
+      }),
+    } as any;
+
+    await (global as any).self.__queueRequest(request);
+
+    expect(addMock).toHaveBeenCalledWith('transactions', { raw: 'not json' });
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Guard service worker body parsing with content-type validation and fallback to raw text when JSON parsing fails
- Expose `queueRequest` helper for testing and offline queuing
- Add Jest test to verify queuing on invalid JSON payloads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05696e2288331a9233ab1792310d1