### PR TITLE
Add numeric validation with limits

### DIFF
--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+
+function setupValidationMocks(output: any) {
+  const definePromptMock = jest.fn().mockReturnValue(async () => ({ output }));
+  const defineFlowMock = jest.fn((config: any, handler: any) => {
+    return async (input: any) => {
+      const parsedInput = config.inputSchema.parse(input);
+      const result = await handler(parsedInput);
+      return config.outputSchema.parse(result);
+    };
+  });
+  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+}
+
+describe('calculateCashflow validation', () => {
+  it('rejects negative values', async () => {
+    jest.resetModules();
+    setupValidationMocks({ grossMonthlyIncome: 0, netMonthlyIncome: 0, analysis: '' });
+    const { calculateCashflow } = await import('@/ai/flows/calculate-cashflow');
+    await expect(
+      calculateCashflow({
+        annualIncome: -1,
+        estimatedAnnualTaxes: 1000,
+        totalMonthlyDeductions: 100,
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe('taxEstimation validation', () => {
+  it('rejects negative income', async () => {
+    jest.resetModules();
+    setupValidationMocks({ estimatedTax: 0, taxRate: 0, breakdown: '' });
+    const { estimateTax } = await import('@/ai/flows/tax-estimation');
+    await expect(
+      estimateTax({ income: -5000, deductions: 0, location: 'NY', filingStatus: 'single' })
+    ).rejects.toThrow();
+  });
+
+  it('rejects taxRate over 100', async () => {
+    jest.resetModules();
+    setupValidationMocks({ estimatedTax: 1000, taxRate: 150, breakdown: 'invalid rate' });
+    const { estimateTax } = await import('@/ai/flows/tax-estimation');
+    await expect(
+      estimateTax({ income: 50000, deductions: 10000, location: 'NY', filingStatus: 'single' })
+    ).rejects.toThrow();
+  });
+});
+
+describe('suggestDebtStrategy validation', () => {
+  const validDebt = {
+    id: '1',
+    name: 'Debt',
+    initialAmount: 1000,
+    currentAmount: 500,
+    interestRate: 5,
+    minimumPayment: 50,
+    dueDate: '2024-01-01',
+    recurrence: 'monthly',
+  };
+
+  it('rejects negative currentAmount', async () => {
+    jest.resetModules();
+    setupValidationMocks({
+      recommendedStrategy: 'avalanche',
+      strategyReasoning: '',
+      payoffOrder: [{ debtName: 'Debt', priority: 1 }],
+      summary: '',
+    });
+    const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
+    await expect(
+      suggestDebtStrategy({
+        debts: [{ ...validDebt, currentAmount: -10 }],
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects interestRate over 100', async () => {
+    jest.resetModules();
+    setupValidationMocks({
+      recommendedStrategy: 'avalanche',
+      strategyReasoning: '',
+      payoffOrder: [{ debtName: 'Debt', priority: 1 }],
+      summary: '',
+    });
+    const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
+    await expect(
+      suggestDebtStrategy({
+        debts: [{ ...validDebt, interestRate: 150 }],
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects negative payoff order priority', async () => {
+    jest.resetModules();
+    setupValidationMocks({
+      recommendedStrategy: 'avalanche',
+      strategyReasoning: '',
+      payoffOrder: [{ debtName: 'Debt', priority: -1 }],
+      summary: '',
+    });
+    const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
+    await expect(
+      suggestDebtStrategy({ debts: [validDebt] })
+    ).rejects.toThrow();
+  });
+});

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -15,12 +15,15 @@ import {z} from 'genkit';
 const CalculateCashflowInputSchema = z.object({
   annualIncome: z
     .number()
+    .min(0)
     .describe('Total annual gross income from all sources.'),
   estimatedAnnualTaxes: z
     .number()
+    .min(0)
     .describe('Estimated total annual taxes (federal, state, local).'),
   totalMonthlyDeductions: z
     .number()
+    .min(0)
     .describe('Total of all monthly deductions and expenses (e.g., rent, loans, utilities, groceries).'),
 });
 export type CalculateCashflowInput = z.infer<typeof CalculateCashflowInputSchema>;
@@ -28,9 +31,11 @@ export type CalculateCashflowInput = z.infer<typeof CalculateCashflowInputSchema
 const CalculateCashflowOutputSchema = z.object({
   grossMonthlyIncome: z
     .number()
+    .min(0)
     .describe('The gross monthly income, calculated as annual income divided by 12.'),
   netMonthlyIncome: z
     .number()
+    .min(0)
     .describe('The net monthly income, calculated as gross monthly income minus monthly taxes and deductions.'),
   analysis: z
     .string()

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -16,10 +16,10 @@ import { RecurrenceValues } from '@/lib/types';
 const DebtSchema = z.object({
     id: z.string(),
     name: z.string(),
-    initialAmount: z.number(),
-    currentAmount: z.number(),
-    interestRate: z.number(),
-    minimumPayment: z.number(),
+    initialAmount: z.number().min(0),
+    currentAmount: z.number().min(0),
+    interestRate: z.number().min(0).max(100),
+    minimumPayment: z.number().min(0),
     dueDate: z.string(),
     recurrence: z.enum(RecurrenceValues),
 });
@@ -34,7 +34,7 @@ const SuggestDebtStrategyOutputSchema = z.object({
   strategyReasoning: z.string().describe("The reasoning behind the recommended strategy."),
   payoffOrder: z.array(z.object({
       debtName: z.string(),
-      priority: z.number(),
+      priority: z.number().min(0),
   })).describe("The recommended order to pay off the debts, starting with priority 1."),
   summary: z.string().describe("A brief, encouraging summary of the plan."),
 });

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -15,9 +15,11 @@ import {z} from 'genkit';
 const TaxEstimationInputSchema = z.object({
   income: z
     .number()
+    .min(0)
     .describe('Annual income in USD.'),
   deductions: z
     .number()
+    .min(0)
     .describe('Total deductions in USD.'),
   location: z
     .string()
@@ -30,9 +32,12 @@ export type TaxEstimationInput = z.infer<typeof TaxEstimationInputSchema>;
 const TaxEstimationOutputSchema = z.object({
   estimatedTax: z
     .number()
+    .min(0)
     .describe('Estimated total tax amount in USD.'),
   taxRate: z
     .number()
+    .min(0)
+    .max(100)
     .describe('Estimated effective tax rate as a percentage.'),
   breakdown: z
     .string()


### PR DESCRIPTION
## Summary
- require non-negative numbers for cashflow, tax estimation, and debt strategy flows
- cap percentages like tax and interest rates at 100
- add tests verifying negative and out-of-range values are rejected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b059ab62c0833188dd6eeb1d60b4cb