### PR TITLE
feat: prune offline queue with cursors

### DIFF
--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -1,5 +1,13 @@
 jest.mock("idb", () => {
   const store: unknown[] = []
+  const createCursor = (index: number) => ({
+    async delete() {
+      store.splice(index, 1)
+    },
+    async continue() {
+      return index < store.length ? createCursor(index) : null
+    },
+  })
   return {
     openDB: jest.fn(async () => ({
       add: async (_store: string, value: unknown) => {
@@ -9,10 +17,13 @@ jest.mock("idb", () => {
       clear: async () => {
         store.length = 0
       },
-      getAllKeys: async () => store.map((_, i) => i),
-      delete: async () => {
-        store.shift()
-      },
+      count: async () => store.length,
+      transaction: () => ({
+        store: {
+          openKeyCursor: async () => (store.length ? createCursor(0) : null),
+        },
+        done: Promise.resolve(),
+      }),
     })),
   }
 })
@@ -24,7 +35,7 @@ import {
 } from "../lib/offline"
 
 describe("offline fallbacks", () => {
-  it("uses in-memory store when IndexedDB fails", async () => {
+  it("queues and retrieves transactions", async () => {
     expect(await queueTransaction({ id: 1 })).toBe(true)
     expect(await queueTransaction({ id: 2 })).toBe(true)
 
@@ -34,5 +45,16 @@ describe("offline fallbacks", () => {
     expect(await clearQueuedTransactions()).toBe(true)
     const empty = await getQueuedTransactions()
     expect(empty).toEqual([])
+  })
+
+  it("prunes oldest transactions beyond queue size", async () => {
+    for (let i = 1; i <= 5; i++) {
+      await queueTransaction({ id: i }, 3)
+    }
+
+    const queued = await getQueuedTransactions<{ id: number }>()
+    expect(queued).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }])
+
+    await clearQueuedTransactions()
   })
 })


### PR DESCRIPTION
## Summary
- replace getAllKeys with openKeyCursor to prune only oldest overflow entries
- limit cursor loop to required deletions
- test cursor-based pruning logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cf9d14088331a9f65ce8d508b75c