### PR TITLE
Validate bank import transactions

### DIFF
--- a/src/__tests__/api-validation.test.ts
+++ b/src/__tests__/api-validation.test.ts
@@ -30,6 +30,24 @@ describe("/api/bank/import", () => {
     const res = await bankImport(req)
     expect(res.status).toBe(400)
   })
+
+  it("returns 400 when transactions contain invalid entries", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({
+        provider: "plaid",
+        transactions: [
+          {
+            description: "Missing required fields",
+            amount: 10,
+          },
+        ],
+      }),
+    })
+    const res = await bankImport(req)
+    expect(res.status).toBe(400)
+  })
 })
 
 describe("/api/transactions/sync", () => {

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -2,6 +2,16 @@ import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
 
+const transactionSchema = z.object({
+  date: z.string(),
+  description: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  type: z.enum(["Income", "Expense"]),
+  category: z.string(),
+  isRecurring: z.boolean().optional(),
+})
+
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
  * This endpoint deals with provider-specific payloads and is distinct from the
@@ -9,7 +19,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
  */
 const bodySchema = z.object({
   provider: z.string(),
-  transactions: z.array(z.any()),
+  transactions: z.array(transactionSchema),
 })
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB


### PR DESCRIPTION
## Summary
- add strict `transactionSchema` for bank import API
- validate incoming transactions using `transactionSchema`
- test that malformed transaction entries are rejected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b056a70dd4833196d49993c40f99eb