### PR TITLE
Slice transactions before formatting

### DIFF
--- a/src/components/transactions/transactions-table.tsx
+++ b/src/components/transactions/transactions-table.tsx
@@ -37,16 +37,19 @@ export const TransactionsTable = memo(function TransactionsTable({
 }: TransactionsTableProps) {
   const [visibleRange, setVisibleRange] = useState({ start: 0, end: 0 })
 
-  const visibleTransactions = useMemo(() => {
-    const slice = transactions.slice(visibleRange.start, visibleRange.end + 1)
-    return slice.map((transaction) => ({
-      ...transaction,
-      formattedDate: new Date(transaction.date).toLocaleDateString(),
-      formattedAmount: `${
-        transaction.type === "Income" ? "+" : "-"
-      }$${transaction.amount.toFixed(2)}`,
-    }))
-  }, [transactions, visibleRange])
+  const visibleTransactions = useMemo(
+    () =>
+      transactions
+        .slice(visibleRange.start, visibleRange.end + 1)
+        .map((transaction) => ({
+          ...transaction,
+          formattedDate: new Date(transaction.date).toLocaleDateString(),
+          formattedAmount: `${
+            transaction.type === "Income" ? "+" : "-"
+          }$${transaction.amount.toFixed(2)}`,
+        })),
+    [transactions, visibleRange],
+  )
 
   const Row = ({ index, style }: ListChildComponentProps) => {
     const fallback = transactions[index]


### PR DESCRIPTION
## Summary
- slice transactions to current page before mapping and formatting
- inline transaction slice mapping to address review comments

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0c88f34a48331b578c1f545ec4371