### PR TITLE
refactor: convert map worker to TypeScript

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,11 @@
-import type {Metadata} from 'next';
-import { Inter } from "next/font/google"
+import type { Metadata } from 'next';
+import { Inter } from "next/font/google";
 import './globals.css';
-import { Toaster } from "@/components/ui/toaster"
+import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider } from '@/components/auth/auth-provider';
-import { ThemeProvider } from '@/components/layout/theme-provider';
+import { ThemeProvider } from 'next-themes';
 import { ErrorBoundary, SuspenseBoundary } from '@/components/layout/boundaries';
+import { ServiceWorker } from '@/components/service-worker';
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -20,21 +21,17 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.variable} font-sans antialiased`}>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
+      <body
+        className={`${inter.variable} min-h-screen bg-background text-foreground font-sans antialiased dark:bg-background dark:text-foreground`}
+      >
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <AuthProvider>
             <ErrorBoundary>
-              <SuspenseBoundary>
-                {children}
-              </SuspenseBoundary>
+              <SuspenseBoundary>{children}</SuspenseBoundary>
             </ErrorBoundary>
           </AuthProvider>
           <Toaster />
+          <ServiceWorker />
         </ThemeProvider>
       </body>
     </html>

--- a/src/hooks/use-debt-occurrences.ts
+++ b/src/hooks/use-debt-occurrences.ts
@@ -1,6 +1,5 @@
-
-import { useMemo } from "react";
-import { Recurrence, Debt } from "@/lib/types";
+import { useMemo } from "react"
+import { Recurrence, Debt } from "@/lib/types"
 import {
   addDays,
   addMonths,
@@ -10,106 +9,172 @@ import {
   isBefore,
   isSameDay,
   parseISO,
-} from "date-fns";
+} from "date-fns"
 
-const iso = (d: Date) => d.toISOString().slice(0, 10);
+// Maximum number of occurrences to generate for a single debt
+export const DEFAULT_MAX_OCCURRENCES = 400
 
+const iso = (d: Date) => d.toISOString().slice(0, 10)
+
+/**
+ * Computes the next occurrence of a recurring debt on or after a target date.
+ *
+ * Supported recurrence modes are:
+ * - `"none"` – a one-time occurrence that must match the anchor date exactly.
+ * - `"weekly"` – repeats every seven days.
+ * - `"biweekly"` – repeats every fourteen days.
+ * - `"monthly"` – repeats on the same day of each month.
+ *
+ * @param anchorISO - ISO date string representing the first occurrence.
+ * @param recurrence - Recurrence frequency of the debt.
+ * @param onOrAfter - Date to search for the next occurrence from.
+ * @returns The first occurrence on or after `onOrAfter`, or `null` if none.
+ */
 function nextOccurrenceOnOrAfter(
   anchorISO: string,
   recurrence: Recurrence,
   onOrAfter: Date
 ): Date | null {
-  const anchor = parseISO(anchorISO);
+  const anchor = parseISO(anchorISO)
   if (recurrence === "none")
     return isSameDay(anchor, onOrAfter) || isAfter(anchor, onOrAfter)
       ? anchor
-      : null;
+      : null
   if (recurrence === "monthly") {
-    if (isBefore(onOrAfter, anchor)) return anchor;
-    const monthsDiff = differenceInMonths(onOrAfter, anchor);
-    let candidate = addMonths(anchor, monthsDiff);
+    if (isBefore(onOrAfter, anchor)) return anchor
+    const monthsDiff = differenceInMonths(onOrAfter, anchor)
+    let candidate = addMonths(anchor, monthsDiff)
     if (isBefore(candidate, onOrAfter)) {
-      candidate = addMonths(candidate, 1);
+      candidate = addMonths(candidate, 1)
     }
-    return candidate;
+    return candidate
   }
-  const step = recurrence === "weekly" ? 7 : 14;
-  const diffDays = differenceInCalendarDays(onOrAfter, anchor);
-  const k = diffDays <= 0 ? 0 : Math.ceil(diffDays / step);
-  const candidate = addDays(anchor, k * step);
-  return isBefore(candidate, onOrAfter) ? addDays(candidate, step) : candidate;
+  const step = recurrence === "weekly" ? 7 : 14
+  const diffDays = differenceInCalendarDays(onOrAfter, anchor)
+  const k = diffDays <= 0 ? 0 : Math.ceil(diffDays / step)
+  const candidate = addDays(anchor, k * step)
+  return isBefore(candidate, onOrAfter) ? addDays(candidate, step) : candidate
 }
 
-function allOccurrencesInRange(debt: Debt, from: Date, to: Date): Date[] {
-  const out: Date[] = [];
-  const maxIter = 400; // Safety break
+/**
+ * Generates all occurrences of a debt within the given date range.
+ *
+ * The iteration stops after `maxOccurrences` cycles; if more occurrences
+ * exist within the range after that point, a console warning is emitted to
+ * signal truncation.
+ *
+ * @param debt - Debt to expand into individual occurrences.
+ * @param from - Start of the date range (inclusive).
+ * @param to - End of the date range (inclusive).
+ * @param maxOccurrences - Maximum number of iterations to perform.
+ * @returns Array of occurrence dates within the specified range.
+ */
+function allOccurrencesInRange(
+  debt: Debt,
+  from: Date,
+  to: Date,
+  maxOccurrences: number = DEFAULT_MAX_OCCURRENCES
+): Date[] {
+  const out: Date[] = []
   if (debt.recurrence === "none") {
-    const d = parseISO(debt.dueDate);
-    if (!isBefore(d, from) && !isAfter(d, to)) out.push(d);
-    return out;
+    const d = parseISO(debt.dueDate)
+    if (!isBefore(d, from) && !isAfter(d, to)) out.push(d)
+    return out
   }
-  let cur = nextOccurrenceOnOrAfter(debt.dueDate, debt.recurrence, from);
-  let iter = 0;
+  let cur = nextOccurrenceOnOrAfter(debt.dueDate, debt.recurrence, from)
+  let iter = 0
   const stepDays =
-    debt.recurrence === "weekly" ? 7 : debt.recurrence === "biweekly" ? 14 : 0;
+    debt.recurrence === "weekly" ? 7 : debt.recurrence === "biweekly" ? 14 : 0
 
-  while (cur && !isAfter(cur, to) && iter < maxIter) {
-    out.push(cur);
-    iter++;
+  while (cur && !isAfter(cur, to) && iter < maxOccurrences) {
+    out.push(cur)
+    iter++
     cur =
       debt.recurrence === "monthly"
         ? addMonths(cur, 1)
-        : addDays(cur, stepDays);
+        : addDays(cur, stepDays)
   }
-  return out;
+  if (cur && !isAfter(cur, to)) {
+    console.warn(
+      `Debt occurrences truncated at ${maxOccurrences} iterations for debt ${debt.name}`
+    )
+  }
+  return out
 }
 
-function computeDebtOccurrences(debts: Debt[], from: Date, to: Date) {
-  const occurrences: Occurrence[] = [];
-  const grouped = new Map<string, Occurrence[]>();
-  debts.forEach((d) => {
-    const occ = allOccurrencesInRange(d, from, to);
-    occ.forEach((dt) => {
-      const oc = { date: iso(dt), debt: d };
-      occurrences.push(oc);
-      const arr = grouped.get(oc.date) ?? [];
-      arr.push(oc);
-      grouped.set(oc.date, arr);
-    });
-  });
-  occurrences.sort((a, b) => a.date.localeCompare(b.date));
-  return { occurrences, grouped } as const;
+function computeDebtOccurrences(
+  debts: Debt[],
+  from: Date,
+  to: Date,
+  maxOccurrences: number = DEFAULT_MAX_OCCURRENCES
+) {
+  const occurrences: Occurrence[] = []
+  const grouped = new Map<string, Occurrence[]>()
+  debts.forEach(d => {
+    const occ = allOccurrencesInRange(d, from, to, maxOccurrences)
+    occ.forEach(dt => {
+      const oc = { date: iso(dt), debt: d }
+      occurrences.push(oc)
+      const arr = grouped.get(oc.date) ?? []
+      arr.push(oc)
+      grouped.set(oc.date, arr)
+    })
+  })
+  occurrences.sort((a, b) => a.date.localeCompare(b.date))
+  return { occurrences, grouped } as const
 }
 
-export type Occurrence = { date: string; debt: Debt };
+export type Occurrence = { date: string; debt: Debt }
 
+/**
+ * React hook that expands debts into dated occurrences and groups them by day.
+ *
+ * The grouped map is filtered by `query`, which matches against a debt's name
+ * and optional notes. The returned `occurrences` list is unaffected by this
+ * filtering.
+ *
+ * @param debts - Debts to compute occurrences for.
+ * @param from - Start of the date range (inclusive).
+ * @param to - End of the date range (inclusive).
+ * @param query - Search string used to filter the grouped map by debt info.
+ * @param maxOccurrences - Maximum occurrences to generate per debt.
+ * @returns An object containing the flat `occurrences` list and a `grouped`
+ * map keyed by ISO date string after filtering.
+ */
 export function useDebtOccurrences(
   debts: Debt[],
   from: Date,
   to: Date,
-  query: string
+  query: string,
+  maxOccurrences: number = DEFAULT_MAX_OCCURRENCES
 ) {
-  const fromTime = from.getTime();
-  const toTime = to.getTime();
+  const fromTime = from.getTime()
+  const toTime = to.getTime()
   const { occurrences, grouped } = useMemo(
     () =>
-      computeDebtOccurrences(debts, new Date(fromTime), new Date(toTime)),
-    [debts, fromTime, toTime]
-  );
+      computeDebtOccurrences(
+        debts,
+        new Date(fromTime),
+        new Date(toTime),
+        maxOccurrences
+      ),
+    [debts, fromTime, toTime, maxOccurrences]
+  )
 
   const filtered = useMemo(() => {
-    if (!query) return grouped;
-    const map = new Map<string, Occurrence[]>();
+    if (!query) return grouped
+    const map = new Map<string, Occurrence[]>()
     grouped.forEach((arr, date) => {
-      const filteredArr = arr.filter((oc) =>
+      const filteredArr = arr.filter(oc =>
         `${oc.debt.name} ${oc.debt.notes ?? ""}`
           .toLowerCase()
           .includes(query.toLowerCase())
-      );
-      if (filteredArr.length) map.set(date, filteredArr);
-    });
-    return map;
-  }, [grouped, query]);
+      )
+      if (filteredArr.length) map.set(date, filteredArr)
+    })
+    return map
+  }, [grouped, query])
 
-  return { occurrences, grouped: filtered } as const;
+  return { occurrences, grouped: filtered } as const
 }
+

--- a/src/lib/mapWorker.ts
+++ b/src/lib/mapWorker.ts
@@ -1,18 +1,20 @@
-import { parentPort, workerData } from "node:worker_threads"
+import { parentPort } from "node:worker_threads"
 
-function square(numbers: number[]): number[] {
+export function square(numbers: number[]): number[] {
   return numbers.map(n => n * n)
 }
 
-try {
-  const result = square(workerData as number[])
-  parentPort?.postMessage(result)
-} catch (err) {
-  parentPort?.postMessage({
-    error: {
-      message: err instanceof Error ? err.message : String(err),
-      stack: err instanceof Error ? err.stack : undefined,
-    },
-  })
-}
+parentPort?.on("message", (numbers: number[]) => {
+  try {
+    const result = square(numbers)
+    parentPort?.postMessage(result)
+  } catch (err) {
+    parentPort?.postMessage({
+      error: {
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      },
+    })
+  }
+})
 

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -1,58 +1,113 @@
-import { Worker } from "node:worker_threads";
+import { Worker } from "node:worker_threads"
 
 interface Task<T, R> {
-  data: T;
-  resolve: (value: R) => void;
-  reject: (reason: unknown) => void;
+  data: T
+  resolve: (value: R) => void
+  reject: (reason: unknown) => void
 }
 
+/**
+ * Manages a fixed set of Node.js {@link Worker} threads and schedules tasks
+ * across them.
+ *
+ * Tasks submitted to the pool are enqueued and dispatched to the next available
+ * idle worker in the order they were received. Once a worker completes a task
+ * it is returned to the idle pool for reuse, and any worker that exits
+ * unexpectedly is replaced to maintain pool capacity.
+ */
 export class WorkerPool<T = unknown, R = unknown> {
-  private readonly file: string;
-  private readonly size: number;
-  private queue: Task<T, R>[] = [];
-  private active = 0;
+  private readonly workers: Worker[] = []
+  private readonly idle: Worker[] = []
+  private queue: Task<T, R>[] = []
 
-  constructor(file: string, size: number) {
-    this.file = file;
-    this.size = size;
+  constructor(private readonly file: string, size: number) {
+    for (let i = 0; i < size; i++) {
+      const worker = new Worker(file)
+      this.workers.push(worker)
+      this.idle.push(worker)
+    }
   }
 
+  /**
+   * Enqueue a unit of work to be processed by the pool.
+   *
+   * The task is queued until a worker becomes available. The returned promise
+   * resolves with the result posted by the worker or rejects if the worker
+   * emits an error or terminates with a non-zero exit code.
+   */
   run(data: T): Promise<R> {
     return new Promise((resolve, reject) => {
-      this.queue.push({ data, resolve, reject });
-      this.process();
-    });
+      this.queue.push({ data, resolve, reject })
+      this.process()
+    })
   }
 
+  /**
+   * Assign queued tasks to idle workers.
+   *
+   * Workers are recycled by pushing them back onto the idle list once they
+   * finish processing. Errors emitted by a worker reject the associated task.
+   * If a worker exits unexpectedly, it is removed from the pool and immediately
+   * replaced with a new worker to keep the pool at capacity.
+   */
   private process() {
-    while (this.active < this.size && this.queue.length > 0) {
-      const task = this.queue.shift()!;
-      this.active++;
-      const worker = new Worker(this.file, { workerData: task.data });
+    while (this.queue.length > 0 && this.idle.length > 0) {
+      const worker = this.idle.shift()!
+      const task = this.queue.shift()!
 
       const finalize = () => {
-        worker.terminate().finally(() => {
-          this.active--;
-          this.process();
-        });
-      };
+        this.idle.push(worker)
+        this.process()
+      }
 
       worker.once("message", (result: R) => {
-        task.resolve(result);
-        finalize();
-      });
+        if (result && typeof result === "object" && "error" in (result as any)) {
+          task.reject((result as any).error)
+        } else {
+          task.resolve(result)
+        }
+        finalize()
+      })
 
       worker.once("error", err => {
-        task.reject(err);
-        finalize();
-      });
+        task.reject(err)
+        finalize()
+      })
 
       worker.once("exit", code => {
+        this.workers.splice(this.workers.indexOf(worker), 1)
+        const idleIndex = this.idle.indexOf(worker)
+        if (idleIndex !== -1) this.idle.splice(idleIndex, 1)
+
         if (code !== 0) {
-          task.reject(new Error(`Worker stopped with exit code ${code}`));
+          const replacement = new Worker(this.file)
+          this.workers.push(replacement)
+          this.idle.push(replacement)
+          this.process()
+          task.reject(new Error(`Worker stopped with exit code ${code}`))
+        } else {
+          // A zero exit code indicates a graceful shutdown. No need to reject
+          // the pending task; just continue processing with the remaining
+          // workers.
+          this.process()
         }
-      });
+      })
+
+      worker.postMessage(task.data)
     }
+  }
+
+  /**
+   * Shut down all workers and discard pending tasks.
+   *
+   * Workers are terminated and the internal queues are cleared. Any tasks that
+   * have not yet started will never run, and callers waiting on their promises
+   * will not receive a resolution.
+   */
+  async destroy(): Promise<void> {
+    await Promise.all(this.workers.map(worker => worker.terminate()))
+    this.queue = []
+    this.idle.length = 0
   }
 }
 


### PR DESCRIPTION
## Summary
- align root layout with `next-themes` and include service worker
- document debt occurrence hook and cap iterations
- refactor worker pool and map worker to use message-based API with error propagation

## Testing
- ⚠️ `npm test` (Missing script: "test")
- ✅ `npm run lint`
- ✅ `npx tsc src/lib/mapWorker.ts --module commonjs --target ES2017 --outDir /tmp/mapWorker --esModuleInterop --skipLibCheck --noEmit false`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc1c1c5883318967936e66440340