### PR TITLE
Use timestamps for backup ordering

### DIFF
--- a/docs/firestore-schema.md
+++ b/docs/firestore-schema.md
@@ -1,0 +1,73 @@
+# Firestore Schema
+
+## Collections
+
+### transactions
+- `id`: string
+- `date`: string (ISO)
+- `description`: string
+- `amount`: number
+- `currency`: string (ISO currency code)
+- `type`: "Income" | "Expense"
+- `category`: string
+- `isRecurring?`: boolean
+- `createdAt`: string (ISO timestamp)
+
+### debts
+- `id`: string
+- `name`: string
+- `initialAmount`: number
+- `currentAmount`: number
+- `interestRate`: number
+- `minimumPayment`: number
+- `dueDate`: string
+- `recurrence`: "none" | "weekly" | "biweekly" | "monthly"
+- `autopay`: boolean
+- `notes?`: string
+- `color?`: string
+- `paidDates?`: string[]
+- `createdAt`: string (ISO timestamp)
+
+### goals
+- `id`: string
+- `name`: string
+- `targetAmount`: number
+- `currentAmount`: number
+- `deadline`: string
+- `importance`: number
+- `createdAt`: string (ISO timestamp)
+
+### backups
+- `transactions`: Transaction[]
+- `debts`: Debt[]
+- `goals`: Goal[]
+- `createdAt`: string (ISO timestamp)
+
+## Indexes
+
+Each collection is queried by the `createdAt` field during backups.
+Ensure a single-field index on `createdAt` exists for `transactions`, `debts`, and `goals`.
+Firestore creates these automatically, but include them in `firestore.indexes.json` if deploying via Firebase CLI:
+
+```json
+{
+  "indexes": [
+    {
+      "collectionGroup": "transactions",
+      "queryScope": "COLLECTION",
+      "fields": [{ "fieldPath": "createdAt", "order": "ASCENDING" }]
+    },
+    {
+      "collectionGroup": "debts",
+      "queryScope": "COLLECTION",
+      "fields": [{ "fieldPath": "createdAt", "order": "ASCENDING" }]
+    },
+    {
+      "collectionGroup": "goals",
+      "queryScope": "COLLECTION",
+      "fields": [{ "fieldPath": "createdAt", "order": "ASCENDING" }]
+    }
+  ],
+  "fieldOverrides": []
+}
+```

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,20 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "transactions",
+      "queryScope": "COLLECTION",
+      "fields": [{ "fieldPath": "createdAt", "order": "ASCENDING" }]
+    },
+    {
+      "collectionGroup": "debts",
+      "queryScope": "COLLECTION",
+      "fields": [{ "fieldPath": "createdAt", "order": "ASCENDING" }]
+    },
+    {
+      "collectionGroup": "goals",
+      "queryScope": "COLLECTION",
+      "fields": [{ "fieldPath": "createdAt", "order": "ASCENDING" }]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -154,11 +154,13 @@ export async function backupData(
     return items;
   }
 
-  const data = {
-    transactions: await fetchAll<Transaction>("transactions", "id"),
-    debts: await fetchAll<Debt>("debts", "id"),
-    goals: await fetchAll<Goal>("goals", "id"),
-  };
+  const [transactions, debts, goals] = await Promise.all([
+    fetchAll<Transaction>("transactions", "createdAt"),
+    fetchAll<Debt>("debts", "createdAt"),
+    fetchAll<Goal>("goals", "createdAt"),
+  ]);
+
+  const data = { transactions, debts, goals };
 
   await runWithRetry(
     () =>


### PR DESCRIPTION
## Summary
- Order backup queries by `createdAt` and fetch collections in parallel
- Document Firestore schemas and createdAt indexes
- Define indexes for `transactions`, `debts`, and `goals`

## Testing
- `npm run lint` *(fails: Unexpected any and no-require-imports)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0599d8a748331b6bb5da181dddde2