### PR TITLE
Reject oversized API payloads early

### DIFF
--- a/src/__tests__/payload-size-limit.test.ts
+++ b/src/__tests__/payload-size-limit.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment node
+ */
+import { Readable } from "stream"
+import { POST as bankImport } from "@/app/api/bank/import/route"
+import { POST as transactionsSync } from "@/app/api/transactions/sync/route"
+
+const MAX_BODY_SIZE = 1024 * 1024
+
+function createOversizedRequest() {
+  let read = false
+  const stream = new Readable({
+    read() {
+      read = true
+      this.push("a")
+      this.push(null)
+    },
+  })
+  const req = new Request("http://localhost", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer test-token",
+      "content-length": String(MAX_BODY_SIZE + 1),
+    },
+    body: stream,
+    // Node's Request type requires duplex when using a stream body
+    duplex: "half" as any,
+  })
+  return { req, read: () => read }
+}
+
+describe("payload size limits", () => {
+  it("rejects oversized /api/bank/import payload without reading body", async () => {
+    const { req, read } = createOversizedRequest()
+    const res = await bankImport(req)
+    expect(res.status).toBe(413)
+    expect(read()).toBe(false)
+  })
+
+  it("rejects oversized /api/transactions/sync payload without reading body", async () => {
+    const { req, read } = createOversizedRequest()
+    const res = await transactionsSync(req)
+    expect(res.status).toBe(413)
+    expect(read()).toBe(false)
+  })
+})

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -14,6 +14,34 @@ const bodySchema = z.object({
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
+async function readBodyWithLimit(req: Request, limit: number) {
+  const contentLength = req.headers.get("content-length")
+  if (contentLength && Number(contentLength) > limit) {
+    return null
+  }
+
+  const reader = req.body?.getReader()
+  if (!reader) {
+    return ""
+  }
+  const decoder = new TextDecoder()
+  let total = 0
+  let result = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) {
+      total += value.length
+      if (total > limit) {
+        return null
+      }
+      result += decoder.decode(value, { stream: true })
+    }
+  }
+  result += decoder.decode()
+  return result
+}
+
 export async function POST(req: Request) {
   try {
     await verifyFirebaseToken(req)
@@ -22,13 +50,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: message }, { status: 401 })
   }
 
-  let text: string
-  try {
-    text = await req.text()
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
-  }
-  if (new TextEncoder().encode(text).byteLength > MAX_BODY_SIZE) {
+  const text = await readBodyWithLimit(req, MAX_BODY_SIZE)
+  if (text === null) {
     return NextResponse.json({ error: "Payload too large" }, { status: 413 })
   }
 

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -13,6 +13,34 @@ const bodySchema = z.object({
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
+async function readBodyWithLimit(req: Request, limit: number) {
+  const contentLength = req.headers.get("content-length")
+  if (contentLength && Number(contentLength) > limit) {
+    return null
+  }
+
+  const reader = req.body?.getReader()
+  if (!reader) {
+    return ""
+  }
+  const decoder = new TextDecoder()
+  let total = 0
+  let result = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) {
+      total += value.length
+      if (total > limit) {
+        return null
+      }
+      result += decoder.decode(value, { stream: true })
+    }
+  }
+  result += decoder.decode()
+  return result
+}
+
 export async function POST(req: Request) {
   try {
     await verifyFirebaseToken(req)
@@ -21,13 +49,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: message }, { status: 401 })
   }
 
-  let text: string
-  try {
-    text = await req.text()
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
-  }
-  if (new TextEncoder().encode(text).byteLength > MAX_BODY_SIZE) {
+  const text = await readBodyWithLimit(req, MAX_BODY_SIZE)
+  if (text === null) {
     return NextResponse.json({ error: "Payload too large" }, { status: 413 })
   }
 


### PR DESCRIPTION
## Summary
- guard bank import and transactions sync endpoints with content-length checks and size-capped body readers
- add tests verifying 413 responses for oversized payloads without consuming body

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0695cab788331b0fcd5acd7f776b4