### PR TITLE
fix: preserve paid-date keys when using date-fns

### DIFF
--- a/src/components/debts/DebtCalendar.tsx
+++ b/src/components/debts/DebtCalendar.tsx
@@ -2,9 +2,9 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { formatISO, parseISO, isSameDay } from "date-fns";
+import { parseISO, isSameDay } from "date-fns";
 import { Recurrence, Debt } from "@/lib/types"; // Use the unified Debt type
-import { monthMatrix } from "@/lib/calendar";
+import { monthMatrix, dateKey } from "@/lib/calendar";
 import { useDebtOccurrences } from "@/hooks/use-debt-occurrences";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -150,7 +150,7 @@ export default function DebtCalendar({ storageKey = "debt.calendar", initialDebt
       <div className="grid grid-cols-7 gap-1 rounded-lg bg-muted/50 p-1">
         {grid.map((date, idx) => {
           const inMonth = date.getMonth() === cursor.getMonth();
-          const dateISO = formatISO(date, { representation: "date" });
+          const dateISO = dateKey(date);
           const dayEvents = grouped.get(dateISO) ?? [];
           const isToday = isSameDay(date, today);
           const isPast = date < new Date(today.getFullYear(), today.getMonth(), today.getDate());
@@ -211,7 +211,7 @@ export default function DebtCalendar({ storageKey = "debt.calendar", initialDebt
 
       {showForm && (
         <DebtForm
-          dateISO={formatISO(selectedDate ?? today, { representation: "date" })}
+          dateISO={dateKey(selectedDate ?? today)}
           initial={activeDebt}
           onClose={() => setShowForm(false)}
           onDelete={activeDebt ? () => { deleteDebt(activeDebt.id); setShowForm(false); } : undefined}

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,4 +1,4 @@
-import { addDays, formatISO, isSameDay, parseISO } from "date-fns";
+import { addDays, addMinutes, formatISO, isSameDay, parseISO } from "date-fns";
 import type { Debt, Recurrence } from "./types";
 
 export function monthMatrix(year: number, month: number, startOn: 0 | 1): Date[] {
@@ -8,6 +8,12 @@ export function monthMatrix(year: number, month: number, startOn: 0 | 1): Date[]
   const cells: Date[] = [];
   for (let i = 0; i < 42; i++) cells.push(addDays(startDate, i));
   return cells;
+}
+
+export function dateKey(date: Date): string {
+  return formatISO(addMinutes(date, date.getTimezoneOffset()), {
+    representation: "date",
+  });
 }
 
 export function nextOccurrenceOnOrAfter(anchorISO: string, recurrence: Recurrence, onOrAfter: Date): Date | null {
@@ -72,7 +78,7 @@ export function computeDebtOccurrences(debts: Debt[], from: Date, to: Date) {
   debts.forEach((d) => {
     const occ = allOccurrencesInRange(d, from, to);
     occ.forEach((dt) => {
-      const oc = { date: formatISO(dt, { representation: "date" }), debt: d };
+      const oc = { date: dateKey(dt), debt: d };
       occurrences.push(oc);
       const arr = grouped.get(oc.date) ?? [];
       arr.push(oc);


### PR DESCRIPTION
## Summary
- add `dateKey` helper to format dates in UTC for consistent debt lookups
- update DebtCalendar to use `dateKey` when computing and editing dates

## Testing
- `npm run lint`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b0c8682244833180c2e353e41c0657