### PR TITLE
chore: remove housekeeping console log

### DIFF
--- a/src/lib/housekeeping.ts
+++ b/src/lib/housekeeping.ts
@@ -6,5 +6,4 @@ export async function runHousekeeping(): Promise<void> {
   // Example: ensure auth SDK is initialized to avoid cold-start costs
   // and perform cleanup tasks such as removing expired sessions.
   getAuth();
-  console.log("Housekeeping job executed");
 }


### PR DESCRIPTION
## Summary
- remove leftover console log in housekeeping stub

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b056a5337483318cc750b420175470