### PR TITLE
feat(payroll): add optional pay period anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ Adjust the retention threshold by setting `RETENTION_DAYS` before running the se
 ## Upgrading Next.js
 
 This project pins Next.js to a specific version. When upgrading, follow the steps in [docs/next-upgrade.md](docs/next-upgrade.md) to review releases, update the version, and verify the changes.
+
+## Payroll utilities
+
+The `getPayPeriodStart(date, anchor?)` helper returns the Sunday that starts a
+two-week pay period. It is used by the `PayPeriodSummary` utilities to group
+shifts into the correct pay cycle. A custom `anchor` date can be provided to
+align the cycle with organization-specific schedules. When omitted, the anchor
+defaults to the pay period beginning on January 7, 2024.

--- a/src/__tests__/payroll.test.ts
+++ b/src/__tests__/payroll.test.ts
@@ -13,6 +13,13 @@ describe('payroll utilities', () => {
     expect(start.toISOString().slice(0, 10)).toBe('2024-01-07');
   });
 
+  test('getPayPeriodStart accepts a custom anchor', () => {
+    const date = new Date('2024-01-15T12:00:00Z');
+    const anchor = new Date('2024-01-14T00:00:00Z');
+    const start = getPayPeriodStart(date, anchor);
+    expect(start.toISOString().slice(0, 10)).toBe('2024-01-14');
+  });
+
   test('calculateOvertimeDates identifies shifts after 40 hours', () => {
     const shifts: Shift[] = [
       { date: new Date('2024-01-08'), hours: 8, rate: 10 },

--- a/src/app/cashflow/page.tsx
+++ b/src/app/cashflow/page.tsx
@@ -20,6 +20,9 @@ import {
 
 type ShiftDetails = Omit<Shift, 'date'>;
 
+// Anchor date used to align bi-weekly pay periods for this organization
+const payPeriodAnchor = new Date('2024-01-07T00:00:00.000Z');
+
 
 export default function CashflowPage() {
   const [annualIncome, setAnnualIncome] = useState("")
@@ -176,7 +179,7 @@ export default function CashflowPage() {
       setSelectedDate(date);
       
       if (date) {
-        const start = getPayPeriodStart(date);
+        const start = getPayPeriodStart(date, payPeriodAnchor);
         const end = new Date(start);
         end.setDate(start.getDate() + 13);
         setPayPeriod({ from: start, to: end });

--- a/src/lib/payroll.ts
+++ b/src/lib/payroll.ts
@@ -16,14 +16,18 @@ export interface PayPeriodSummary {
 }
 
 // Helper to find the start of a 2-week pay period (a Sunday) for any given date.
-export const getPayPeriodStart = (date: Date): Date => {
+// The optional `anchor` parameter lets different organizations align pay periods
+// to their own reference Sunday. By default, January 7, 2024 is used as the anchor
+// date for calculations.
+export const getPayPeriodStart = (
+  date: Date,
+  anchor: Date = new Date('2024-01-07T00:00:00.000Z')
+): Date => {
   const d = new Date(date);
   d.setHours(0, 0, 0, 0);
   const dayOfWeek = d.getDay();
   d.setDate(d.getDate() - dayOfWeek);
 
-  // Use a fixed anchor date to determine the "even" or "odd" week period.
-  const anchor = new Date('2024-01-07T00:00:00.000Z'); // A known Sunday
   const diffWeeks = Math.floor((d.getTime() - anchor.getTime()) / (1000 * 60 * 60 * 24 * 7));
 
   if (diffWeeks % 2 !== 0) {


### PR DESCRIPTION
## Summary
- allow `getPayPeriodStart` to accept an optional anchor for different org cycles
- update cashflow page and tests to pass explicit anchors
- document anchor usage in README

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / require import across unrelated test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b069823f188331a0d93c94229dc010