### PR TITLE
fix: resolve worker pool merge conflicts

### DIFF
--- a/src/lib/mapWorker.ts
+++ b/src/lib/mapWorker.ts
@@ -1,18 +1,19 @@
-import { parentPort, workerData } from "node:worker_threads"
+import { parentPort } from "node:worker_threads"
 
-function square(numbers: number[]): number[] {
+export function square(numbers: number[]): number[] {
   return numbers.map(n => n * n)
 }
 
-try {
-  const result = square(workerData as number[])
-  parentPort?.postMessage(result)
-} catch (err) {
-  parentPort?.postMessage({
-    error: {
-      message: err instanceof Error ? err.message : String(err),
-      stack: err instanceof Error ? err.stack : undefined,
-    },
-  })
-}
+parentPort?.on("message", (numbers: number[]) => {
+  try {
+    parentPort?.postMessage(square(numbers))
+  } catch (err) {
+    parentPort?.postMessage({
+      error: {
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      },
+    })
+  }
+})
 

--- a/src/lib/parallel.ts
+++ b/src/lib/parallel.ts
@@ -5,19 +5,19 @@ import { WorkerPool } from "./worker-pool"
 
 export async function parallelSquare(
   numbers: number[],
-  threads = Math.min(os.cpus().length, numbers.length),
+  threads = Math.min(os.cpus().length, numbers.length)
 ): Promise<number[]> {
   if (numbers.length === 0) return []
 
   const actualThreads = Math.min(threads, numbers.length)
   const chunkSize = Math.ceil(numbers.length / actualThreads)
   const chunks = Array.from({ length: actualThreads }, (_, i) =>
-    numbers.slice(i * chunkSize, (i + 1) * chunkSize),
+    numbers.slice(i * chunkSize, (i + 1) * chunkSize)
   )
 
   const pool = new WorkerPool<number[], number[]>(
     path.join(fileURLToPath(new URL(".", import.meta.url)), "mapWorker.js"),
-    actualThreads,
+    actualThreads
   )
 
   try {

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -6,6 +6,15 @@ interface Task<T, R> {
   reject: (reason: unknown) => void
 }
 
+/**
+ * Manages a fixed set of Node.js {@link Worker} threads and schedules tasks
+ * across them.
+ *
+ * Tasks submitted to the pool are enqueued and dispatched to the next available
+ * idle worker in the order they were received. Once a worker completes a task
+ * it is returned to the idle pool for reuse, and any worker that exits
+ * unexpectedly is replaced to maintain pool capacity.
+ */
 export class WorkerPool<T = unknown, R = unknown> {
   private readonly workers: Worker[] = []
   private readonly idle: Worker[] = []
@@ -19,6 +28,13 @@ export class WorkerPool<T = unknown, R = unknown> {
     }
   }
 
+  /**
+   * Enqueue a unit of work to be processed by the pool.
+   *
+   * The task is queued until a worker becomes available. The returned promise
+   * resolves with the result posted by the worker or rejects if the worker
+   * emits an error or terminates with a non-zero exit code.
+   */
   run(data: T): Promise<R> {
     return new Promise((resolve, reject) => {
       this.queue.push({ data, resolve, reject })
@@ -26,6 +42,14 @@ export class WorkerPool<T = unknown, R = unknown> {
     })
   }
 
+  /**
+   * Assign queued tasks to idle workers.
+   *
+   * Workers are recycled by pushing them back onto the idle list once they
+   * finish processing. Errors emitted by a worker reject the associated task.
+   * If a worker exits unexpectedly, it is removed from the pool and immediately
+   * replaced with a new worker to keep the pool at capacity.
+   */
   private process() {
     while (this.queue.length > 0 && this.idle.length > 0) {
       const worker = this.idle.shift()!
@@ -60,16 +84,27 @@ export class WorkerPool<T = unknown, R = unknown> {
           const replacement = new Worker(this.file)
           this.workers.push(replacement)
           this.idle.push(replacement)
+          this.process()
+          task.reject(new Error(`Worker stopped with exit code ${code}`))
+        } else {
+          // A zero exit code indicates a graceful shutdown. No need to reject
+          // the pending task; just continue processing with the remaining
+          // workers.
+          this.process()
         }
-
-        this.process()
-        task.reject(new Error(`Worker stopped with exit code ${code}`))
       })
 
       worker.postMessage(task.data)
     }
   }
 
+  /**
+   * Shut down all workers and discard pending tasks.
+   *
+   * Workers are terminated and the internal queues are cleared. Any tasks that
+   * have not yet started will never run, and callers waiting on their promises
+   * will not receive a resolution.
+   */
   async destroy(): Promise<void> {
     await Promise.all(this.workers.map(worker => worker.terminate()))
     this.queue = []


### PR DESCRIPTION
## Summary
- handle worker messages with structured error reporting
- align parallelSquare formatting with project style
- document worker pool and propagate worker errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc src/lib/mapWorker.ts src/lib/parallel.ts src/lib/worker-pool.ts --module esnext --target ES2017 --outDir /tmp/mapWorker --esModuleInterop --skipLibCheck --noEmit false`


------
https://chatgpt.com/codex/tasks/task_e_68b0cd481e5c8331a324fa3a1fcb0dde