### PR TITLE
Use manual pagination for transactions table

### DIFF
--- a/src/__tests__/transactions-table.test.tsx
+++ b/src/__tests__/transactions-table.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TransactionsTable } from '@/components/transactions/transactions-table';
+jest.mock('lucide-react', () => ({ Repeat: () => null }));
+
+type Tx = {
+  id: string;
+  date: string;
+  description: string;
+  category: string;
+  type: 'Income' | 'Expense';
+  amount: number;
+  currency: string;
+  isRecurring: boolean;
+};
+
+function makeTransactions(count: number): Tx[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `tx-${i}`,
+    date: '2024-01-01',
+    description: `Transaction ${i + 1}`,
+    category: 'Misc',
+    type: 'Income',
+    amount: 100,
+    currency: 'USD',
+    isRecurring: false,
+  }));
+}
+
+describe('TransactionsTable', () => {
+  it('paginates transactions', () => {
+    const transactions = makeTransactions(25);
+    render(<TransactionsTable transactions={transactions} />);
+
+    // first page
+    expect(screen.getByText('Transaction 1')).toBeInTheDocument();
+    expect(screen.queryByText('Transaction 21')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(screen.getByText('Transaction 21')).toBeInTheDocument();
+    expect(screen.queryByText('Transaction 1')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/transactions/transactions-table.tsx
+++ b/src/components/transactions/transactions-table.tsx
@@ -11,32 +11,18 @@ import { cn } from "@/lib/utils"
 import type { Transaction } from "@/lib/types"
 import { Repeat } from "lucide-react"
 import { formatCurrency } from "@/lib/currency"
-import {
-  memo,
-  useMemo,
-  useState,
-  forwardRef,
-  type HTMLAttributes,
-  type ComponentType,
-} from "react"
-import { FixedSizeList, type ListChildComponentProps } from "react-window"
+import { memo, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 
 interface TransactionsTableProps {
   transactions: Transaction[]
-  /** Height of the scrollable list in pixels */
-  height?: number
-  /** Height of each row in pixels */
-  rowHeight?: number
 }
 
 export const TransactionsTable = memo(function TransactionsTable({
   transactions,
-  height = 400,
-  rowHeight = 56,
 }: TransactionsTableProps) {
   const [page, setPage] = useState(0)
-  const [pageSize] = useState(20)
+  const pageSize = 20
 
   const currentTransactions = useMemo(
     () =>
@@ -52,47 +38,6 @@ export const TransactionsTable = memo(function TransactionsTable({
     [transactions, page, pageSize],
   )
 
-  const Row = ({ index, style }: ListChildComponentProps) => {
-    const transaction = currentTransactions[index]
-    return (
-      <TableRow style={style} key={transaction.id}>
-        <TableCell>{transaction.formattedDate}</TableCell>
-        <TableCell className="font-medium">{transaction.description}</TableCell>
-        <TableCell>
-          <Badge variant="outline">{transaction.category}</Badge>
-        </TableCell>
-        <TableCell>
-          {transaction.isRecurring && (
-            <Repeat className="h-4 w-4 text-muted-foreground" />
-          )}
-        </TableCell>
-        <TableCell
-          className={cn(
-            "text-right",
-            transaction.type === "Income" ? "text-green-600" : "text-red-600",
-            "dark:text-inherit",
-          )}
-        >
-          {transaction.formattedAmount}
-        </TableCell>
-      </TableRow>
-    )
-  }
-
-  const Outer: ComponentType<HTMLAttributes<HTMLDivElement>> =
-    forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-      ({ style, children, ...props }, ref) => (
-        <div ref={ref} style={{ ...style, overflow: "auto" }} {...props}>
-          <Table>{children}</Table>
-        </div>
-      ),
-    )
-
-  const Inner: ComponentType<HTMLAttributes<HTMLTableSectionElement>> =
-    forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSectionElement>>(
-      (props, ref) => <TableBody ref={ref} {...props} />,
-    )
-
   return (
     <div className="rounded-lg border">
       <Table>
@@ -105,18 +50,36 @@ export const TransactionsTable = memo(function TransactionsTable({
             <TableHead className="text-right">Amount</TableHead>
           </TableRow>
         </TableHeader>
+        <TableBody>
+          {currentTransactions.map((transaction) => (
+            <TableRow key={transaction.id}>
+              <TableCell>{transaction.formattedDate}</TableCell>
+              <TableCell className="font-medium">
+                {transaction.description}
+              </TableCell>
+              <TableCell>
+                <Badge variant="outline">{transaction.category}</Badge>
+              </TableCell>
+              <TableCell>
+                {transaction.isRecurring && (
+                  <Repeat className="h-4 w-4 text-muted-foreground" />
+                )}
+              </TableCell>
+              <TableCell
+                className={cn(
+                  "text-right",
+                  transaction.type === "Income"
+                    ? "text-green-600"
+                    : "text-red-600",
+                  "dark:text-inherit",
+                )}
+              >
+                {transaction.formattedAmount}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
       </Table>
-      <FixedSizeList
-        height={height}
-        itemCount={currentTransactions.length}
-        itemSize={rowHeight}
-        width="100%"
-        outerElementType={Outer}
-        innerElementType={Inner}
-        itemKey={(index) => currentTransactions[index].id}
-      >
-        {Row}
-      </FixedSizeList>
       <div className="flex justify-between p-4">
         <Button
           variant="outline"


### PR DESCRIPTION
## Summary
- render transactions using manual pagination
- drop react-window virtualization
- test table navigation behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0694fe228833181cdaf9fd04deafd