### PR TITLE
fix: resolve conflicts in navigation components

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -28,8 +28,8 @@ import {
 } from "@/components/ui/sheet"
 import { NurseFinAILogo } from "@/components/icons"
 import { useToast } from "@/hooks/use-toast"
-import { ThemeSwitcher } from "./theme-switcher"
 import { Navigation } from "./navigation"
+import { ThemeToggle } from "@/components/ThemeToggle"
 
 export default function AppHeader() {
   const router = useRouter()
@@ -55,7 +55,7 @@ export default function AppHeader() {
   }
 
   return (
-    <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b bg-background px-4 sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
+    <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b bg-background px-4 dark:bg-background sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
           <Button size="icon" variant="outline" className="sm:hidden">
@@ -81,10 +81,10 @@ export default function AppHeader() {
         <Input
           type="search"
           placeholder="Search..."
-          className="w-full rounded-lg bg-secondary pl-8 md:w-[200px] lg:w-[336px]"
+          className="w-full rounded-lg bg-secondary pl-8 md:w-[200px] lg:w-[336px] dark:bg-secondary"
         />
       </div>
-      <ThemeSwitcher />
+      <ThemeToggle />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -20,7 +20,7 @@ export default function AppSidebar() {
   return (
     <aside
       className={cn(
-        "fixed inset-y-0 left-0 z-10 hidden flex-col border-r bg-background transition-all sm:flex",
+        "fixed inset-y-0 left-0 z-10 hidden flex-col border-r bg-background dark:border-r dark:bg-background transition-all sm:flex",
         collapsed ? "w-14" : "w-56"
       )}
     >


### PR DESCRIPTION
## Summary
- replace ThemeSwitcher with shared ThemeToggle in header
- ensure header and sidebar support dark theme styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0ca9bbb348331848df62224326937