### PR TITLE
Validate date and month formats in schemas

### DIFF
--- a/src/__tests__/transactions.test.ts
+++ b/src/__tests__/transactions.test.ts
@@ -14,4 +14,17 @@ describe("validateTransactions", () => {
       /Invalid amount in row 1/
     );
   });
+
+  it("accepts valid ISO date", () => {
+    const rows = [{ ...baseRow, amount: "10.00", date: "2024-12-31" }];
+    expect(() => validateTransactions(rows)).not.toThrow();
+  });
+
+  it.each(["2024/01/01", "2024-1-1", "01-01-2024"])(
+    "throws for invalid date '%s'",
+    (date) => {
+      const rows = [{ ...baseRow, amount: "10.00", date }];
+      expect(() => validateTransactions(rows)).toThrow(/Invalid row 1/);
+    }
+  );
 });

--- a/src/ai/flows/__tests__/spendingForecast.test.ts
+++ b/src/ai/flows/__tests__/spendingForecast.test.ts
@@ -1,0 +1,47 @@
+jest.mock('@/ai/genkit', () => ({ ai: { definePrompt: jest.fn(), defineFlow: jest.fn() } }));
+
+import { SpendingForecastInputSchema, SpendingForecastOutputSchema } from '../spendingForecast';
+
+describe('SpendingForecast schemas', () => {
+  it('accepts valid date and month formats', () => {
+    expect(() =>
+      SpendingForecastInputSchema.parse({
+        transactions: [
+          { date: '2024-01-01', amount: 100, category: 'Misc' },
+        ],
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      SpendingForecastOutputSchema.parse({
+        forecast: [{ month: '2024-08', amount: 200 }],
+        analysis: 'ok',
+      })
+    ).not.toThrow();
+  });
+
+  it.each(['2024/01', '2024-1', '01-2024'])(
+    'rejects invalid month %s',
+    month => {
+      expect(() =>
+        SpendingForecastOutputSchema.parse({
+          forecast: [{ month, amount: 200 }],
+          analysis: 'x',
+        })
+      ).toThrow();
+    }
+  );
+
+  it.each(['20240101', '2024/01/01', '01-01-2024'])(
+    'rejects invalid date %s',
+    date => {
+      expect(() =>
+        SpendingForecastInputSchema.parse({
+          transactions: [
+            { date, amount: 100, category: 'Misc' },
+          ],
+        })
+      ).toThrow();
+    }
+  );
+});

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -13,23 +13,29 @@ import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 
 const TransactionSchema = z.object({
-  date: z.string().describe('ISO date of the transaction.'),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .describe('ISO date of the transaction.'),
   amount: z.number().describe('Transaction amount in USD.'),
   category: z.string().describe('Category for the transaction.'),
   description: z.string().optional().describe('Optional description of the transaction.'),
 });
 
-const SpendingForecastInputSchema = z.object({
+export const SpendingForecastInputSchema = z.object({
   transactions: z.array(TransactionSchema).describe('Historical transaction data to analyze.'),
 });
 export type SpendingForecastInput = z.infer<typeof SpendingForecastInputSchema>;
 
 const ForecastPointSchema = z.object({
-  month: z.string().describe('Month for the forecasted spending (e.g., 2024-08).'),
+  month: z
+    .string()
+    .regex(/^\d{4}-\d{2}$/)
+    .describe('Month for the forecasted spending (e.g., 2024-08).'),
   amount: z.number().describe('Predicted total spending for the month in USD.'),
 });
 
-const SpendingForecastOutputSchema = z.object({
+export const SpendingForecastOutputSchema = z.object({
   forecast: z.array(ForecastPointSchema).describe('Predicted spending for upcoming months.'),
   analysis: z.string().describe('Brief analysis of expected spending trends.'),
 });

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -4,7 +4,7 @@ import { db } from "./firebase";
 import type { Transaction } from "./types";
 
 const TransactionRow = z.object({
-  date: z.string(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   description: z.string(),
   amount: z.preprocess(
     (val) => (typeof val === "number" || typeof val === "string" ? String(val) : val),


### PR DESCRIPTION
## Summary
- enforce ISO date format for transactions and spending forecast inputs
- validate month format for spending forecast outputs
- add tests covering valid and invalid date/month values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06973ad7883319583cb75bc21c211