### PR TITLE
chore(ai): standardize fileoverview tag

### DIFF
--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -2,7 +2,7 @@
 'use server';
 
 /**
- * @fileOverview Analyzes a receipt image and extracts transaction details.
+ * @fileoverview Analyzes a receipt image and extracts transaction details.
  *
  * - analyzeReceipt - A function that analyzes a receipt image.
  * - AnalyzeReceiptInput - The input type for the analyzeReceipt function.

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -4,7 +4,7 @@
 'use server';
 
 /**
- * @fileOverview Analyzes user's spending habits based on uploaded financial documents.
+ * @fileoverview Analyzes user's spending habits based on uploaded financial documents.
  *
  * - analyzeSpendingHabits - A function that analyzes spending habits.
  * - AnalyzeSpendingHabitsInput - The input type for the analyzeSpendingHabits function.

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -2,7 +2,7 @@
 'use server';
 
 /**
- * @fileOverview Provides a cashflow analysis based on income, taxes, and deductions.
+ * @fileoverview Provides a cashflow analysis based on income, taxes, and deductions.
  *
  * - calculateCashflow - A function that estimates monthly gross and net cashflow.
  * - CalculateCashflowInput - The input type for the calculateCashflow function.

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -2,7 +2,7 @@
 'use server';
 
 /**
- * @fileOverview Generates a spending forecast based on past transactions.
+ * @fileoverview Generates a spending forecast based on past transactions.
  *
  * - predictSpending - A function that predicts future spending.
  * - SpendingForecastInput - The input type for the predictSpending function.

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -2,7 +2,7 @@
 'use server';
 
 /**
- * @fileOverview Analyzes a user's debts and suggests a payoff strategy.
+ * @fileoverview Analyzes a user's debts and suggests a payoff strategy.
  *
  * - suggestDebtStrategy - A function that returns an AI-powered debt payoff plan.
  * - SuggestDebtStrategyInput - The input type for the suggestDebtStrategy function.

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -2,7 +2,7 @@
 'use server';
 
 /**
- * @fileOverview Provides a tax estimation based on user's income, deductions, and location.
+ * @fileoverview Provides a tax estimation based on user's income, deductions, and location.
  *
  * - estimateTax - A function that estimates tax obligations.
  * - TaxEstimationInput - The input type for the estimateTax function.


### PR DESCRIPTION
## Summary
- standardize JSDoc `@fileoverview` tag across AI flow modules

## Testing
- `npm run lint` *(fails: existing @typescript-eslint errors in unrelated test files)*
- `npx eslint src/ai/flows/*.ts --no-ignore`


------
https://chatgpt.com/codex/tasks/task_e_68b059272c2c833181758e9c4ff70845