### PR TITLE
feat: add retry backoff for offline sync

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -2,6 +2,7 @@ importScripts("https://cdn.jsdelivr.net/npm/idb@7/build/iife/index-min.js")
 
 const DB_NAME = "offline-db"
 const STORE_NAME = "transactions"
+const MAX_QUEUE_LENGTH = 100
 
 const dbPromise = idb.openDB(DB_NAME, 1, {
   upgrade(db) {
@@ -25,6 +26,11 @@ self.addEventListener("fetch", event => {
           const body = await clone.json()
           const db = await dbPromise
           await db.add(STORE_NAME, body)
+          const keys = await db.getAllKeys(STORE_NAME)
+          if (keys.length > MAX_QUEUE_LENGTH) {
+            const excess = keys.slice(0, keys.length - MAX_QUEUE_LENGTH)
+            await Promise.all(excess.map((key) => db.delete(STORE_NAME, key)))
+          }
           return new Response(JSON.stringify({ offline: true }), {
             status: 202,
             headers: { "Content-Type": "application/json" },

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -3,45 +3,68 @@
 import { useEffect, useRef } from "react"
 import { getQueuedTransactions, clearQueuedTransactions } from "@/lib/offline"
 import { auth } from "@/lib/firebase"
+import { toast } from "@/hooks/use-toast"
 
 export function ServiceWorker() {
   const debounceId = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const retryTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const retryCount = useRef(0)
+  const notified = useRef(false)
 
   useEffect(() => {
+    const syncQueued = async () => {
+      const queued = await getQueuedTransactions()
+      if (!queued.length) return
+
+      try {
+        const user = auth.currentUser
+        const token = user ? await user.getIdToken() : null
+        if (!token) {
+          console.error("Cannot sync queued transactions without auth")
+          return
+        }
+
+        const response = await fetch("/api/transactions/sync", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ transactions: queued }),
+        })
+
+        if (!response.ok) {
+          throw new Error(await response.text())
+        }
+
+        await clearQueuedTransactions()
+        retryCount.current = 0
+        notified.current = false
+      } catch (error) {
+        retryCount.current += 1
+        const delay = Math.min(1000 * 2 ** (retryCount.current - 1), 30000)
+
+        if (retryCount.current >= 5 && !notified.current) {
+          toast({
+            title: "Sync failed",
+            description:
+              "Unable to sync offline transactions. We'll keep trying in the background.",
+          })
+          notified.current = true
+        }
+
+        console.error("Failed to sync queued transactions", error)
+        if (retryTimeoutId.current) clearTimeout(retryTimeoutId.current)
+        retryTimeoutId.current = setTimeout(syncQueued, delay)
+      }
+    }
+
     const handleOnline = () => {
       if (debounceId.current) clearTimeout(debounceId.current)
-
-      debounceId.current = setTimeout(async () => {
-        const queued = await getQueuedTransactions()
-        if (queued.length) {
-          try {
-            const user = auth.currentUser
-            const token = user ? await user.getIdToken() : null
-            if (!token) {
-              console.error("Cannot sync queued transactions without auth")
-              return
-            }
-            const response = await fetch("/api/transactions/sync", {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
-              },
-              body: JSON.stringify({ transactions: queued }),
-            })
-            if (!response.ok) {
-              console.error(
-                "Failed to sync queued transactions",
-                await response.text()
-              )
-              return
-            }
-            await clearQueuedTransactions()
-          } catch (error) {
-            console.error("Failed to sync queued transactions", error)
-          }
-        }
-      }, 1000)
+      if (retryTimeoutId.current) clearTimeout(retryTimeoutId.current)
+      retryCount.current = 0
+      notified.current = false
+      debounceId.current = setTimeout(syncQueued, 1000)
     }
 
     const registerAndListen = async () => {
@@ -62,6 +85,7 @@ export function ServiceWorker() {
     return () => {
       window.removeEventListener("online", handleOnline)
       if (debounceId.current) clearTimeout(debounceId.current)
+      if (retryTimeoutId.current) clearTimeout(retryTimeoutId.current)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- add exponential backoff and retry tracking to offline transaction sync
- notify users when sync repeatedly fails
- limit offline queue growth in service worker

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0696cada483319ca6ae0365b507dd