### PR TITLE
Handle graceful worker exits in WorkerPool

### DIFF
--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -55,10 +55,14 @@ export class WorkerPool<T = unknown, R = unknown> {
           const replacement = new Worker(this.file)
           this.workers.push(replacement)
           this.idle.push(replacement)
+          this.process()
+          task.reject(new Error(`Worker stopped with exit code ${code}`))
+        } else {
+          // A zero exit code indicates a graceful shutdown. No need to reject
+          // the pending task; just continue processing with the remaining
+          // workers.
+          this.process()
         }
-
-        this.process()
-        task.reject(new Error(`Worker stopped with exit code ${code}`))
       })
 
       worker.postMessage(task.data)


### PR DESCRIPTION
## Summary
- Avoid rejecting tasks when a worker exits with code 0
- Add regression test for normal worker exits

## Testing
- `npm test src/__tests__/worker-pool.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b06986362c833199eea78eff39c592