### PR TITLE
refactor: drop async wrappers for flow calls

### DIFF
--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -28,7 +28,7 @@ const AnalyzeReceiptOutputSchema = z.object({
 });
 export type AnalyzeReceiptOutput = z.infer<typeof AnalyzeReceiptOutputSchema>;
 
-export async function analyzeReceipt(input: AnalyzeReceiptInput): Promise<AnalyzeReceiptOutput> {
+export function analyzeReceipt(input: AnalyzeReceiptInput): Promise<AnalyzeReceiptOutput> {
   return analyzeReceiptFlow(input);
 }
 

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -41,7 +41,9 @@ const AnalyzeSpendingHabitsOutputSchema = z.object({
 });
 export type AnalyzeSpendingHabitsOutput = z.infer<typeof AnalyzeSpendingHabitsOutputSchema>;
 
-export async function analyzeSpendingHabits(input: AnalyzeSpendingHabitsInput): Promise<AnalyzeSpendingHabitsOutput> {
+export function analyzeSpendingHabits(
+  input: AnalyzeSpendingHabitsInput,
+): Promise<AnalyzeSpendingHabitsOutput> {
   return analyzeSpendingHabitsFlow(input);
 }
 

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -38,7 +38,9 @@ const CalculateCashflowOutputSchema = z.object({
 });
 export type CalculateCashflowOutput = z.infer<typeof CalculateCashflowOutputSchema>;
 
-export async function calculateCashflow(input: CalculateCashflowInput): Promise<CalculateCashflowOutput> {
+export function calculateCashflow(
+  input: CalculateCashflowInput,
+): Promise<CalculateCashflowOutput> {
   return calculateCashflowFlow(input);
 }
 

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -35,7 +35,9 @@ const SpendingForecastOutputSchema = z.object({
 });
 export type SpendingForecastOutput = z.infer<typeof SpendingForecastOutputSchema>;
 
-export async function predictSpending(input: SpendingForecastInput): Promise<SpendingForecastOutput> {
+export function predictSpending(
+  input: SpendingForecastInput,
+): Promise<SpendingForecastOutput> {
   return spendingForecastFlow(input);
 }
 

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -40,7 +40,9 @@ const SuggestDebtStrategyOutputSchema = z.object({
 });
 export type SuggestDebtStrategyOutput = z.infer<typeof SuggestDebtStrategyOutputSchema>;
 
-export async function suggestDebtStrategy(input: SuggestDebtStrategyInput): Promise<SuggestDebtStrategyOutput> {
+export function suggestDebtStrategy(
+  input: SuggestDebtStrategyInput,
+): Promise<SuggestDebtStrategyOutput> {
   return suggestDebtStrategyFlow(input);
 }
 

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -40,7 +40,9 @@ const TaxEstimationOutputSchema = z.object({
 });
 export type TaxEstimationOutput = z.infer<typeof TaxEstimationOutputSchema>;
 
-export async function estimateTax(input: TaxEstimationInput): Promise<TaxEstimationOutput> {
+export function estimateTax(
+  input: TaxEstimationInput,
+): Promise<TaxEstimationOutput> {
   return taxEstimationFlow(input);
 }
 


### PR DESCRIPTION
## Summary
- remove redundant `async` keywords from AI flow wrappers so they directly return the flow promise
- update receipt analysis, debt strategy, cashflow, spending forecast, spending habits, and tax estimation flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0592680788331b136ea10fe55daa4