### PR TITLE
docs: document worker pool

### DIFF
--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -6,6 +6,15 @@ interface Task<T, R> {
   reject: (reason: unknown) => void
 }
 
+/**
+ * Manages a fixed set of Node.js {@link Worker} threads and schedules tasks
+ * across them.
+ *
+ * Tasks submitted to the pool are enqueued and dispatched to the next available
+ * idle worker in the order they were received. Once a worker completes a task
+ * it is returned to the idle pool for reuse, and any worker that exits
+ * unexpectedly is replaced to maintain pool capacity.
+ */
 export class WorkerPool<T = unknown, R = unknown> {
   private readonly workers: Worker[] = []
   private readonly idle: Worker[] = []
@@ -19,6 +28,13 @@ export class WorkerPool<T = unknown, R = unknown> {
     }
   }
 
+  /**
+   * Enqueue a unit of work to be processed by the pool.
+   *
+   * The task is queued until a worker becomes available. The returned promise
+   * resolves with the result posted by the worker or rejects if the worker
+   * emits an error or terminates with a non-zero exit code.
+   */
   run(data: T): Promise<R> {
     return new Promise((resolve, reject) => {
       this.queue.push({ data, resolve, reject })
@@ -26,6 +42,14 @@ export class WorkerPool<T = unknown, R = unknown> {
     })
   }
 
+  /**
+   * Assign queued tasks to idle workers.
+   *
+   * Workers are recycled by pushing them back onto the idle list once they
+   * finish processing. Errors emitted by a worker reject the associated task.
+   * If a worker exits unexpectedly, it is removed from the pool and immediately
+   * replaced with a new worker to keep the pool at capacity.
+   */
   private process() {
     while (this.queue.length > 0 && this.idle.length > 0) {
       const worker = this.idle.shift()!
@@ -69,6 +93,13 @@ export class WorkerPool<T = unknown, R = unknown> {
     }
   }
 
+  /**
+   * Shut down all workers and discard pending tasks.
+   *
+   * Workers are terminated and the internal queues are cleared. Any tasks that
+   * have not yet started will never run, and callers waiting on their promises
+   * will not receive a resolution.
+   */
   async destroy(): Promise<void> {
     await Promise.all(this.workers.map(worker => worker.terminate()))
     this.queue = []


### PR DESCRIPTION
## Summary
- add top-level documentation for WorkerPool
- explain how tasks are scheduled and workers recycled
- describe run, process, and destroy behavior

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-require-imports, no-unused-vars, no-constant-condition)*

------
https://chatgpt.com/codex/tasks/task_e_68b0721e5160833197a02316356dc8c8