### PR TITLE
Clarify transaction sync endpoint behavior

### DIFF
--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -5,8 +5,10 @@ import { TransactionPayloadSchema } from "@/lib/transactions"
 
 /**
  * Generic transaction syncing endpoint.
- * Unlike `/api/bank/import`, this expects transactions already retrieved
- * from any source and persists them to the database.
+ * Unlike `/api/bank/import`, this expects transactions that have already
+ * been fetched from any source. The current implementation only validates
+ * and reports how many transactions were received without persisting them.
+ * TODO: Implement database persistence for received transactions.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),
@@ -50,6 +52,7 @@ export async function POST(req: Request) {
   const { transactions } = parsed.data
 
   try {
+    // TODO: Persist transactions to the database.
     return NextResponse.json({ received: transactions.length })
   } catch {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- update `/api/transactions/sync` docs to reflect validation-only behavior
- note TODO for future database persistence

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b070cc785c8331af977452488c67bf