### PR TITLE
fix: integrate worker pool with error propagation

### DIFF
--- a/src/lib/parallel.ts
+++ b/src/lib/parallel.ts
@@ -1,43 +1,30 @@
-import { Worker } from "node:worker_threads"
 import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { WorkerPool } from "./worker-pool"
 
-export async function parallelSquare(numbers: number[], threads = os.cpus().length): Promise<number[]> {
-  const chunkSize = Math.ceil(numbers.length / threads)
-  const chunks = Array.from({ length: threads }, (_, i) => numbers.slice(i * chunkSize, (i + 1) * chunkSize))
+export async function parallelSquare(
+  numbers: number[],
+  threads = Math.min(os.cpus().length, numbers.length),
+): Promise<number[]> {
+  if (numbers.length === 0) return []
 
-  return new Promise((resolve, reject) => {
-    const results: number[] = []
-    let completed = 0
+  const actualThreads = Math.min(threads, numbers.length)
+  const chunkSize = Math.ceil(numbers.length / actualThreads)
+  const chunks = Array.from({ length: actualThreads }, (_, i) =>
+    numbers.slice(i * chunkSize, (i + 1) * chunkSize),
+  )
 
-    chunks.forEach(chunk => {
-      if (chunk.length === 0) {
-        completed++
-        if (completed === chunks.length) {
-          resolve(results)
-        }
-        return
-      }
+  const pool = new WorkerPool<number[], number[]>(
+    path.join(fileURLToPath(new URL(".", import.meta.url)), "mapWorker.js"),
+    actualThreads,
+  )
 
-      const worker = new Worker(new URL("./mapWorker.js", import.meta.url), {
-        workerData: chunk,
-      })
-
-      worker.on(
-        "message",
-        (data: number[] | { error: { message: string } }) => {
-          if (Array.isArray(data)) {
-            results.push(...data)
-            completed++
-            if (completed === chunks.length) {
-              resolve(results)
-            }
-          } else if (data && "error" in data) {
-            reject(new Error(data.error.message))
-          }
-        },
-      )
-
-      worker.on("error", reject)
-    })
-  })
+  try {
+    const promises = chunks.map(chunk => pool.run(chunk))
+    const results = await Promise.all(promises)
+    return results.flat()
+  } finally {
+    await pool.destroy()
+  }
 }

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -1,0 +1,78 @@
+import { Worker } from "node:worker_threads"
+
+interface Task<T, R> {
+  data: T
+  resolve: (value: R) => void
+  reject: (reason: unknown) => void
+}
+
+export class WorkerPool<T = unknown, R = unknown> {
+  private readonly workers: Worker[] = []
+  private readonly idle: Worker[] = []
+  private queue: Task<T, R>[] = []
+
+  constructor(private readonly file: string, size: number) {
+    for (let i = 0; i < size; i++) {
+      const worker = new Worker(file)
+      this.workers.push(worker)
+      this.idle.push(worker)
+    }
+  }
+
+  run(data: T): Promise<R> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ data, resolve, reject })
+      this.process()
+    })
+  }
+
+  private process() {
+    while (this.queue.length > 0 && this.idle.length > 0) {
+      const worker = this.idle.shift()!
+      const task = this.queue.shift()!
+
+      const finalize = () => {
+        this.idle.push(worker)
+        this.process()
+      }
+
+      worker.once("message", (result: unknown) => {
+        if (result && typeof result === "object" && "error" in result) {
+          const { error } = result as { error: { message: string } }
+          task.reject(new Error(error.message))
+        } else {
+          task.resolve(result as R)
+        }
+        finalize()
+      })
+
+      worker.once("error", err => {
+        task.reject(err)
+        finalize()
+      })
+
+      worker.once("exit", code => {
+        this.workers.splice(this.workers.indexOf(worker), 1)
+        const idleIndex = this.idle.indexOf(worker)
+        if (idleIndex !== -1) this.idle.splice(idleIndex, 1)
+
+        if (code !== 0) {
+          const replacement = new Worker(this.file)
+          this.workers.push(replacement)
+          this.idle.push(replacement)
+        }
+
+        this.process()
+        task.reject(new Error(`Worker stopped with exit code ${code}`))
+      })
+
+      worker.postMessage(task.data)
+    }
+  }
+
+  async destroy(): Promise<void> {
+    await Promise.all(this.workers.map(worker => worker.terminate()))
+    this.queue = []
+    this.idle.length = 0
+  }
+}


### PR DESCRIPTION
## Summary
- add WorkerPool abstraction with error propagation
- use WorkerPool in parallelSquare and cap threads to input size

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc src/lib/mapWorker.ts src/lib/parallel.ts src/lib/worker-pool.ts --module commonjs --target ES2017 --outDir /tmp/mapWorker --esModuleInterop --skipLibCheck --noEmit false` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cb553548833198e7f56bc14e1f09