### PR TITLE
Handle invalid JSON in service worker offline queue

### DIFF
--- a/src/__tests__/service-worker-invalid.test.ts
+++ b/src/__tests__/service-worker-invalid.test.ts
@@ -1,0 +1,39 @@
+const listeners: Record<string, (e: any) => void> = {}
+;(globalThis as any).self = { addEventListener: (type: string, cb: any) => { listeners[type] = cb } }
+;(globalThis as any).importScripts = jest.fn()
+
+const addMock = jest.fn()
+;(globalThis as any).idb = { openDB: jest.fn(async () => ({ add: addMock })) }
+
+require('../../public/sw.js')
+
+describe('service worker invalid payload', () => {
+  it('logs warning and stores raw text when JSON parsing fails', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    ;(globalThis as any).fetch = jest.fn(() => Promise.reject(new Error('offline')))
+
+    const request = {
+      method: 'POST',
+      url: 'https://example.com/api/transactions',
+      headers: { get: () => 'application/json' },
+      clone: () => ({
+        json: () => Promise.reject(new Error('invalid')),
+        text: () => Promise.resolve('not-json'),
+      }),
+    }
+
+    let responsePromise: Promise<Response> | undefined
+    const event = {
+      request,
+      respondWith: (p: Promise<Response>) => {
+        responsePromise = p
+      },
+    }
+
+    listeners.fetch(event)
+    await responsePromise
+    expect(addMock).toHaveBeenCalledWith('transactions', 'not-json')
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- validate request content type before JSON parsing in service worker
- fall back to storing raw request text when JSON parsing fails
- add Jest test covering invalid payload handling in the service worker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06950c0fc8331a570950c20fb0404