### PR TITLE
Abort in-flight service worker sync requests

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -1,0 +1,83 @@
+import { render, act } from "@testing-library/react"
+import { ServiceWorker } from "../components/service-worker"
+
+jest.mock("../lib/offline", () => ({
+  getQueuedTransactions: jest.fn().mockResolvedValue([{ id: 1 }]),
+  clearQueuedTransactions: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock("../lib/firebase", () => ({
+  auth: { currentUser: { getIdToken: jest.fn().mockResolvedValue("token") } },
+}))
+
+jest.mock("../hooks/use-toast", () => ({ toast: jest.fn() }))
+
+describe("ServiceWorker aborts in-flight sync", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    ;(fetch as jest.Mock).mockReset()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("aborts fetch on unmount", async () => {
+    let signal: AbortSignal | undefined
+    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
+      signal = options.signal
+      return new Promise(() => {})
+    })
+
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      configurable: true,
+    })
+
+    const { unmount } = render(<ServiceWorker />)
+
+    await act(async () => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(signal).toBeDefined()
+
+    unmount()
+
+    expect(signal!.aborted).toBe(true)
+  })
+
+  it("aborts previous fetch when new sync starts", async () => {
+    const signals: AbortSignal[] = []
+    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
+      signals.push(options.signal)
+      return new Promise(() => {})
+    })
+
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      configurable: true,
+    })
+
+    render(<ServiceWorker />)
+
+    await act(async () => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(signals[0].aborted).toBe(false)
+
+    await act(async () => {
+      window.dispatchEvent(new Event("online"))
+    })
+
+    expect(signals[0].aborted).toBe(true)
+
+    await act(async () => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(signals[1]).toBeDefined()
+    expect(signals[1].aborted).toBe(false)
+  })
+})

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -10,11 +10,16 @@ export function ServiceWorker() {
   const retryTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null)
   const retryCount = useRef(0)
   const notified = useRef(false)
+  const abortController = useRef<AbortController | null>(null)
 
   useEffect(() => {
     const syncQueued = async () => {
       const queued = await getQueuedTransactions()
       if (!queued.length) return
+
+      abortController.current?.abort()
+      const controller = new AbortController()
+      abortController.current = controller
 
       try {
         const user = auth.currentUser
@@ -31,6 +36,7 @@ export function ServiceWorker() {
             Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({ transactions: queued }),
+          signal: controller.signal,
         })
 
         if (!response.ok) {
@@ -41,6 +47,8 @@ export function ServiceWorker() {
         retryCount.current = 0
         notified.current = false
       } catch (error) {
+        if (controller.signal.aborted) return
+
         retryCount.current += 1
         const delay = Math.min(1000 * 2 ** (retryCount.current - 1), 30000)
 
@@ -60,6 +68,7 @@ export function ServiceWorker() {
     }
 
     const handleOnline = () => {
+      abortController.current?.abort()
       if (debounceId.current) clearTimeout(debounceId.current)
       if (retryTimeoutId.current) clearTimeout(retryTimeoutId.current)
       retryCount.current = 0
@@ -86,6 +95,7 @@ export function ServiceWorker() {
       window.removeEventListener("online", handleOnline)
       if (debounceId.current) clearTimeout(debounceId.current)
       if (retryTimeoutId.current) clearTimeout(retryTimeoutId.current)
+      abortController.current?.abort()
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- cancel in-progress queued sync fetches using `AbortController`
- pass abort signal to sync fetch and cancel on unmount or new sync event
- test that sync aborts when component unmounts or a new sync starts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0cf9ec3708331b10026b3908ae8b4