### PR TITLE
feat: validate numeric fields in ai flows

### DIFF
--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,0 +1,85 @@
+function setupSuccessMocks(output: any) {
+  const definePromptMock = jest.fn().mockReturnValue(async () => ({ output }));
+  const defineFlowMock = jest.fn((config: any, handler: any) => {
+    return async (input: any) => {
+      const parsedInput = config.inputSchema.parse(input);
+      const result = await handler(parsedInput);
+      return config.outputSchema.parse(result);
+    };
+  });
+  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+}
+
+describe('calculateCashflow validation', () => {
+  it('rejects negative annual income', async () => {
+    jest.resetModules();
+    setupSuccessMocks({ grossMonthlyIncome: 0, netMonthlyIncome: 0, analysis: '' });
+    const { calculateCashflow } = await import('@/ai/flows/calculate-cashflow');
+    await expect(
+      calculateCashflow({ annualIncome: -1, estimatedAnnualTaxes: 0, totalMonthlyDeductions: 0 })
+    ).rejects.toThrow();
+  });
+});
+
+describe('taxEstimation validation', () => {
+  it('rejects negative income', async () => {
+    jest.resetModules();
+    setupSuccessMocks({ estimatedTax: 0, taxRate: 10, breakdown: '' });
+    const { estimateTax } = await import('@/ai/flows/tax-estimation');
+    await expect(
+      estimateTax({ income: -1, deductions: 0, location: 'NY', filingStatus: 'single' })
+    ).rejects.toThrow();
+  });
+
+  it('rejects tax rate over 100', async () => {
+    jest.resetModules();
+    setupSuccessMocks({ estimatedTax: 1000, taxRate: 150, breakdown: '' });
+    const { estimateTax } = await import('@/ai/flows/tax-estimation');
+    await expect(
+      estimateTax({ income: 50000, deductions: 10000, location: 'NY', filingStatus: 'single' })
+    ).rejects.toThrow();
+  });
+});
+
+describe('suggestDebtStrategy validation', () => {
+  it('rejects interest rate over 100', async () => {
+    jest.resetModules();
+    setupSuccessMocks({
+      recommendedStrategy: 'snowball',
+      strategyReasoning: '',
+      payoffOrder: [],
+      summary: '',
+    });
+    const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
+    await expect(
+      suggestDebtStrategy({
+        debts: [
+          {
+            id: '1',
+            name: 'Card',
+            initialAmount: 1000,
+            currentAmount: 1000,
+            interestRate: 150,
+            minimumPayment: 50,
+            dueDate: '2024-01-01',
+            recurrence: 'monthly',
+          },
+        ],
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects payoff order priority less than 1', async () => {
+    jest.resetModules();
+    setupSuccessMocks({
+      recommendedStrategy: 'snowball',
+      strategyReasoning: '',
+      payoffOrder: [{ debtName: 'Card', priority: 0 }],
+      summary: '',
+    });
+    const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
+    await expect(
+      suggestDebtStrategy({ debts: [] })
+    ).rejects.toThrow();
+  });
+});

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -15,12 +15,15 @@ import {z} from 'genkit';
 const CalculateCashflowInputSchema = z.object({
   annualIncome: z
     .number()
+    .nonnegative()
     .describe('Total annual gross income from all sources.'),
   estimatedAnnualTaxes: z
     .number()
+    .nonnegative()
     .describe('Estimated total annual taxes (federal, state, local).'),
   totalMonthlyDeductions: z
     .number()
+    .nonnegative()
     .describe('Total of all monthly deductions and expenses (e.g., rent, loans, utilities, groceries).'),
 });
 export type CalculateCashflowInput = z.infer<typeof CalculateCashflowInputSchema>;
@@ -28,9 +31,11 @@ export type CalculateCashflowInput = z.infer<typeof CalculateCashflowInputSchema
 const CalculateCashflowOutputSchema = z.object({
   grossMonthlyIncome: z
     .number()
+    .nonnegative()
     .describe('The gross monthly income, calculated as annual income divided by 12.'),
   netMonthlyIncome: z
     .number()
+    .min(-1000000)
     .describe('The net monthly income, calculated as gross monthly income minus monthly taxes and deductions.'),
   analysis: z
     .string()

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -16,10 +16,10 @@ import { RecurrenceValues } from '@/lib/types';
 const DebtSchema = z.object({
     id: z.string(),
     name: z.string(),
-    initialAmount: z.number(),
-    currentAmount: z.number(),
-    interestRate: z.number(),
-    minimumPayment: z.number(),
+    initialAmount: z.number().nonnegative(),
+    currentAmount: z.number().nonnegative(),
+    interestRate: z.number().nonnegative().max(100),
+    minimumPayment: z.number().nonnegative(),
     dueDate: z.string(),
     recurrence: z.enum(RecurrenceValues),
 });
@@ -34,7 +34,7 @@ const SuggestDebtStrategyOutputSchema = z.object({
   strategyReasoning: z.string().describe("The reasoning behind the recommended strategy."),
   payoffOrder: z.array(z.object({
       debtName: z.string(),
-      priority: z.number(),
+      priority: z.number().int().min(1),
   })).describe("The recommended order to pay off the debts, starting with priority 1."),
   summary: z.string().describe("A brief, encouraging summary of the plan."),
 });

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -15,9 +15,11 @@ import {z} from 'genkit';
 const TaxEstimationInputSchema = z.object({
   income: z
     .number()
+    .nonnegative()
     .describe('Annual income in USD.'),
   deductions: z
     .number()
+    .nonnegative()
     .describe('Total deductions in USD.'),
   location: z
     .string()
@@ -30,9 +32,12 @@ export type TaxEstimationInput = z.infer<typeof TaxEstimationInputSchema>;
 const TaxEstimationOutputSchema = z.object({
   estimatedTax: z
     .number()
+    .nonnegative()
     .describe('Estimated total tax amount in USD.'),
   taxRate: z
     .number()
+    .nonnegative()
+    .max(100)
     .describe('Estimated effective tax rate as a percentage.'),
   breakdown: z
     .string()


### PR DESCRIPTION
## Summary
- enforce non-negative and bounded numeric fields in tax estimation, cashflow, and debt strategy flows
- add output constraints for percentages and priorities
- cover edge cases with new validation tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b069751900833182b12a7371c388c6