### PR TITLE
feat: return decoded firebase token

### DIFF
--- a/src/__tests__/api-validation.test.ts
+++ b/src/__tests__/api-validation.test.ts
@@ -30,6 +30,18 @@ describe("/api/bank/import", () => {
     const res = await bankImport(req)
     expect(res.status).toBe(400)
   })
+
+  it("returns decoded uid for valid payload", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ provider: "bank", transactions: [] }),
+    })
+    const res = await bankImport(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.uid).toBe("test-uid")
+  })
 })
 
 describe("/api/transactions/sync", () => {
@@ -57,5 +69,17 @@ describe("/api/transactions/sync", () => {
     })
     const res = await transactionsSync(req)
     expect(res.status).toBe(400)
+  })
+
+  it("returns decoded uid for valid payload", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ transactions: [] }),
+    })
+    const res = await transactionsSync(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.uid).toBe("test-uid")
   })
 })

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
+import type { DecodedIdToken } from "firebase-admin/auth"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -15,8 +16,9 @@ const bodySchema = z.object({
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
 export async function POST(req: Request) {
+  let decodedToken: DecodedIdToken
   try {
-    await verifyFirebaseToken(req)
+    decodedToken = await verifyFirebaseToken(req)
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unauthorized"
     return NextResponse.json({ error: message }, { status: 401 })
@@ -50,6 +52,7 @@ export async function POST(req: Request) {
     return NextResponse.json({
       provider,
       imported: transactions.length,
+      uid: decodedToken.uid,
     })
   } catch {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- return decoded Firebase ID token from `verifyFirebaseToken`
- reuse initialized Firebase Admin app across requests
- capture decoded token in bank import and transaction sync routes
- add tests for returning decoded uid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0599bbb7483318e188fdb63bacf12