### PR TITLE
Add transaction schema validation and tests

### DIFF
--- a/src/ai/flows/__tests__/transaction-routes-invalid.test.ts
+++ b/src/ai/flows/__tests__/transaction-routes-invalid.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment node
+ */
+import { POST as bankImport } from "@/app/api/bank/import/route";
+import { POST as syncTransactions } from "@/app/api/transactions/sync/route";
+
+jest.mock("@/lib/server-auth", () => ({
+  verifyFirebaseToken: jest.fn(),
+}));
+
+describe("transaction route validation", () => {
+  it("bank import returns 400 for invalid transaction", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({
+        provider: "plaid",
+        transactions: [
+          {
+            id: "1",
+            date: "2024-01-01",
+            description: "test",
+            amount: "oops",
+            currency: "USD",
+            type: "Income",
+            category: "salary",
+          },
+        ],
+      }),
+    });
+    const res = await bankImport(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(Array.isArray(data.error)).toBe(true);
+    expect(data.error[0].path).toEqual(["transactions", 0, "amount"]);
+  });
+
+  it("transactions sync returns 400 for invalid transaction", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({
+        transactions: [
+          {
+            id: "1",
+            date: "2024-01-01",
+            description: "test",
+            amount: "oops",
+            currency: "USD",
+            type: "Income",
+            category: "salary",
+          },
+        ],
+      }),
+    });
+    const res = await syncTransactions(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(Array.isArray(data.error)).toBe(true);
+    expect(data.error[0].path).toEqual(["transactions", 0, "amount"]);
+  });
+});

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
+import { TransactionSchema } from "@/lib/types"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -9,7 +10,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
  */
 const bodySchema = z.object({
   provider: z.string(),
-  transactions: z.array(z.any()),
+  transactions: z.array(TransactionSchema),
 })
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
@@ -41,7 +42,7 @@ export async function POST(req: Request) {
 
   const parsed = bodySchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
   }
 
   const { provider, transactions } = parsed.data

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
+import { TransactionSchema } from "@/lib/types"
 
 /**
  * Generic transaction syncing endpoint.
@@ -8,7 +9,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
  * from any source and persists them to the database.
  */
 const bodySchema = z.object({
-  transactions: z.array(z.any()),
+  transactions: z.array(TransactionSchema),
 })
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
@@ -40,7 +41,7 @@ export async function POST(req: Request) {
 
   const parsed = bodySchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+    return NextResponse.json({ error: parsed.error.issues }, { status: 400 })
   }
 
   const { transactions } = parsed.data

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,14 +1,18 @@
 
-export type Transaction = {
-  id: string;
-  date: string;
-  description: string;
-  amount: number;
-  currency: string; // ISO currency code
-  type: "Income" | "Expense";
-  category: string;
-  isRecurring?: boolean;
-};
+import { z } from "zod";
+
+export const TransactionSchema = z.object({
+  id: z.string(),
+  date: z.string(),
+  description: z.string(),
+  amount: z.number(),
+  currency: z.string(), // ISO currency code
+  type: z.enum(["Income", "Expense"]),
+  category: z.string(),
+  isRecurring: z.boolean().optional(),
+});
+
+export type Transaction = z.infer<typeof TransactionSchema>;
 
 export type Goal = {
   id: string;


### PR DESCRIPTION
## Summary
- enforce transaction schema using Zod for bank import and sync APIs
- return detailed validation errors on malformed transactions
- add tests covering invalid transaction payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0569b43e883319843592f15221646