### PR TITLE
Validate currency codes in FX utilities

### DIFF
--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -1,0 +1,25 @@
+import { getFxRate } from '@/lib/currency'
+
+describe('getFxRate validation', () => {
+  beforeEach(() => {
+    ;(global as any).fetch = jest.fn()
+  })
+
+  it('rejects invalid currency codes', async () => {
+    await expect(getFxRate('US', 'EUR')).rejects.toThrow('Invalid currency code')
+    await expect(getFxRate('USD', 'EURO')).rejects.toThrow('Invalid currency code')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches rate for valid currency codes', async () => {
+    ;(global.fetch as any) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rates: { EUR: 0.9 } }),
+    })
+    const rate = await getFxRate('usd', 'eur')
+    expect(rate).toBe(0.9)
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.exchangerate.host/latest?base=USD&symbols=EUR',
+    )
+  })
+})

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,20 +1,36 @@
+import { z } from 'zod';
+
+const CurrencyCode = z.string().regex(/^[A-Z]{3}$/);
+
+function parseCurrency(code: string): string {
+  try {
+    return CurrencyCode.parse(code.trim().toUpperCase());
+  } catch {
+    throw new Error(`Invalid currency code: ${code}`);
+  }
+}
+
 export async function getFxRate(from: string, to: string): Promise<number> {
-  if (from === to) return 1;
+  const fromCode = parseCurrency(from);
+  const toCode = parseCurrency(to);
+  if (fromCode === toCode) return 1;
   let res: Response;
   try {
     res = await fetch(
-      `https://api.exchangerate.host/latest?base=${from}&symbols=${to}`,
+      `https://api.exchangerate.host/latest?base=${fromCode}&symbols=${toCode}`,
     );
   } catch (err) {
     throw new Error(
-      `Network error while fetching FX rates: ${err instanceof Error ? err.message : err}`,
+      `Network error while fetching FX rates: ${
+        err instanceof Error ? err.message : err
+      }`,
     );
   }
   if (!res.ok) {
     throw new Error('Failed to fetch FX rates');
   }
   const data = await res.json();
-  const rate = data?.rates?.[to];
+  const rate = data?.rates?.[toCode];
   if (typeof rate !== 'number') {
     throw new Error('Invalid FX rate data');
   }


### PR DESCRIPTION
## Summary
- validate currency codes using Zod and sanitize before fetch
- add tests for valid and invalid currency codes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0569842dc8331baa47a2c24419229