### PR TITLE
Add data URI validation for AI flows

### DIFF
--- a/src/ai/flows/__tests__/data-uri-validation.test.ts
+++ b/src/ai/flows/__tests__/data-uri-validation.test.ts
@@ -1,0 +1,100 @@
+function setupAnalyzeReceiptMocks() {
+  const definePromptMock = jest
+    .fn()
+    .mockReturnValue(async () => ({
+      output: { description: 'desc', amount: 1, category: 'cat' },
+    }));
+  const defineFlowMock = jest.fn((config: any, handler: any) => async (input: any) => {
+    const parsed = config.inputSchema.parse(input);
+    return handler(parsed);
+  });
+  jest.doMock('@/ai/genkit', () => ({
+    ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock },
+  }));
+}
+
+function setupAnalyzeSpendingMocks() {
+  const definePromptMock = jest
+    .fn()
+    .mockReturnValue(async () => ({
+      output: {
+        spendingAnalysis: 'analysis',
+        savingsOpportunities: 'savings',
+        recommendations: 'recommendations',
+      },
+    }));
+  const defineFlowMock = jest.fn((config: any, handler: any) => async (input: any) => {
+    const parsed = config.inputSchema.parse(input);
+    return handler(parsed);
+  });
+  jest.doMock('@/ai/genkit', () => ({
+    ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock },
+  }));
+}
+
+describe('AnalyzeReceiptInputSchema', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    setupAnalyzeReceiptMocks();
+  });
+
+  it('accepts valid data URI', async () => {
+    const { analyzeReceipt } = await import('@/ai/flows/analyze-receipt');
+    await expect(
+      analyzeReceipt({ receiptImage: 'data:image/png;base64,AAA=' })
+    ).resolves.toEqual({ description: 'desc', amount: 1, category: 'cat' });
+  });
+
+  it('rejects invalid data URI', async () => {
+    const { analyzeReceipt } = await import('@/ai/flows/analyze-receipt');
+    await expect(
+      analyzeReceipt({ receiptImage: 'not-a-data-uri' })
+    ).rejects.toThrow();
+  });
+});
+
+describe('AnalyzeSpendingHabitsInputSchema', () => {
+  const baseInput = {
+    userDescription: 'desc',
+    goals: [
+      {
+        id: '1',
+        name: 'Goal',
+        targetAmount: 100,
+        currentAmount: 10,
+        deadline: '2025-01-01',
+        importance: 3,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    setupAnalyzeSpendingMocks();
+  });
+
+  it('accepts valid data URI', async () => {
+    const { analyzeSpendingHabits } = await import('@/ai/flows/analyze-spending-habits');
+    await expect(
+      analyzeSpendingHabits({
+        financialDocuments: ['data:application/pdf;base64,AAA='],
+        ...baseInput,
+      })
+    ).resolves.toEqual({
+      spendingAnalysis: 'analysis',
+      savingsOpportunities: 'savings',
+      recommendations: 'recommendations',
+    });
+  });
+
+  it('rejects invalid data URI', async () => {
+    const { analyzeSpendingHabits } = await import('@/ai/flows/analyze-spending-habits');
+    await expect(
+      analyzeSpendingHabits({
+        financialDocuments: ['not-a-data-uri'],
+        ...baseInput,
+      })
+    ).rejects.toThrow();
+  });
+});
+

--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -15,6 +15,9 @@ import {z} from 'genkit';
 const AnalyzeReceiptInputSchema = z.object({
   receiptImage: z
     .string()
+    .regex(/^data:[\w/-]+;base64,[A-Za-z0-9+/=]+$/, {
+      message: 'receiptImage must be a valid base64-encoded data URI.',
+    })
     .describe(
       "An image of a receipt, as a data URI that must include a MIME type and use Base64 encoding. Expected format: 'data:<mimetype>;base64,<encoded_data>'."
     ),

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -25,7 +25,11 @@ const GoalSchema = z.object({
 
 const AnalyzeSpendingHabitsInputSchema = z.object({
   financialDocuments: z
-    .array(z.string())
+    .array(
+      z.string().regex(/^data:[\w/-]+;base64,[A-Za-z0-9+/=]+$/, {
+        message: 'Each document must be a valid base64-encoded data URI.',
+      })
+    )
     .describe(
       'An array of financial documents as data URIs that must include a MIME type and use Base64 encoding. Expected format: data:<mimetype>;base64,<encoded_data>.'
     ),


### PR DESCRIPTION
## Summary
- validate analyzeReceipt receiptImage as base64 data URI
- validate analyzeSpendingHabits financialDocuments as base64 data URIs
- test valid and invalid data URI inputs for both flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b059ac731883318e2a68cdceb88b7d