### PR TITLE
feat: validate bank import transactions

### DIFF
--- a/src/__tests__/api-validation.test.ts
+++ b/src/__tests__/api-validation.test.ts
@@ -30,6 +30,16 @@ describe("/api/bank/import", () => {
     const res = await bankImport(req)
     expect(res.status).toBe(400)
   })
+
+  it("returns 400 when transactions contain invalid entries", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ provider: "test", transactions: [{ id: "1" }] }),
+    })
+    const res = await bankImport(req)
+    expect(res.status).toBe(400)
+  })
 })
 
 describe("/api/transactions/sync", () => {

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -7,9 +7,20 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
  * This endpoint deals with provider-specific payloads and is distinct from the
  * generic transaction syncing endpoint at `/api/transactions/sync`.
  */
+const transactionSchema = z.object({
+  id: z.string(),
+  date: z.string(),
+  description: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  type: z.enum(["Income", "Expense"]),
+  category: z.string(),
+  isRecurring: z.boolean().optional(),
+})
+
 const bodySchema = z.object({
   provider: z.string(),
-  transactions: z.array(z.any()),
+  transactions: z.array(transactionSchema),
 })
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB


### PR DESCRIPTION
## Summary
- add transactionSchema for bank import API
- validate transactions array against schema
- test invalid transaction entries are rejected

## Testing
- `npm test`
- `npm run lint src/app/api/bank/import/route.ts src/__tests__/api-validation.test.ts` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0694ac0f08331b235a81bc54443cf