### PR TITLE
Add payday countdown card

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,7 @@
 
 import OverviewCards from "@/components/dashboard/overview-cards";
+import TimeCard from "@/components/dashboard/time-card";
+import PaydayCountdownCard from "@/components/dashboard/payday-countdown-card";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import DashboardCharts from '@/app/dashboard/dashboard-charts';
@@ -36,6 +38,10 @@ export default async function DashboardPage() {
       <div className="space-y-1">
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
         <p className="text-muted-foreground">Here's a high-level overview of your finances.</p>
+      </div>
+      <div className="grid gap-6 sm:grid-cols-2">
+        <TimeCard />
+        <PaydayCountdownCard />
       </div>
       <Suspense fallback={<Skeleton className="h-[126px] w-full" />}>
         <OverviewCards transactions={transactions} />

--- a/src/components/dashboard/payday-countdown-card.tsx
+++ b/src/components/dashboard/payday-countdown-card.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@/components/ui/card"
+import { getNextPayDay } from "@/lib/payroll"
+
+export default function PaydayCountdownCard() {
+  const today = new Date()
+  const nextPayDay = getNextPayDay(today)
+
+  const startOfToday = new Date(today)
+  startOfToday.setHours(0, 0, 0, 0)
+  const diffMs = nextPayDay.getTime() - startOfToday.getTime()
+  const daysRemaining = Math.max(0, Math.ceil(diffMs / (1000 * 60 * 60 * 24)))
+
+  const message = daysRemaining === 0 ? "It's pay day!" : `${daysRemaining} day${daysRemaining !== 1 ? 's' : ''} remaining`
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Next Pay Day</CardTitle>
+        <CardDescription>{nextPayDay.toLocaleDateString()}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{message}</div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/dashboard/time-card.tsx
+++ b/src/components/dashboard/time-card.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card"
+
+export default function TimeCard() {
+  const [now, setNow] = useState(new Date())
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Current Time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{now.toLocaleTimeString()}</div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/lib/payroll.ts
+++ b/src/lib/payroll.ts
@@ -38,6 +38,22 @@ export const getPayPeriodStart = (
   return d;
 };
 
+// Determine the next pay day for a biweekly schedule. If the provided date is
+// already the start of a pay period, that date is considered the pay day.
+export const getNextPayDay = (date: Date = new Date()): Date => {
+  const start = getPayPeriodStart(date)
+  const today = new Date(date)
+  today.setHours(0, 0, 0, 0)
+
+  if (today > start) {
+    const next = new Date(start)
+    next.setDate(start.getDate() + 14)
+    return next
+  }
+
+  return start
+}
+
 export const calculateOvertimeDates = (shifts: Shift[]): Date[] => {
   const weeklyShifts: Record<string, Shift[]> = {};
 


### PR DESCRIPTION
## Summary
- add helper to compute next pay day for biweekly payroll
- show current time and countdown until next pay day on dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d0dcc5f8833194165e61ba0ad5cd