### PR TITLE
Validate data URI inputs for AI flows

### DIFF
--- a/src/ai/flows/__tests__/data-uri-validation.test.ts
+++ b/src/ai/flows/__tests__/data-uri-validation.test.ts
@@ -1,0 +1,65 @@
+import { MAX_DATA_URI_SIZE } from '@/ai/flows/utils';
+
+function setupValidationMocks() {
+  const promptFn = jest.fn();
+  const definePromptMock = jest.fn().mockReturnValue(promptFn);
+  const defineFlowMock = jest.fn((_config: any, handler: any) => handler);
+  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+  return { promptFn };
+}
+
+describe('analyzeReceipt input validation', () => {
+  it('rejects invalid data URI', async () => {
+    jest.resetModules();
+    const { promptFn } = setupValidationMocks();
+    const { analyzeReceipt } = await import('@/ai/flows/analyze-receipt');
+    await expect(
+      analyzeReceipt({ receiptImage: 'not-a-data-uri' })
+    ).rejects.toThrow('receiptImage: Invalid data URI format');
+    expect(promptFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized data URI', async () => {
+    jest.resetModules();
+    const { promptFn } = setupValidationMocks();
+    const { analyzeReceipt } = await import('@/ai/flows/analyze-receipt');
+    const largeBuffer = Buffer.alloc(MAX_DATA_URI_SIZE + 1);
+    const largeDataUri = `data:image/png;base64,${largeBuffer.toString('base64')}`;
+    await expect(
+      analyzeReceipt({ receiptImage: largeDataUri })
+    ).rejects.toThrow('receiptImage: Data URI exceeds');
+    expect(promptFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('analyzeSpendingHabits input validation', () => {
+  it('rejects invalid data URI', async () => {
+    jest.resetModules();
+    const { promptFn } = setupValidationMocks();
+    const { analyzeSpendingHabits } = await import('@/ai/flows/analyze-spending-habits');
+    await expect(
+      analyzeSpendingHabits({
+        financialDocuments: ['not-a-data-uri'],
+        userDescription: 'desc',
+        goals: [],
+      })
+    ).rejects.toThrow('financialDocuments.0: Invalid data URI format');
+    expect(promptFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized data URI', async () => {
+    jest.resetModules();
+    const { promptFn } = setupValidationMocks();
+    const { analyzeSpendingHabits } = await import('@/ai/flows/analyze-spending-habits');
+    const largeBuffer = Buffer.alloc(MAX_DATA_URI_SIZE + 1);
+    const largeDataUri = `data:application/pdf;base64,${largeBuffer.toString('base64')}`;
+    await expect(
+      analyzeSpendingHabits({
+        financialDocuments: [largeDataUri],
+        userDescription: 'desc',
+        goals: [],
+      })
+    ).rejects.toThrow('financialDocuments.0: Data URI exceeds');
+    expect(promptFn).not.toHaveBeenCalled();
+  });
+});

--- a/src/ai/flows/utils.ts
+++ b/src/ai/flows/utils.ts
@@ -1,0 +1,23 @@
+import { z } from 'genkit';
+
+export const MAX_DATA_URI_SIZE = 10 * 1024 * 1024; // 10MB
+
+export const dataUriSchema = z
+  .string()
+  .regex(
+    /^data:[a-zA-Z0-9.+-]+\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+$/,
+    "Invalid data URI format. Expected 'data:<mimetype>;base64,<encoded_data>'",
+  )
+  .refine(
+    value => {
+      const base64 = value.split(',')[1];
+      if (!base64) {
+        return false;
+      }
+      // Ensure the decoded content does not exceed the maximum allowed size.
+      return Buffer.from(base64, 'base64').byteLength <= MAX_DATA_URI_SIZE;
+    },
+    {
+      message: `Data URI exceeds ${MAX_DATA_URI_SIZE} bytes`,
+    },
+  );


### PR DESCRIPTION
## Summary
- enforce data URI and size validation on receipt and spending analysis flows
- add shared `dataUriSchema` for reusable validation logic
- cover invalid and oversized data URIs with new tests

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, require imports, no-constant-condition)*

------
https://chatgpt.com/codex/tasks/task_e_68b0695962cc8331bf3494de04edd272