### PR TITLE
refactor: make useIsMobile server-safe

### DIFF
--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -7,9 +7,13 @@ import * as React from "react"
 export const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState(false)
+  const [isMobile, setIsMobile] = React.useState(() => {
+    return typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT
+  })
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
+    if (typeof window === "undefined") return
+
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)


### PR DESCRIPTION
## Summary
- use useEffect for `useIsMobile` to ensure server compatibility
- guard window usage to avoid SSR crashes

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*


------
https://chatgpt.com/codex/tasks/task_e_68b069878e388331b30de532d2483fa8