### PR TITLE
chore: annotate offline queue return types

### DIFF
--- a/src/lib/offline.ts
+++ b/src/lib/offline.ts
@@ -9,17 +9,17 @@ const dbPromise = openDB(DB_NAME, 1, {
   },
 })
 
-export async function queueTransaction(tx: unknown) {
+export async function queueTransaction(tx: unknown): Promise<void> {
   const db = await dbPromise
   await db.add(STORE_NAME, tx)
 }
 
-export async function getQueuedTransactions<T = unknown>() {
+export async function getQueuedTransactions<T = unknown>(): Promise<T[]> {
   const db = await dbPromise
   return db.getAll(STORE_NAME) as Promise<T[]>
 }
 
-export async function clearQueuedTransactions() {
+export async function clearQueuedTransactions(): Promise<void> {
   const db = await dbPromise
   await db.clear(STORE_NAME)
 }


### PR DESCRIPTION
## Summary
- add explicit return types to offline queue utilities

## Testing
- `npm run lint` *(fails: Unexpected any, require() style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b05925298483319130b33da2e19fea