### PR TITLE
feat: improve offline sync reliability

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -2,6 +2,8 @@ importScripts("https://cdn.jsdelivr.net/npm/idb@7/build/iife/index-min.js")
 
 const DB_NAME = "offline-db"
 const STORE_NAME = "transactions"
+const MAX_QUEUE = 50
+const STALE_AGE = 7 * 24 * 60 * 60 * 1000 // one week
 
 const dbPromise = idb.openDB(DB_NAME, 1, {
   upgrade(db) {
@@ -24,7 +26,25 @@ self.addEventListener("fetch", event => {
           const clone = request.clone()
           const body = await clone.json()
           const db = await dbPromise
-          await db.add(STORE_NAME, body)
+          const tx = db.transaction(STORE_NAME, "readwrite")
+          const store = tx.store
+          const now = Date.now()
+
+          let count = await store.count()
+          let cursor = await store.openCursor()
+          while (cursor) {
+            const value = cursor.value
+            const isStale = value.timestamp && value.timestamp < now - STALE_AGE
+            if (isStale || count >= MAX_QUEUE) {
+              await cursor.delete()
+              count--
+            }
+            cursor = await cursor.continue()
+          }
+
+          await store.add({ data: body, timestamp: now })
+          await tx.done
+
           return new Response(JSON.stringify({ offline: true }), {
             status: 202,
             headers: { "Content-Type": "application/json" },

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -3,45 +3,60 @@
 import { useEffect, useRef } from "react"
 import { getQueuedTransactions, clearQueuedTransactions } from "@/lib/offline"
 import { auth } from "@/lib/firebase"
+import { useToast } from "@/hooks/use-toast"
 
 export function ServiceWorker() {
-  const debounceId = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const retryTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { toast } = useToast()
 
   useEffect(() => {
-    const handleOnline = () => {
-      if (debounceId.current) clearTimeout(debounceId.current)
+    const MAX_RETRIES = 5
+    const BASE_DELAY = 1000
 
-      debounceId.current = setTimeout(async () => {
-        const queued = await getQueuedTransactions()
-        if (queued.length) {
-          try {
-            const user = auth.currentUser
-            const token = user ? await user.getIdToken() : null
-            if (!token) {
-              console.error("Cannot sync queued transactions without auth")
-              return
-            }
-            const response = await fetch("/api/transactions/sync", {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
-              },
-              body: JSON.stringify({ transactions: queued }),
-            })
-            if (!response.ok) {
-              console.error(
-                "Failed to sync queued transactions",
-                await response.text()
-              )
-              return
-            }
-            await clearQueuedTransactions()
-          } catch (error) {
-            console.error("Failed to sync queued transactions", error)
-          }
+    const attemptSync = async (attempt = 0): Promise<void> => {
+      const queued = await getQueuedTransactions()
+      if (!queued.length) return
+      try {
+        const user = auth.currentUser
+        const token = user ? await user.getIdToken() : null
+        if (!token) {
+          console.error("Cannot sync queued transactions without auth")
+          return
         }
-      }, 1000)
+        const response = await fetch("/api/transactions/sync", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ transactions: queued }),
+        })
+        if (!response.ok) {
+          throw new Error(await response.text())
+        }
+        await clearQueuedTransactions()
+      } catch (error) {
+        console.error("Failed to sync queued transactions", error)
+        if (attempt >= MAX_RETRIES - 1) {
+          toast({
+            title: "Sync failed",
+            description:
+              "Unable to sync offline transactions. We'll keep them queued.",
+            variant: "destructive",
+          })
+          return
+        }
+        const delay = Math.pow(2, attempt) * BASE_DELAY
+        retryTimeout.current = setTimeout(
+          () => attemptSync(attempt + 1),
+          delay
+        )
+      }
+    }
+
+    const handleOnline = () => {
+      if (retryTimeout.current) clearTimeout(retryTimeout.current)
+      attemptSync()
     }
 
     const registerAndListen = async () => {
@@ -61,9 +76,9 @@ export function ServiceWorker() {
 
     return () => {
       window.removeEventListener("online", handleOnline)
-      if (debounceId.current) clearTimeout(debounceId.current)
+      if (retryTimeout.current) clearTimeout(retryTimeout.current)
     }
-  }, [])
+  }, [toast])
 
   return null
 }

--- a/src/lib/offline.ts
+++ b/src/lib/offline.ts
@@ -11,12 +11,13 @@ const dbPromise = openDB(DB_NAME, 1, {
 
 export async function queueTransaction(tx: unknown) {
   const db = await dbPromise
-  await db.add(STORE_NAME, tx)
+  await db.add(STORE_NAME, { data: tx, timestamp: Date.now() })
 }
 
 export async function getQueuedTransactions<T = unknown>() {
   const db = await dbPromise
-  return db.getAll(STORE_NAME) as Promise<T[]>
+  const entries = await db.getAll(STORE_NAME)
+  return entries.map((e: any) => ("data" in e ? e.data : e)) as T[]
 }
 
 export async function clearQueuedTransactions() {


### PR DESCRIPTION
## Summary
- add exponential backoff and toast notifications for offline sync failures
- persist timestamped transactions and limit/purge queue in service worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b05a808c948331a095a310d7d9dd0a