### PR TITLE
docs: clarify auth flow in login page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,8 @@ export default function LoginPage() {
     } catch (error) {
       const authError = error as AuthError
       const errorMessage = authErrorMessages[authError.code] ?? DEFAULT_AUTH_ERROR_MESSAGE
+      // If we don't have a user-friendly message for this error, log it for debugging
+      // while showing a generic message to the user to avoid exposing raw error codes.
       if (!authErrorMessages[authError.code]) {
         // Log unexpected errors for debugging without exposing details to the user
         console.error(authError.code, authError.message)


### PR DESCRIPTION
## Summary
- document auth view and loading states
- clarify login vs signup flow and why unexpected errors are only logged

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0721b282c83318dc7cebcf37f9693