### PR TITLE
fix: format virtualized transaction amounts

### DIFF
--- a/src/components/transactions/transactions-table.tsx
+++ b/src/components/transactions/transactions-table.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import type { Transaction } from "@/lib/types"
 import { Repeat } from "lucide-react"
+import { formatCurrency } from "@/lib/currency"
 import {
   memo,
   useMemo,
@@ -46,7 +47,7 @@ export const TransactionsTable = memo(function TransactionsTable({
           formattedDate: new Date(transaction.date).toLocaleDateString(),
           formattedAmount: `${
             transaction.type === "Income" ? "+" : "-"
-          }$${transaction.amount.toFixed(2)}`,
+          }${formatCurrency(transaction.amount, transaction.currency)}`,
         })),
     [transactions, visibleRange],
   )
@@ -62,7 +63,7 @@ export const TransactionsTable = memo(function TransactionsTable({
             formattedDate: new Date(fallback.date).toLocaleDateString(),
             formattedAmount: `${
               fallback.type === "Income" ? "+" : "-"
-            }$${fallback.amount.toFixed(2)}`,
+            }${formatCurrency(fallback.amount, fallback.currency)}`,
           }
     return (
       <TableRow style={style} key={transaction.id}>
@@ -91,11 +92,7 @@ export const TransactionsTable = memo(function TransactionsTable({
 
   const Outer = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
     ({ style, children, ...props }, ref) => (
-      <div
-        ref={ref}
-        style={{ ...style, overflow: "auto" }}
-        {...props}
-      >
+      <div ref={ref} style={{ ...style, overflow: "auto" }} {...props}>
         <Table>{children}</Table>
       </div>
     ),


### PR DESCRIPTION
## Summary
- use `formatCurrency` to render locale-aware amounts in virtualized transactions table

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0d37779ec8331a97e2d8099227173