### PR TITLE
feat: add network time helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,17 @@ Create a `.env.local` file by copying `.env.example` and populate it with the re
 | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Default Cloud Storage bucket for uploads. |
 | `RETENTION_DAYS` | Number of days to retain files before deletion (default: 30). |
 | `CRON_SECRET` | Shared secret expected in the `X-CRON-SECRET` header for housekeeping runs. |
+| `DEFAULT_TZ` | Optional IANA timezone used when synchronizing time with the network. Defaults to the system timezone. |
 
 Adjust the retention threshold by setting `RETENTION_DAYS` before running the service or updating the scheduled job configuration.
+
+## Internet time helper
+
+Use `fetchInternetTime(tz)` to query a trusted source for the current time and
+cache the offset between the device clock and network time. Subsequent calls to
+`getCurrentTime(tz?)` apply this offset and fall back to the local clock when
+the API is unreachable. The optional `tz` parameter accepts any IANA timezone
+string and defaults to `DEFAULT_TZ` or the runtime's resolved timezone.
 
 ## Upgrading Next.js
 

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -3,9 +3,14 @@
  */
 import { GET, resetRateLimit } from "@/app/api/cron/housekeeping/route";
 import { runHousekeeping } from "@/lib/housekeeping";
+import { getCurrentTime } from "@/lib/internet-time";
 
 jest.mock("@/lib/housekeeping", () => ({
   runHousekeeping: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/lib/internet-time", () => ({
+  getCurrentTime: jest.fn(),
 }));
 
 jest.mock("@/lib/firebase", () => ({ db: {} }));
@@ -52,6 +57,7 @@ describe("/api/cron/housekeeping", () => {
     process.env.CRON_SECRET = secret;
     await resetRateLimit();
     (runHousekeeping as jest.Mock).mockClear();
+    (getCurrentTime as jest.Mock).mockResolvedValue(new Date(61_000));
   });
 
   it("returns 401 when secret is missing or invalid", async () => {

--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -23,6 +23,10 @@ jest.mock('firebase/auth', () => ({
   getAuth: jest.fn(() => ({})),
 }));
 
+jest.mock('../lib/internet-time', () => ({
+  getCurrentTime: jest.fn(async () => new Date(0)),
+}));
+
 jest.mock('firebase/firestore', () => {
   const where = (field: string, op: string, value: any) => ({
     type: 'where',

--- a/src/__tests__/internet-time.test.ts
+++ b/src/__tests__/internet-time.test.ts
@@ -1,0 +1,72 @@
+import {
+  fetchInternetTime,
+  getCurrentTime,
+  __resetInternetTimeOffset,
+} from "@/lib/internet-time";
+
+describe("internet time", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    __resetInternetTimeOffset();
+    (global as any).fetch = jest.fn();
+    delete process.env.DEFAULT_TZ;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("calculates offset and adjusts current time", async () => {
+    const deviceNow = new Date("2024-01-01T00:00:00Z").getTime();
+    jest.setSystemTime(deviceNow);
+    const networkTime = new Date(deviceNow + 5000).toISOString();
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ datetime: networkTime }),
+    });
+
+    const fetched = await fetchInternetTime("Etc/UTC");
+    expect(fetched.toISOString()).toBe(networkTime);
+
+    jest.setSystemTime(deviceNow + 1000);
+    const current = await getCurrentTime("Etc/UTC");
+    expect(current.getTime()).toBe(deviceNow + 1000 + 5000);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to device time when fetch fails", async () => {
+    const deviceNow = 123456;
+    jest.setSystemTime(deviceNow);
+    (fetch as jest.Mock).mockRejectedValue(new Error("fail"));
+
+    const current = await getCurrentTime("Etc/UTC");
+    expect(current.getTime()).toBe(deviceNow);
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  it("uses environment timezone by default", async () => {
+    process.env.DEFAULT_TZ = "Etc/UTC";
+    const deviceNow = 0;
+    jest.setSystemTime(deviceNow);
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ datetime: new Date(deviceNow).toISOString() }),
+    });
+
+    await getCurrentTime();
+    expect((fetch as jest.Mock).mock.calls[0][0]).toContain("/Etc/UTC");
+  });
+
+  it("allows overriding timezone", async () => {
+    const deviceNow = 0;
+    jest.setSystemTime(deviceNow);
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ datetime: new Date(deviceNow).toISOString() }),
+    });
+
+    await getCurrentTime("Asia/Tokyo");
+    expect((fetch as jest.Mock).mock.calls[0][0]).toContain("/Asia/Tokyo");
+  });
+});

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { runHousekeeping } from "@/lib/housekeeping";
 import { db } from "@/lib/firebase";
+import { getCurrentTime } from "@/lib/internet-time";
 import { doc, runTransaction, setDoc } from "firebase/firestore";
 
 const HEADER_NAME = "x-cron-secret";
@@ -19,10 +20,10 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const now = (await getCurrentTime()).getTime();
   const allowed = await runTransaction(db, async (tx) => {
     const snap = await tx.get(STATE_DOC);
     const last = snap.exists() ? snap.data().lastRun ?? 0 : 0;
-    const now = Date.now();
     if (now - last < WINDOW_MS) {
       return false;
     }

--- a/src/lib/internet-time.ts
+++ b/src/lib/internet-time.ts
@@ -1,0 +1,36 @@
+let offsetMs: number | null = null;
+
+function resolveTimezone(tz?: string): string {
+  return (
+    tz ||
+    process.env.DEFAULT_TZ ||
+    Intl.DateTimeFormat().resolvedOptions().timeZone
+  );
+}
+
+export async function fetchInternetTime(tz: string): Promise<Date> {
+  const res = await fetch(`https://worldtimeapi.org/api/timezone/${tz}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch time for timezone ${tz}`);
+  }
+  const data = await res.json();
+  const networkDate = new Date(data.datetime);
+  const deviceDate = new Date();
+  offsetMs = networkDate.getTime() - deviceDate.getTime();
+  return networkDate;
+}
+
+export async function getCurrentTime(tz?: string): Promise<Date> {
+  if (offsetMs === null) {
+    try {
+      await fetchInternetTime(resolveTimezone(tz));
+    } catch {
+      return new Date();
+    }
+  }
+  return new Date(Date.now() + (offsetMs ?? 0));
+}
+
+export function __resetInternetTimeOffset() {
+  offsetMs = null;
+}

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -13,6 +13,7 @@ import {
 } from "firebase/firestore";
 import { db } from "../lib/firebase";
 import type { Transaction, Debt, Goal } from "../lib/types";
+import { getCurrentTime } from "../lib/internet-time";
 
 /**
  * Moves transactions older than the provided cutoff date to an archive collection
@@ -169,10 +170,10 @@ export async function backupData(
   };
 
   await runWithRetry(
-    () =>
+    async () =>
       addDoc(collection(db, "backups"), {
         ...data,
-        createdAt: new Date().toISOString(),
+        createdAt: (await getCurrentTime()).toISOString(),
       }),
     retries,
     delayMs


### PR DESCRIPTION
## Summary
- add internet time helper with fetch, offset cache, and timezone support
- use internet time for cron rate limits and backups
- document DEFAULT_TZ and add unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d223e24c833180c6dd50095075f9