### PR TITLE
feat: add centralized logger for housekeeping

### DIFF
--- a/src/lib/housekeeping.ts
+++ b/src/lib/housekeeping.ts
@@ -1,4 +1,5 @@
 import { getAuth } from "firebase/auth";
+import { logger } from "./logger";
 
 // Placeholder housekeeping service that cleans up outdated data.
 // Replace with actual implementation as needed.
@@ -6,5 +7,7 @@ export async function runHousekeeping(): Promise<void> {
   // Example: ensure auth SDK is initialized to avoid cold-start costs
   // and perform cleanup tasks such as removing expired sessions.
   getAuth();
-  console.log("Housekeeping job executed");
+  if (process.env.NEXT_PUBLIC_ENABLE_HOUSEKEEPING_LOG === "true") {
+    logger.info("Housekeeping job executed: Firebase auth initialized");
+  }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,7 @@
+export const logger = {
+  info: (message: string, ...args: unknown[]) => {
+    if (process.env.NODE_ENV !== "production") {
+      console.log(message, ...args);
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- add lightweight logger utility
- use environment-gated logger in housekeeping

## Testing
- `npm run lint` *(fails: Unexpected any and other existing lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0694a3d9883318e28e3d2b9a3e172