### PR TITLE
feat: add shared data URI validation

### DIFF
--- a/src/__tests__/data-uri-regex.test.ts
+++ b/src/__tests__/data-uri-regex.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment node
+ */
+import { z } from "zod";
+import { DATA_URI_REGEX } from "@/lib/data-uri";
+
+describe("DATA_URI_REGEX", () => {
+  const schema = z.string().regex(DATA_URI_REGEX);
+
+  it("accepts valid data URIs", () => {
+    const valid = "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==";
+    expect(schema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects invalid data URIs", () => {
+    const missingMeta = "data:text/plain,SGVsbG8sIFdvcmxkIQ==";
+    const badBase64 = "data:text/plain;base64,@@@";
+    expect(schema.safeParse(missingMeta).success).toBe(false);
+    expect(schema.safeParse(badBase64).success).toBe(false);
+  });
+});

--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -10,11 +10,13 @@
  */
 
 import {ai} from '@/ai/genkit';
+import {DATA_URI_REGEX} from '@/lib/data-uri';
 import {z} from 'genkit';
 
-const AnalyzeReceiptInputSchema = z.object({
+export const AnalyzeReceiptInputSchema = z.object({
   receiptImage: z
     .string()
+    .regex(DATA_URI_REGEX)
     .describe(
       "An image of a receipt, as a data URI that must include a MIME type and use Base64 encoding. Expected format: 'data:<mimetype>;base64,<encoded_data>'."
     ),

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -12,6 +12,7 @@
  */
 
 import {ai} from '@/ai/genkit';
+import {DATA_URI_REGEX} from '@/lib/data-uri';
 import {z} from 'genkit';
 
 const GoalSchema = z.object({
@@ -23,9 +24,9 @@ const GoalSchema = z.object({
     importance: z.number().describe("User's importance rating for this goal, from 1 (not important) to 5 (very important)."),
 });
 
-const AnalyzeSpendingHabitsInputSchema = z.object({
+export const AnalyzeSpendingHabitsInputSchema = z.object({
   financialDocuments: z
-    .array(z.string())
+    .array(z.string().regex(DATA_URI_REGEX))
     .describe(
       'An array of financial documents as data URIs that must include a MIME type and use Base64 encoding. Expected format: data:<mimetype>;base64,<encoded_data>.'
     ),

--- a/src/lib/data-uri.ts
+++ b/src/lib/data-uri.ts
@@ -1,0 +1,5 @@
+/**
+ * Regular expression for matching data URIs that include a MIME type and base64-encoded data.
+ * Example: data:image/png;base64,iVBORw0...
+ */
+export const DATA_URI_REGEX = /^data:[a-zA-Z0-9]+\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+$/;


### PR DESCRIPTION
## Summary
- add reusable `DATA_URI_REGEX`
- validate receipt images and financial documents against `DATA_URI_REGEX`
- test valid and invalid data URIs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b069764b78833187bba0a04f7d5da9