### PR TITLE
Validate financial document uploads

### DIFF
--- a/src/__tests__/analyze-spending-habits.test.ts
+++ b/src/__tests__/analyze-spending-habits.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/ai/genkit", () => ({
+  ai: {
+    definePrompt: jest.fn(),
+    defineFlow: jest.fn((_c: any, handler: any) => handler),
+  },
+}));
+import { AnalyzeSpendingHabitsInputSchema, MAX_DOCUMENT_SIZE, MAX_FINANCIAL_DOCUMENTS } from "@/ai/flows/analyze-spending-habits";
+
+const validDoc = "data:text/plain;base64," + Buffer.from("test").toString("base64");
+
+describe("AnalyzeSpendingHabitsInputSchema", () => {
+  it("rejects invalid document string", () => {
+    const input = { financialDocuments: ["not-a-data-uri"], userDescription: "desc", goals: [] };
+    expect(() => AnalyzeSpendingHabitsInputSchema.parse(input)).toThrow();
+  });
+
+  it("rejects oversized document string", () => {
+    const largeDoc = "data:text/plain;base64," + "a".repeat(MAX_DOCUMENT_SIZE + 1);
+    const input = { financialDocuments: [largeDoc], userDescription: "desc", goals: [] };
+    expect(() => AnalyzeSpendingHabitsInputSchema.parse(input)).toThrow();
+  });
+
+  it("rejects too many documents", () => {
+    const docs = Array(MAX_FINANCIAL_DOCUMENTS + 1).fill(validDoc);
+    const input = { financialDocuments: docs, userDescription: "desc", goals: [] };
+    expect(() => AnalyzeSpendingHabitsInputSchema.parse(input)).toThrow();
+  });
+});

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -12,6 +12,7 @@
  */
 
 import {ai} from '@/ai/genkit';
+import {DATA_URI_REGEX} from '@/lib/regex';
 import {z} from 'genkit';
 
 const GoalSchema = z.object({
@@ -23,9 +24,13 @@ const GoalSchema = z.object({
     importance: z.number().describe("User's importance rating for this goal, from 1 (not important) to 5 (very important)."),
 });
 
-const AnalyzeSpendingHabitsInputSchema = z.object({
+export const MAX_FINANCIAL_DOCUMENTS = 10;
+export const MAX_DOCUMENT_SIZE = 1024 * 1024; // 1MB
+
+export const AnalyzeSpendingHabitsInputSchema = z.object({
   financialDocuments: z
-    .array(z.string())
+    .array(z.string().regex(DATA_URI_REGEX).max(MAX_DOCUMENT_SIZE))
+    .max(MAX_FINANCIAL_DOCUMENTS)
     .describe(
       'An array of financial documents as data URIs that must include a MIME type and use Base64 encoding. Expected format: data:<mimetype>;base64,<encoded_data>.'
     ),

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -1,0 +1,2 @@
+export const DATA_URI_REGEX = /^data:[^;]+;base64,[A-Za-z0-9+/]+=*$/;
+


### PR DESCRIPTION
## Summary
- enforce DATA_URI_REGEX and size limits on financial document inputs
- share reusable DATA_URI_REGEX helper
- test invalid or oversized financial document payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0697256788331b0993de140c87efb