### PR TITLE
fix: resolve dashboard merge conflicts

### DIFF
--- a/src/app/dashboard/dashboard-charts.tsx
+++ b/src/app/dashboard/dashboard-charts.tsx
@@ -10,11 +10,11 @@ import {
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import RecentTransactions from "@/components/dashboard/recent-transactions";
-import type { Transaction, CategorySummary } from "@/lib/types";
+import type { Transaction, ChartPoint, CategorySummary } from "@/lib/types";
 
 // This file is now a client component module.
 // The dynamic import for the chart component is defined here.
-const IncomeExpenseChartClient = dynamic(
+const IncomeExpenseChartClient = dynamic<{ data: ChartPoint[] }>(
   () => import("@/components/dashboard/income-expense-chart"),
   {
     ssr: false,
@@ -56,7 +56,7 @@ const CategorySummaryChartClient = dynamic(
 
 interface DashboardChartsProps {
   transactions: Transaction[];
-  chartData: any[];
+  chartData: ChartPoint[];
   categorySummaries: CategorySummary[];
 }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,18 +4,16 @@ import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import DashboardCharts from '@/app/dashboard/dashboard-charts';
 import { mockTransactions, mockCategorySummaries } from "@/lib/data";
-import type { Transaction, CategorySummary } from "@/lib/types";
+import type { Transaction, ChartPoint, CategorySummary } from "@/lib/types";
 
 // Server-side data fetching now happens in the page component.
 const getTransactions = async (): Promise<Transaction[]> => {
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 500));
+  // Replace with real data fetching when an API is available
   return mockTransactions;
 };
 
-const getChartData = async () => {
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 800));
+const getChartData = async (): Promise<ChartPoint[]> => {
+  // Replace with real data fetching when an API is available
   return [
     { month: "Jan", income: 4000, expenses: 2400 },
     { month: "Feb", income: 3000, expenses: 1398 },
@@ -33,10 +31,14 @@ const getCategorySummaries = async (): Promise<CategorySummary[]> => {
 };
 
 export default async function DashboardPage() {
-  const [transactions, chartData, categorySummaries] = await Promise.all([
+  const [transactions, chartData, categorySummaries]: [
+    Transaction[],
+    ChartPoint[],
+    CategorySummary[]
+  ] = await Promise.all([
     getTransactions(),
     getChartData(),
-    getCategorySummaries()
+    getCategorySummaries(),
   ]);
 
   return (


### PR DESCRIPTION
## Summary
- type chart data with `ChartPoint` in dashboard charts
- include `ChartPoint` in dashboard page data fetching and tuple

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68b0c8e120f4833181138b1f14420800