### PR TITLE
docs: clarify debt occurrence helpers

### DIFF
--- a/src/hooks/use-debt-occurrences.ts
+++ b/src/hooks/use-debt-occurrences.ts
@@ -17,6 +17,20 @@ export const DEFAULT_MAX_OCCURRENCES = 400;
 
 const iso = (d: Date) => d.toISOString().slice(0, 10);
 
+/**
+ * Computes the next occurrence of a recurring debt on or after a target date.
+ *
+ * Supported recurrence modes are:
+ * - `"none"` – a one-time occurrence that must match the anchor date exactly.
+ * - `"weekly"` – repeats every seven days.
+ * - `"biweekly"` – repeats every fourteen days.
+ * - `"monthly"` – repeats on the same day of each month.
+ *
+ * @param anchorISO - ISO date string representing the first occurrence.
+ * @param recurrence - Recurrence frequency of the debt.
+ * @param onOrAfter - Date to search for the next occurrence from.
+ * @returns The first occurrence on or after `onOrAfter`, or `null` if none.
+ */
 function nextOccurrenceOnOrAfter(
   anchorISO: string,
   recurrence: Recurrence,
@@ -43,6 +57,19 @@ function nextOccurrenceOnOrAfter(
   return isBefore(candidate, onOrAfter) ? addDays(candidate, step) : candidate;
 }
 
+/**
+ * Generates all occurrences of a debt within the given date range.
+ *
+ * The iteration stops after `maxOccurrences` cycles; if more occurrences
+ * exist within the range after that point, a console warning is emitted to
+ * signal truncation.
+ *
+ * @param debt - Debt to expand into individual occurrences.
+ * @param from - Start of the date range (inclusive).
+ * @param to - End of the date range (inclusive).
+ * @param maxOccurrences - Maximum number of iterations to perform.
+ * @returns Array of occurrence dates within the specified range.
+ */
 function allOccurrencesInRange(
   debt: Debt,
   from: Date,
@@ -100,6 +127,21 @@ function computeDebtOccurrences(
 
 export type Occurrence = { date: string; debt: Debt };
 
+/**
+ * React hook that expands debts into dated occurrences and groups them by day.
+ *
+ * The grouped map is filtered by `query`, which matches against a debt's name
+ * and optional notes. The returned `occurrences` list is unaffected by this
+ * filtering.
+ *
+ * @param debts - Debts to compute occurrences for.
+ * @param from - Start of the date range (inclusive).
+ * @param to - End of the date range (inclusive).
+ * @param query - Search string used to filter the grouped map by debt info.
+ * @param maxOccurrences - Maximum occurrences to generate per debt.
+ * @returns An object containing the flat `occurrences` list and a `grouped`
+ * map keyed by ISO date string after filtering.
+ */
 export function useDebtOccurrences(
   debts: Debt[],
   from: Date,


### PR DESCRIPTION
## Summary
- document supported recurrence modes in `nextOccurrenceOnOrAfter`
- explain iteration limits in `allOccurrencesInRange`
- describe returned data and filtering in `useDebtOccurrences`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0721bfc988331ac097bec0262f578