### PR TITLE
fix: merge main and resolve conflicts

### DIFF
--- a/src/hooks/use-debt-occurrences.ts
+++ b/src/hooks/use-debt-occurrences.ts
@@ -5,6 +5,16 @@ import { computeOccurrences, groupOccurrences, Occurrence } from "@/lib/debt-occ
 // Maximum number of occurrences to generate for a single debt
 export const DEFAULT_MAX_OCCURRENCES = 400;
 
+/**
+ * React hook that computes and groups debt occurrences within a date range.
+ *
+ * @param debts - Debts to compute occurrences for.
+ * @param from - Start of the date range (inclusive).
+ * @param to - End of the date range (inclusive).
+ * @param query - Search string used to filter grouped results.
+ * @param maxOccurrences - Maximum occurrences to generate per debt.
+ * @returns An object containing `occurrences` and `grouped` occurrences map.
+ */
 export function useDebtOccurrences(
   debts: Debt[],
   from: Date,
@@ -16,7 +26,10 @@ export function useDebtOccurrences(
     () => computeOccurrences(debts, from, to, maxOccurrences),
     [debts, from, to, maxOccurrences]
   );
-  const grouped = useMemo(() => groupOccurrences(occurrences, query), [occurrences, query]);
+  const grouped = useMemo(
+    () => groupOccurrences(occurrences, query),
+    [occurrences, query]
+  );
   return { occurrences, grouped } as const;
 }
 


### PR DESCRIPTION
## Summary
- merge latest `main` and resolve conflicts in DebtCalendar and useDebtOccurrences
- reintroduce memoized occurrence hook leveraging cached helpers

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any usage and other lint errors)*
- `npm run build` *(fails: Module not found: @genkit-ai/googleai)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d159c9f08331ab1c5d37aefc7e4e