### PR TITLE
Validate currency codes in FX utilities

### DIFF
--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -1,0 +1,52 @@
+import { getFxRate, convertCurrency } from '@/lib/currency';
+
+describe('currency code validation', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('getFxRate returns rate for valid codes', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rates: { EUR: 0.85 } }),
+    });
+    (global as any).fetch = mockFetch;
+
+    const rate = await getFxRate('usd', 'eur');
+
+    expect(rate).toBe(0.85);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.exchangerate.host/latest?base=USD&symbols=EUR',
+    );
+  });
+
+  it('getFxRate throws on invalid code', async () => {
+    const mockFetch = jest.fn();
+    (global as any).fetch = mockFetch;
+
+    await expect(getFxRate('US', 'EUR')).rejects.toThrow('Invalid currency code');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('convertCurrency returns converted amount for valid codes', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rates: { EUR: 0.5 } }),
+    });
+    (global as any).fetch = mockFetch;
+
+    const converted = await convertCurrency(10, 'usd', 'eur');
+
+    expect(converted).toBe(5);
+  });
+
+  it('convertCurrency returns original amount for invalid codes', async () => {
+    const mockFetch = jest.fn();
+    (global as any).fetch = mockFetch;
+
+    const converted = await convertCurrency(10, 'u$', 'eur');
+
+    expect(converted).toBe(10);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,20 +1,36 @@
+import { z } from 'zod';
+
+const currencyCodeSchema = z.string().regex(/^[A-Z]{3}$/);
+
+function parseCurrencyCode(code: string): string {
+  const parsed = currencyCodeSchema.safeParse(code.trim().toUpperCase());
+  if (!parsed.success) {
+    throw new Error('Invalid currency code');
+  }
+  return parsed.data;
+}
+
 export async function getFxRate(from: string, to: string): Promise<number> {
-  if (from === to) return 1;
+  const fromCode = parseCurrencyCode(from);
+  const toCode = parseCurrencyCode(to);
+  if (fromCode === toCode) return 1;
   let res: Response;
   try {
     res = await fetch(
-      `https://api.exchangerate.host/latest?base=${from}&symbols=${to}`,
+      `https://api.exchangerate.host/latest?base=${fromCode}&symbols=${toCode}`,
     );
   } catch (err) {
     throw new Error(
-      `Network error while fetching FX rates: ${err instanceof Error ? err.message : err}`,
+      `Network error while fetching FX rates: ${
+        err instanceof Error ? err.message : err
+      }`,
     );
   }
   if (!res.ok) {
     throw new Error('Failed to fetch FX rates');
   }
   const data = await res.json();
-  const rate = data?.rates?.[to];
+  const rate = data?.rates?.[toCode];
   if (typeof rate !== 'number') {
     throw new Error('Invalid FX rate data');
   }


### PR DESCRIPTION
## Summary
- validate currency codes using Zod
- sanitize inputs before requesting exchange rates
- add unit tests for currency code validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b06951b608833194b64409b6f99c86