### PR TITLE
Improve offline queue resiliency

### DIFF
--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -9,6 +9,10 @@ jest.mock("idb", () => {
       clear: async () => {
         store.length = 0
       },
+      getAllKeys: async () => store.map((_, i) => i),
+      delete: async () => {
+        store.shift()
+      },
     })),
   }
 })
@@ -21,13 +25,13 @@ import {
 
 describe("offline fallbacks", () => {
   it("uses in-memory store when IndexedDB fails", async () => {
-    await queueTransaction({ id: 1 })
-    await queueTransaction({ id: 2 })
+    expect(await queueTransaction({ id: 1 })).toBe(true)
+    expect(await queueTransaction({ id: 2 })).toBe(true)
 
     const queued = await getQueuedTransactions<{ id: number }>()
     expect(queued).toEqual([{ id: 1 }, { id: 2 }])
 
-    await clearQueuedTransactions()
+    expect(await clearQueuedTransactions()).toBe(true)
     const empty = await getQueuedTransactions()
     expect(empty).toEqual([])
   })

--- a/src/lib/offline.ts
+++ b/src/lib/offline.ts
@@ -2,6 +2,7 @@ import { openDB } from "idb"
 
 const DB_NAME = "offline-db"
 const STORE_NAME = "transactions"
+const DEFAULT_MAX_QUEUE_SIZE = 100
 
 const dbPromise = openDB(DB_NAME, 1, {
   upgrade(db) {
@@ -9,17 +10,45 @@ const dbPromise = openDB(DB_NAME, 1, {
   },
 })
 
-export async function queueTransaction(tx: unknown) {
-  const db = await dbPromise
-  await db.add(STORE_NAME, tx)
+export async function queueTransaction(
+  tx: unknown,
+  maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
+) {
+  try {
+    const db = await dbPromise
+    await db.add(STORE_NAME, tx)
+
+    const keys = await db.getAllKeys(STORE_NAME)
+    const overflow = keys.length - maxQueueSize
+    if (overflow > 0) {
+      for (const key of keys.slice(0, overflow)) {
+        await db.delete(STORE_NAME, key)
+      }
+    }
+    return true
+  } catch (error) {
+    console.error("queueTransaction error", error)
+    return false
+  }
 }
 
 export async function getQueuedTransactions<T = unknown>() {
-  const db = await dbPromise
-  return db.getAll(STORE_NAME) as Promise<T[]>
+  try {
+    const db = await dbPromise
+    return (await db.getAll(STORE_NAME)) as T[]
+  } catch (error) {
+    console.error("getQueuedTransactions error", error)
+    return null
+  }
 }
 
 export async function clearQueuedTransactions() {
-  const db = await dbPromise
-  await db.clear(STORE_NAME)
+  try {
+    const db = await dbPromise
+    await db.clear(STORE_NAME)
+    return true
+  } catch (error) {
+    console.error("clearQueuedTransactions error", error)
+    return false
+  }
 }


### PR DESCRIPTION
## Summary
- wrap IndexedDB actions in offline queue helpers with try/catch and return status
- add configurable maximum queue size and prune oldest transactions when exceeded
- adjust offline tests for new error handling

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, A `require()` style import is forbidden, Unexpected constant condition)*

------
https://chatgpt.com/codex/tasks/task_e_68b0698409dc8331b84e2851ac026294