### PR TITLE
fix: use camelCase blueprint color classes

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/cashflow/page.tsx
+++ b/src/app/cashflow/page.tsx
@@ -416,7 +416,7 @@ export default function CashflowPage() {
                     }}
                     modifiersClassNames={{ 
                         scheduled: "bg-blueprint/20",
-                        payPeriod: "bg-blueprint-accent text-blueprint-accent-foreground",
+                        payPeriod: "bg-blueprintAccent text-blueprintAccent-foreground",
                         overtime: "bg-destructive/20 text-destructive-foreground",
                     }}
                 />

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -126,7 +126,7 @@ export default function InsightsPage() {
         <div className="grid gap-6">
           <Card>
             <CardHeader className="flex flex-row items-center gap-4">
-              <div className="p-3 rounded-full bg-blueprint-accent text-blueprint-accent-foreground">
+              <div className="p-3 rounded-full bg-blueprintAccent text-blueprintAccent-foreground">
                 <Lightbulb className="h-6 w-6" />
               </div>
               <div>
@@ -140,7 +140,7 @@ export default function InsightsPage() {
           </Card>
           <Card>
             <CardHeader className="flex flex-row items-center gap-4">
-                <div className="p-3 rounded-full bg-blueprint-accent text-blueprint-accent-foreground">
+                <div className="p-3 rounded-full bg-blueprintAccent text-blueprintAccent-foreground">
                     <TrendingUp className="h-6 w-6" />
                 </div>
                 <div>
@@ -154,7 +154,7 @@ export default function InsightsPage() {
           </Card>
           <Card>
              <CardHeader className="flex flex-row items-center gap-4">
-                <div className="p-3 rounded-full bg-blueprint-accent text-blueprint-accent-foreground">
+                <div className="p-3 rounded-full bg-blueprintAccent text-blueprintAccent-foreground">
                     <Sparkles className="h-6 w-6" />
                 </div>
                 <div>

--- a/src/components/debts/debt-strategy-plan.tsx
+++ b/src/components/debts/debt-strategy-plan.tsx
@@ -12,7 +12,7 @@ interface DebtStrategyPlanProps {
 
 export function DebtStrategyPlan({ strategy }: DebtStrategyPlanProps) {
   return (
-    <Card className="bg-blueprint-accent/50 border-blueprint/20">
+    <Card className="bg-blueprintAccent/50 border-blueprint/20">
       <CardHeader>
         <div className="flex flex-col sm:flex-row justify-between gap-2">
             <div>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -119,7 +119,7 @@ export default function AppHeader() {
         <Input
           type="search"
           placeholder="Search..."
-          className="w-full rounded-lg bg-blueprint-light pl-8 md:w-[200px] lg:w-[336px]"
+          className="w-full rounded-lg bg-blueprintLight pl-8 md:w-[200px] lg:w-[336px]"
         />
       </div>
       <ThemeSwitcher />

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -59,7 +59,7 @@ export default function AppSidebar() {
                   href={item.href}
                   className={cn(
                     "flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground md:h-8 md:w-8",
-                    pathname.startsWith(item.href) && "bg-blueprint-accent text-blueprint-accent-foreground"
+                    pathname.startsWith(item.href) && "bg-blueprintAccent text-blueprintAccent-foreground"
                   )}
                 >
                   <item.icon className="h-5 w-5" />

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -11,7 +11,7 @@ const badgeVariants = cva(
         default:
           "border-transparent bg-blueprint text-blueprint-foreground hover:bg-blueprint/80",
         secondary:
-          "border-transparent bg-blueprint-light text-blueprint-light-foreground hover:bg-blueprint-light/80",
+          "border-transparent bg-blueprintLight text-blueprintLight-foreground hover:bg-blueprintLight/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,10 +13,10 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-blueprint-accent hover:text-blueprint-accent-foreground",
+          "border border-input bg-background hover:bg-blueprintAccent hover:text-blueprintAccent-foreground",
         secondary:
-          "bg-blueprint-light text-blueprint-light-foreground hover:bg-blueprint-light/80",
-        ghost: "hover:bg-blueprint-accent hover:text-blueprint-accent-foreground",
+          "bg-blueprintLight text-blueprintLight-foreground hover:bg-blueprintLight/80",
+        ghost: "hover:bg-blueprintAccent hover:text-blueprintAccent-foreground",
         link: "text-blueprint underline-offset-4 hover:underline",
       },
       size: {

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -37,7 +37,7 @@ function Calendar({
         head_cell:
           "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
         row: "flex w-full mt-2",
-        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-blueprint-accent/50 [&:has([aria-selected])]:bg-blueprint-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-blueprintAccent/50 [&:has([aria-selected])]:bg-blueprintAccent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
           buttonVariants({ variant: "ghost" }),
           "h-9 w-9 p-0 font-normal aria-selected:opacity-100 text-foreground"
@@ -45,12 +45,12 @@ function Calendar({
         day_range_end: "day-range-end",
         day_selected:
           "bg-blueprint text-blueprint-foreground hover:bg-blueprint hover:text-blueprint-foreground focus:bg-blueprint focus:text-blueprint-foreground",
-        day_today: "bg-blueprint-accent text-blueprint-accent-foreground",
+        day_today: "bg-blueprintAccent text-blueprintAccent-foreground",
         day_outside:
-          "day-outside text-muted-foreground opacity-50 aria-selected:bg-blueprint-accent/50 aria-selected:text-muted-foreground",
+          "day-outside text-muted-foreground opacity-50 aria-selected:bg-blueprintAccent/50 aria-selected:text-muted-foreground",
         day_disabled: "text-muted-foreground opacity-50",
         day_range_middle:
-          "aria-selected:bg-blueprint-accent aria-selected:text-blueprint-accent-foreground",
+          "aria-selected:bg-blueprintAccent aria-selected:text-blueprintAccent-foreground",
         day_hidden: "invisible",
         ...classNames,
       }}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-blueprint-accent data-[state=open]:text-blueprint-accent-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-blueprintAccent data-[state=open]:text-blueprintAccent-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-blueprint-accent data-[state=open]:bg-blueprint-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-blueprintAccent data-[state=open]:bg-blueprintAccent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-blueprint-accent focus:text-blueprint-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-blueprintAccent focus:text-blueprintAccent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-blueprint-accent focus:text-blueprint-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-blueprintAccent focus:text-blueprintAccent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-blueprint-accent focus:text-blueprint-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-blueprintAccent focus:text-blueprintAccent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -58,7 +58,7 @@ const MenubarTrigger = React.forwardRef<
   <MenubarPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none focus:bg-blueprint-accent focus:text-blueprint-accent-foreground data-[state=open]:bg-blueprint-accent data-[state=open]:text-blueprint-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none focus:bg-blueprintAccent focus:text-blueprintAccent-foreground data-[state=open]:bg-blueprintAccent data-[state=open]:text-blueprintAccent-foreground",
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const MenubarSubTrigger = React.forwardRef<
   <MenubarPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-blueprint-accent focus:text-blueprint-accent-foreground data-[state=open]:bg-blueprint-accent data-[state=open]:text-blueprint-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-blueprintAccent focus:text-blueprintAccent-foreground data-[state=open]:bg-blueprintAccent data-[state=open]:text-blueprintAccent-foreground",
       inset && "pl-8",
       className
     )}
@@ -136,7 +136,7 @@ const MenubarItem = React.forwardRef<
   <MenubarPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-blueprint-accent focus:text-blueprint-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-blueprintAccent focus:text-blueprintAccent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -152,7 +152,7 @@ const MenubarCheckboxItem = React.forwardRef<
   <MenubarPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-blueprint-accent focus:text-blueprint-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-blueprintAccent focus:text-blueprintAccent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -175,7 +175,7 @@ const MenubarRadioItem = React.forwardRef<
   <MenubarPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-blueprint-accent focus:text-blueprint-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-blueprintAccent focus:text-blueprintAccent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -12,7 +12,7 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      "relative h-2 w-full overflow-hidden rounded-full bg-blueprint-light",
+      "relative h-2 w-full overflow-hidden rounded-full bg-blueprintLight",
       className
     )}
     {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-blueprint-accent focus:text-blueprint-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-blueprintAccent focus:text-blueprintAccent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -65,7 +65,7 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-blueprint-light">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-blueprintLight">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -17,7 +17,7 @@ const Slider = React.forwardRef<
     )}
     {...props}
   >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-blueprint-light">
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-blueprintLight">
       <SliderPrimitive.Range className="absolute h-full bg-blueprint" />
     </SliderPrimitive.Track>
     <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-blueprint bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -62,7 +62,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-blueprint-light focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-blueprintLight focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- align blueprint color class names with Tailwind config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0c8467f708331be8c647dcdf71e56