### PR TITLE
Validate transactions with schema

### DIFF
--- a/src/__tests__/api-validation.test.ts
+++ b/src/__tests__/api-validation.test.ts
@@ -30,6 +30,16 @@ describe("/api/bank/import", () => {
     const res = await bankImport(req)
     expect(res.status).toBe(400)
   })
+
+  it("returns 400 when transactions are invalid", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ provider: "bank", transactions: [{ id: "1" }] }),
+    })
+    const res = await bankImport(req)
+    expect(res.status).toBe(400)
+  })
 })
 
 describe("/api/transactions/sync", () => {
@@ -54,6 +64,16 @@ describe("/api/transactions/sync", () => {
       method: "POST",
       headers: { Authorization: "Bearer test-token" },
       body: JSON.stringify({ transactions: "not-array" }),
+    })
+    const res = await transactionsSync(req)
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when transactions are invalid", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ transactions: [{ id: "1" }] }),
     })
     const res = await transactionsSync(req)
     expect(res.status).toBe(400)

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
+import { TransactionSchema } from "@/lib/types"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -9,7 +10,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
  */
 const bodySchema = z.object({
   provider: z.string(),
-  transactions: z.array(z.any()),
+  transactions: z.array(TransactionSchema),
 })
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
+import { TransactionSchema } from "@/lib/types"
 
 /**
  * Generic transaction syncing endpoint.
@@ -8,7 +9,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
  * from any source and persists them to the database.
  */
 const bodySchema = z.object({
-  transactions: z.array(z.any()),
+  transactions: z.array(TransactionSchema),
 })
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,14 +1,17 @@
+import { z } from "zod";
 
-export type Transaction = {
-  id: string;
-  date: string;
-  description: string;
-  amount: number;
-  currency: string; // ISO currency code
-  type: "Income" | "Expense";
-  category: string;
-  isRecurring?: boolean;
-};
+export const TransactionSchema = z.object({
+  id: z.string(),
+  date: z.string(),
+  description: z.string(),
+  amount: z.number(),
+  currency: z.string(), // ISO currency code
+  type: z.enum(["Income", "Expense"]),
+  category: z.string(),
+  isRecurring: z.boolean().optional(),
+});
+
+export type Transaction = z.infer<typeof TransactionSchema>;
 
 export type Goal = {
   id: string;


### PR DESCRIPTION
## Summary
- add a zod `TransactionSchema` and export corresponding `Transaction` type
- validate bank import and transaction sync routes with `TransactionSchema`
- test that invalid transactions are rejected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05a8337348331822d13b4de5932c7