### PR TITLE
feat: improve offline transaction queue handling

### DIFF
--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -1,8 +1,8 @@
 jest.mock("idb", () => {
-  const store: unknown[] = []
+  const store: QueuedTransaction[] = []
   return {
     openDB: jest.fn(async () => ({
-      add: async (_store: string, value: unknown) => {
+      add: async (_store: string, value: QueuedTransaction) => {
         store.push(value)
       },
       getAll: async () => [...store],
@@ -17,6 +17,7 @@ import {
   queueTransaction,
   getQueuedTransactions,
   clearQueuedTransactions,
+  QueuedTransaction,
 } from "../lib/offline"
 
 describe("offline fallbacks", () => {
@@ -24,7 +25,7 @@ describe("offline fallbacks", () => {
     await queueTransaction({ id: 1 })
     await queueTransaction({ id: 2 })
 
-    const queued = await getQueuedTransactions<{ id: number }>()
+    const queued = await getQueuedTransactions()
     expect(queued).toEqual([{ id: 1 }, { id: 2 }])
 
     await clearQueuedTransactions()

--- a/src/lib/offline.ts
+++ b/src/lib/offline.ts
@@ -3,23 +3,44 @@ import { openDB } from "idb"
 const DB_NAME = "offline-db"
 const STORE_NAME = "transactions"
 
+export interface QueuedTransaction {
+  [key: string]: unknown
+}
+
 const dbPromise = openDB(DB_NAME, 1, {
-  upgrade(db) {
-    db.createObjectStore(STORE_NAME, { autoIncrement: true })
+  upgrade(db, oldVersion) {
+    switch (oldVersion) {
+      case 0:
+        db.createObjectStore(STORE_NAME, { autoIncrement: true })
+        // future migrations can be handled with additional cases
+    }
   },
 })
 
-export async function queueTransaction(tx: unknown) {
-  const db = await dbPromise
-  await db.add(STORE_NAME, tx)
+export async function queueTransaction(tx: QueuedTransaction): Promise<void> {
+  try {
+    const db = await dbPromise
+    await db.add(STORE_NAME, tx)
+  } catch (error) {
+    console.error("Failed to queue transaction", error)
+  }
 }
 
-export async function getQueuedTransactions<T = unknown>() {
-  const db = await dbPromise
-  return db.getAll(STORE_NAME) as Promise<T[]>
+export async function getQueuedTransactions(): Promise<QueuedTransaction[]> {
+  try {
+    const db = await dbPromise
+    return await db.getAll(STORE_NAME)
+  } catch (error) {
+    console.error("Failed to get queued transactions", error)
+    return []
+  }
 }
 
-export async function clearQueuedTransactions() {
-  const db = await dbPromise
-  await db.clear(STORE_NAME)
+export async function clearQueuedTransactions(): Promise<void> {
+  try {
+    const db = await dbPromise
+    await db.clear(STORE_NAME)
+  } catch (error) {
+    console.error("Failed to clear queued transactions", error)
+  }
 }


### PR DESCRIPTION
## Summary
- add `QueuedTransaction` interface and type offline queue functions
- wrap IndexedDB operations with try/catch for safer error handling
- prepare openDB upgrade callback for future versioned migrations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0599c5a3083319927068eb4f51459