### PR TITLE
feat: tighten script CSP

### DIFF
--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -4,7 +4,7 @@ This project defines security headers in `next.config.ts` for all routes. Any ad
 
 ## Required Headers
 
-- **Content-Security-Policy**: `default-src 'self'; script-src 'self' 'nonce-<nonce>' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'`
+- **Content-Security-Policy**: `default-src 'self'; script-src 'self' 'nonce-<nonce>'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'`
 - **X-Frame-Options**: `DENY`
 - **X-Content-Type-Options**: `nosniff`
 - **Referrer-Policy**: `strict-origin-when-cross-origin`

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
-      `script-src 'self' 'nonce-${cspNonce}' 'unsafe-inline' 'unsafe-eval'`,
+      `script-src 'self' 'nonce-${cspNonce}'`,
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: https:",
       "font-src 'self'",


### PR DESCRIPTION
## Summary
- drop `unsafe-inline` and `unsafe-eval` from `script-src` and rely on nonces
- document stricter CSP requirements
- remove external `importScripts` in service worker and use IndexedDB helper

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any ...)*
- `npm run build` *(fails: ESLint errors during build)*
- `npm run dev` & `curl -I http://127.0.0.1:3000`

------
https://chatgpt.com/codex/tasks/task_e_68b05a818cd48331a1715094a3b28cd3