### PR TITLE
Add transaction payload schema and validate API routes

### DIFF
--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
+import { TransactionPayloadSchema } from "@/lib/transactions"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -9,7 +10,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
  */
 const bodySchema = z.object({
   provider: z.string(),
-  transactions: z.array(z.any()),
+  transactions: z.array(TransactionPayloadSchema),
 })
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
@@ -41,7 +42,10 @@ export async function POST(req: Request) {
 
   const parsed = bodySchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+    return NextResponse.json(
+      { error: "Invalid payload", details: parsed.error.flatten() },
+      { status: 400 },
+    )
   }
 
   const { provider, transactions } = parsed.data

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
+import { TransactionPayloadSchema } from "@/lib/transactions"
 
 /**
  * Generic transaction syncing endpoint.
@@ -8,7 +9,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
  * from any source and persists them to the database.
  */
 const bodySchema = z.object({
-  transactions: z.array(z.any()),
+  transactions: z.array(TransactionPayloadSchema),
 })
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
@@ -40,7 +41,10 @@ export async function POST(req: Request) {
 
   const parsed = bodySchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+    return NextResponse.json(
+      { error: "Invalid payload", details: parsed.error.flatten() },
+      { status: 400 },
+    )
   }
 
   const { transactions } = parsed.data

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -3,6 +3,19 @@ import { collection, doc, writeBatch } from "firebase/firestore";
 import { db } from "./firebase";
 import type { Transaction } from "./types";
 
+export const TransactionPayloadSchema = z.object({
+  id: z.string(),
+  date: z.string(),
+  description: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  type: z.enum(["Income", "Expense"]),
+  category: z.string(),
+  isRecurring: z.boolean().optional(),
+});
+
+export type TransactionPayload = z.infer<typeof TransactionPayloadSchema>;
+
 const TransactionRow = z.object({
   date: z.string(),
   description: z.string(),


### PR DESCRIPTION
## Summary
- add a TransactionPayloadSchema describing required transaction fields
- validate bank import and transaction sync API payloads with the schema
- return detailed validation errors when payloads are invalid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06977acb88331a0b092285fcec6e9