### PR TITLE
chore: remove unsafe script directives

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
-      `script-src 'self' 'nonce-${cspNonce}' 'unsafe-inline' 'unsafe-eval'`,
+      `script-src 'self' 'nonce-${cspNonce}'`,
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: https:",
       "font-src 'self'",


### PR DESCRIPTION
## Summary
- drop `unsafe-inline` and `unsafe-eval` from CSP `script-src`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, etc.)*
- `curl -sD - http://127.0.0.1:3000/favicon.ico -o /tmp/favicon`


------
https://chatgpt.com/codex/tasks/task_e_68b0592465d88331bfd60650c42ea9b5