### PR TITLE
feat: introduce ChartPoint type for chart data

### DIFF
--- a/src/app/dashboard/dashboard-charts.tsx
+++ b/src/app/dashboard/dashboard-charts.tsx
@@ -10,11 +10,13 @@ import {
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import RecentTransactions from "@/components/dashboard/recent-transactions";
-import type { Transaction } from "@/lib/types";
+import type { Transaction, ChartPoint } from "@/lib/types";
 
 // This file is now a client component module.
 // The dynamic import for the chart component is defined here.
-const IncomeExpenseChartClient = dynamic(
+const IncomeExpenseChartClient = dynamic<{
+  data: ChartPoint[];
+}>(
   () => import("@/components/dashboard/income-expense-chart"),
   {
     ssr: false,
@@ -36,7 +38,7 @@ const IncomeExpenseChartClient = dynamic(
 
 interface DashboardChartsProps {
     transactions: Transaction[];
-    chartData: any[];
+    chartData: ChartPoint[];
 }
 
 export default function DashboardCharts({ transactions, chartData }: DashboardChartsProps) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import DashboardCharts from '@/app/dashboard/dashboard-charts';
 import { mockTransactions } from "@/lib/data";
-import type { Transaction } from "@/lib/types";
+import type { Transaction, ChartPoint } from "@/lib/types";
 
 // Server-side data fetching now happens in the page component.
 const getTransactions = async (): Promise<Transaction[]> => {
@@ -12,7 +12,7 @@ const getTransactions = async (): Promise<Transaction[]> => {
   return mockTransactions;
 };
 
-const getChartData = async () => {
+const getChartData = async (): Promise<ChartPoint[]> => {
   // Replace with real data fetching when an API is available
   return [
     { month: "Jan", income: 4000, expenses: 2400 },
@@ -26,9 +26,9 @@ const getChartData = async () => {
 };
 
 export default async function DashboardPage() {
-  const [transactions, chartData] = await Promise.all([
+  const [transactions, chartData]: [Transaction[], ChartPoint[]] = await Promise.all([
     getTransactions(),
-    getChartData()
+    getChartData(),
   ]);
 
   return (

--- a/src/components/dashboard/income-expense-chart.tsx
+++ b/src/components/dashboard/income-expense-chart.tsx
@@ -15,9 +15,10 @@ import {
   ChartLegendContent,
 } from "@/components/ui/chart";
 import { BarChart, Bar, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { ChartPoint } from "@/lib/types";
 
 interface IncomeExpenseChartProps {
-  data: { month: string; income: number; expenses: number }[];
+  data: ChartPoint[];
 }
 
 export default function IncomeExpenseChart({ data }: IncomeExpenseChartProps) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,12 @@ export type Goal = {
   importance: number; // New field: 1-5 rating
 };
 
+export interface ChartPoint {
+  month: string;
+  income: number;
+  expenses: number;
+}
+
 export const RecurrenceValues = ["none", "weekly", "biweekly", "monthly"] as const;
 export type Recurrence = typeof RecurrenceValues[number];
 


### PR DESCRIPTION
## Summary
- define `ChartPoint` interface for income and expense data points
- type dashboard chart props and page data fetching with `ChartPoint[]`
- update chart component to use the new typed data

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68b0694b1a308331bddbb835490cf91e