### PR TITLE
Restrict goal importance to 1-5 scale

### DIFF
--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -20,7 +20,14 @@ const GoalSchema = z.object({
     targetAmount: z.number(),
     currentAmount: z.number(),
     deadline: z.string(),
-    importance: z.number().describe("User's importance rating for this goal, from 1 (not important) to 5 (very important)."),
+    importance: z
+      .number()
+      .int()
+      .min(1)
+      .max(5)
+      .describe(
+        "User's importance rating for this goal, from 1 (not important) to 5 (very important)."
+      ),
 });
 
 const AnalyzeSpendingHabitsInputSchema = z.object({


### PR DESCRIPTION
## Summary
- enforce integer 1-5 bounds on goal importance in AnalyzeSpendingHabits flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06975c614833198074a46607583f4