### PR TITLE
style: format AI imports with spaced named syntax

### DIFF
--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -9,8 +9,8 @@
  * - AnalyzeReceiptOutput - The return type for the analyzeReceipt function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { z } from 'genkit';
 
 const AnalyzeReceiptInputSchema = z.object({
   receiptImage: z

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -11,8 +11,8 @@
  * - AnalyzeSpendingHabitsOutput - The return type for the analyzeSpendingHabits function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { z } from 'genkit';
 
 const GoalSchema = z.object({
     id: z.string(),

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -9,8 +9,8 @@
  * - CalculateCashflowOutput - The return type for the calculateCashflow function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { z } from 'genkit';
 
 const CalculateCashflowInputSchema = z.object({
   annualIncome: z

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -9,8 +9,8 @@
  * - SpendingForecastOutput - The return type for the predictSpending function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { z } from 'genkit';
 
 const TransactionSchema = z.object({
   date: z.string().describe('ISO date of the transaction.'),

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -9,8 +9,8 @@
  * - SuggestDebtStrategyOutput - The return type for the suggestDebtStrategy function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { z } from 'genkit';
 import { RecurrenceValues } from '@/lib/types';
 
 const DebtSchema = z.object({

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -9,8 +9,8 @@
  * - TaxEstimationOutput - The return type for the estimateTax function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { z } from 'genkit';
 
 const TaxEstimationInputSchema = z.object({
   income: z

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,5 +1,5 @@
-import {genkit} from 'genkit';
-import {googleAI} from '@genkit-ai/googleai';
+import { genkit } from 'genkit';
+import { googleAI } from '@genkit-ai/googleai';
 
 const model = process.env.GENKIT_MODEL || 'googleai/gemini-2.5-flash';
 


### PR DESCRIPTION
## Summary
- format genkit and flow module imports using `import { foo } from 'module'` style

## Testing
- `npm run lint` *(fails: Unexpected any, A `require()` style import is forbidden, Unexpected constant condition)*

------
https://chatgpt.com/codex/tasks/task_e_68b0592847408331ae1f3a0c957f8d04