### PR TITLE
Use request-scoped CSP nonce

### DIFF
--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -1,6 +1,6 @@
 # Security Headers
 
-This project defines security headers in `next.config.ts` for all routes. Any additional routes or middleware must continue to apply these headers.
+This project defines security headers in `middleware.ts` for all routes using a request-specific nonce. Any additional routes or middleware must continue to apply these headers.
 
 ## Required Headers
 
@@ -12,6 +12,6 @@ This project defines security headers in `next.config.ts` for all routes. Any ad
 
 ### Using the CSP Nonce
 
-The Content-Security-Policy includes a nonce. When adding inline scripts, apply this nonce to the `<script>` tag's `nonce` attribute or replace the inline script with an external file. Middleware that generates HTML should propagate the same nonce in the response headers.
+The Content-Security-Policy includes a nonce. Server components can access it with `getRequestNonce()` from `@/lib/nonce`. When adding inline scripts, apply this nonce to the `<script>` tag's `nonce` attribute or replace the inline script with an external file. Middleware that generates HTML should propagate the same nonce in the response headers.
 
 Always verify headers locally when introducing new routes or middleware to ensure functionality remains intact.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,49 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import crypto from 'crypto'
+
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+]
+
+export function middleware(request: NextRequest) {
+  const nonce = crypto.randomBytes(16).toString('base64')
+
+  const csp = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'unsafe-inline' 'unsafe-eval'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: https:",
+    "font-src 'self'",
+    "connect-src 'self' https:",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join('; ')
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-nonce', nonce)
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
+
+  response.headers.set('Content-Security-Policy', csp)
+  securityHeaders.forEach(({ key, value }) => {
+    response.headers.set(key, value)
+  })
+
+  response.headers.set('x-nonce', nonce)
+  return response
+}
+
+export const config = {
+  matcher: '/:path*',
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,32 +1,4 @@
 import type { NextConfig } from 'next'
-import crypto from 'crypto'
-
-const cspNonce = crypto.randomBytes(16).toString('base64')
-
-const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value: [
-      "default-src 'self'",
-      `script-src 'self' 'nonce-${cspNonce}' 'unsafe-inline' 'unsafe-eval'`,
-      "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: https:",
-      "font-src 'self'",
-      "connect-src 'self' https:",
-      "base-uri 'self'",
-      "form-action 'self'",
-      "frame-ancestors 'none'",
-    ].join('; '),
-  },
-  { key: 'X-Frame-Options', value: 'DENY' },
-  { key: 'X-Content-Type-Options', value: 'nosniff' },
-  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-  {
-    key: 'Strict-Transport-Security',
-    value: 'max-age=63072000; includeSubDomains; preload',
-  },
-]
-
 const nextConfig: NextConfig = {
   // Enforce type checking and linting during builds
   typescript: { ignoreBuildErrors: false },
@@ -36,15 +8,6 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'placehold.co', pathname: '/**' },
       { protocol: 'https', hostname: 'picsum.photos', pathname: '/**' },
     ],
-  },
-
-  async headers() {
-    return [
-      {
-        source: '/(.*)',
-        headers: securityHeaders,
-      },
-    ]
   },
 
   // Allow Firebase Studio / Cloud Workstations preview host to fetch /_next/*

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from '@/components/auth/auth-provider';
 import { ThemeProvider } from 'next-themes';
 import { ErrorBoundary, SuspenseBoundary } from '@/components/layout/boundaries';
 import { ServiceWorker } from '@/components/service-worker';
+import { getRequestNonce } from '@/lib/nonce';
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -19,8 +20,15 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const nonce = getRequestNonce();
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          nonce={nonce}
+          dangerouslySetInnerHTML={{ __html: `window.__cspNonce="${nonce}"` }}
+        />
+      </head>
       <body
         className={`${inter.variable} min-h-screen bg-background text-foreground font-sans antialiased dark:bg-background dark:text-foreground`}
       >

--- a/src/lib/nonce.ts
+++ b/src/lib/nonce.ts
@@ -1,0 +1,5 @@
+import { headers } from 'next/headers'
+
+export function getRequestNonce(): string | undefined {
+  return headers().get('x-nonce') ?? undefined
+}


### PR DESCRIPTION
## Summary
- remove build-time CSP nonce from Next.js config
- add middleware that injects per-request nonce and security headers
- expose request nonce to components and inline scripts

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, @typescript-eslint/no-explicit-any)*
- `npx next lint --file middleware.ts --file next.config.ts --file src/app/layout.tsx --file src/lib/nonce.ts` *(warnings: File ignored because of a matching ignore pattern. Use "--no-ignore" to override.)*

------
https://chatgpt.com/codex/tasks/task_e_68b06983038c8331bb5c347543c542c7