### PR TITLE
feat: enforce auth for AI flows

### DIFF
--- a/src/ai/auth.ts
+++ b/src/ai/auth.ts
@@ -1,0 +1,47 @@
+'use server'
+
+import { headers } from 'next/headers'
+
+// Simple in-memory rate limiter keyed by user ID.
+const requests = new Map<string, { count: number; reset: number }>()
+const WINDOW_MS = 60 * 1000
+const MAX_REQUESTS = 5
+
+/**
+ * Ensures the request is authenticated and enforces a basic per-user rate limit.
+ * Returns the authenticated user's uid on success.
+ *
+ * In test environments, auth and rate limiting are skipped.
+ */
+export async function ensureAuth(): Promise<string> {
+  if (process.env.NODE_ENV === 'test') {
+    return 'test-user'
+  }
+
+  const authHeader = headers().get('Authorization')
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    throw new Error('Unauthorized')
+  }
+  const token = authHeader.slice('Bearer '.length)
+
+  const { getApps, initializeApp } = await import('firebase-admin/app')
+  const { getAuth } = await import('firebase-admin/auth')
+  if (!getApps().length) {
+    initializeApp()
+  }
+  const decoded = await getAuth().verifyIdToken(token)
+  const uid = decoded.uid
+
+  const now = Date.now()
+  const record = requests.get(uid)
+  if (record && record.reset > now && record.count >= MAX_REQUESTS) {
+    throw new Error('Rate limit exceeded')
+  }
+  if (!record || record.reset <= now) {
+    requests.set(uid, { count: 1, reset: now + WINDOW_MS })
+  } else {
+    record.count++
+  }
+
+  return uid
+}

--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -11,6 +11,7 @@
 
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
+import { ensureAuth } from '@/ai/auth';
 
 const AnalyzeReceiptInputSchema = z.object({
   receiptImage: z
@@ -29,6 +30,7 @@ const AnalyzeReceiptOutputSchema = z.object({
 export type AnalyzeReceiptOutput = z.infer<typeof AnalyzeReceiptOutputSchema>;
 
 export async function analyzeReceipt(input: AnalyzeReceiptInput): Promise<AnalyzeReceiptOutput> {
+  await ensureAuth();
   return analyzeReceiptFlow(input);
 }
 

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -13,6 +13,7 @@
 
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
+import { ensureAuth } from '@/ai/auth';
 
 const GoalSchema = z.object({
     id: z.string(),
@@ -42,6 +43,7 @@ const AnalyzeSpendingHabitsOutputSchema = z.object({
 export type AnalyzeSpendingHabitsOutput = z.infer<typeof AnalyzeSpendingHabitsOutputSchema>;
 
 export async function analyzeSpendingHabits(input: AnalyzeSpendingHabitsInput): Promise<AnalyzeSpendingHabitsOutput> {
+  await ensureAuth();
   return analyzeSpendingHabitsFlow(input);
 }
 

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -11,6 +11,7 @@
 
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
+import { ensureAuth } from '@/ai/auth';
 
 const CalculateCashflowInputSchema = z.object({
   annualIncome: z
@@ -39,6 +40,7 @@ const CalculateCashflowOutputSchema = z.object({
 export type CalculateCashflowOutput = z.infer<typeof CalculateCashflowOutputSchema>;
 
 export async function calculateCashflow(input: CalculateCashflowInput): Promise<CalculateCashflowOutput> {
+  await ensureAuth();
   return calculateCashflowFlow(input);
 }
 

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -11,6 +11,7 @@
 
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
+import { ensureAuth } from '@/ai/auth';
 
 const TransactionSchema = z.object({
   date: z.string().describe('ISO date of the transaction.'),
@@ -36,6 +37,7 @@ const SpendingForecastOutputSchema = z.object({
 export type SpendingForecastOutput = z.infer<typeof SpendingForecastOutputSchema>;
 
 export async function predictSpending(input: SpendingForecastInput): Promise<SpendingForecastOutput> {
+  await ensureAuth();
   return spendingForecastFlow(input);
 }
 

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -12,6 +12,7 @@
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 import { RecurrenceValues } from '@/lib/types';
+import { ensureAuth } from '@/ai/auth';
 
 const DebtSchema = z.object({
     id: z.string(),
@@ -41,6 +42,7 @@ const SuggestDebtStrategyOutputSchema = z.object({
 export type SuggestDebtStrategyOutput = z.infer<typeof SuggestDebtStrategyOutputSchema>;
 
 export async function suggestDebtStrategy(input: SuggestDebtStrategyInput): Promise<SuggestDebtStrategyOutput> {
+  await ensureAuth();
   return suggestDebtStrategyFlow(input);
 }
 

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -11,6 +11,7 @@
 
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
+import { ensureAuth } from '@/ai/auth';
 
 const TaxEstimationInputSchema = z.object({
   income: z
@@ -41,6 +42,7 @@ const TaxEstimationOutputSchema = z.object({
 export type TaxEstimationOutput = z.infer<typeof TaxEstimationOutputSchema>;
 
 export async function estimateTax(input: TaxEstimationInput): Promise<TaxEstimationOutput> {
+  await ensureAuth();
   return taxEstimationFlow(input);
 }
 


### PR DESCRIPTION
## Summary
- add reusable ensureAuth helper that verifies Firebase tokens and applies per-user rate limits
- guard Genkit flows behind ensureAuth
- require logged-in user before generating insights

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b059a8dfb0833180a936983ce8ad70