### PR TITLE
fix: resolve merge conflicts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,12 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.test.ts']
+  testEnvironment: 'jsdom',
+  testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+  },
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,8 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.8.0",
+        "@testing-library/react": "^16.3.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -66,11 +68,19 @@
         "eslint-config-next": "^15.5.2",
         "genkit-cli": "^1.14.1",
         "jest": "^30.1.0",
+        "jest-environment-jsdom": "^30.1.1",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "ts-jest": "^29.4.1",
         "typescript": "^5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -95,6 +105,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@asteasolutions/zod-to-openapi": {
@@ -710,6 +734,121 @@
       "devOptional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -3636,6 +3775,68 @@
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "jest-mock": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.1.1.tgz",
+      "integrity": "sha512-d7pP9SeIOI6qnrNIS/ds1hlS9jpqh8EywHK0dALSLODZKo2QEGnDNvnPvhRKI0FHWDnE2EMl8CDTP0jM9lhlOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.1.1",
+        "@jest/fake-timers": "30.1.1",
+        "@jest/types": "30.0.5",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+      "version": "30.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.1.tgz",
+      "integrity": "sha512-yWHbU+3j7ehQE+NRpnxRvHvpUhoohIjMePBbIr8lfe0cWVb0WeTf80DNux1GPJa18CDHiIU5DtksGUfxcDE+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.1.1",
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "jest-mock": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+      "version": "30.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.1.tgz",
+      "integrity": "sha512-fK/25dNgBNYPw3eLi2CRs57g1H04qBAFNMsUY3IRzkfx/m4THe0E1zF+yGQBOMKKc2XQVdc9EYbJ4hEm7/2UtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@sinonjs/fake-timers": "^13.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.1.0",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7452,6 +7653,142 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -7480,6 +7817,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.122",
@@ -7699,6 +8044,18 @@
       "dependencies": {
         "expect": "^30.0.0",
         "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -9957,6 +10314,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -9966,6 +10330,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/csstype": {
@@ -10098,6 +10476,57 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -10168,6 +10597,13 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -10278,6 +10714,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -10342,6 +10789,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -10509,6 +10964,19 @@
       "devOptional": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error": {
@@ -12917,6 +13385,19 @@
         "node": ">= 0.10.x"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -13155,6 +13636,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -13527,6 +14018,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -14135,6 +14633,65 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.1.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.1.1.tgz",
+      "integrity": "sha512-fInyXsHSuPaERmRiub4V6jl6KERXowGqY8AISJrXZjOq7vdP46qecm+GnTngjcUPeHFqrxp1PfP0XuFfKTzA2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.1.1",
+        "@jest/environment-jsdom-abstract": "30.1.1",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+      "version": "30.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.1.tgz",
+      "integrity": "sha512-yWHbU+3j7ehQE+NRpnxRvHvpUhoohIjMePBbIr8lfe0cWVb0WeTf80DNux1GPJa18CDHiIU5DtksGUfxcDE+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.1.1",
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "jest-mock": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+      "version": "30.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.1.tgz",
+      "integrity": "sha512-fK/25dNgBNYPw3eLi2CRs57g1H04qBAFNMsUY3IRzkfx/m4THe0E1zF+yGQBOMKKc2XQVdc9EYbJ4hEm7/2UtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@sinonjs/fake-timers": "^13.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.1.0",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "30.1.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.0.tgz",
@@ -14609,6 +15166,122 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -15154,6 +15827,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -15305,6 +15989,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -15586,6 +16280,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
+      "integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -15948,6 +16649,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -16873,6 +17587,20 @@
         "decimal.js-light": "^2.4.1"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -17185,6 +17913,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -17294,6 +18029,19 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -17999,6 +18747,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -18095,6 +18856,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/synckit": {
       "version": "0.11.11",
@@ -18450,6 +19218,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -18485,6 +19273,19 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -19052,6 +19853,19 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -19111,6 +19925,42 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -19383,6 +20233,28 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
@@ -19391,6 +20263,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xorshift": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^18",
@@ -67,6 +69,7 @@
     "eslint-config-next": "^15.5.2",
     "genkit-cli": "^1.14.1",
     "jest": "^30.1.0",
+    "jest-environment-jsdom": "^30.1.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.4.1",

--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -1,0 +1,65 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthProvider, useAuth } from '../components/auth/auth-provider';
+
+let mockPathname = '/';
+const pushMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => mockPathname,
+}));
+
+jest.mock('@/lib/firebase', () => ({ auth: { currentUser: null } }));
+const { auth: authStub } = require('@/lib/firebase');
+
+let mockUser: any = null;
+const onAuthStateChanged = jest.fn((_auth: unknown, cb: (u: any) => void) => {
+  cb(mockUser);
+  return () => {};
+});
+
+jest.mock('firebase/auth', () => ({
+  onAuthStateChanged: (...args: any[]) => (onAuthStateChanged as any)(...args),
+}));
+
+function DisplayUser() {
+  const { user } = useAuth();
+  return <div>{user ? user.uid : 'none'}</div>;
+}
+
+beforeEach(() => {
+  mockUser = null;
+  mockPathname = '/';
+  pushMock.mockClear();
+  onAuthStateChanged.mockClear();
+});
+
+test('redirects to dashboard when authenticated on "/" and updates context', async () => {
+  mockPathname = '/';
+  mockUser = { uid: 'abc' } as any;
+
+  render(
+    <AuthProvider>
+      <DisplayUser />
+    </AuthProvider>
+  );
+
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/dashboard'));
+  expect(screen.getByText('abc')).toBeInTheDocument();
+});
+
+test('redirects to "/" when unauthenticated on protected route', async () => {
+  mockPathname = '/dashboard';
+  mockUser = null;
+
+  render(
+    <AuthProvider>
+      <DisplayUser />
+    </AuthProvider>
+  );
+
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/'));
+  expect(screen.getByText('none')).toBeInTheDocument();
+});

--- a/src/__tests__/debt-calendar.test.tsx
+++ b/src/__tests__/debt-calendar.test.tsx
@@ -1,0 +1,105 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DebtCalendar from '../components/debts/DebtCalendar';
+
+// Mock UI components to avoid Radix and other dependencies
+jest.mock('../components/ui/button', () => ({
+  Button: (props: any) => <button {...props} />,
+}));
+jest.mock('../components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+jest.mock('../components/ui/label', () => ({
+  Label: (props: any) => <label {...props} />,
+}));
+jest.mock('../components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectValue: () => null,
+}));
+jest.mock('../components/ui/textarea', () => ({
+  Textarea: (props: any) => <textarea {...props} />,
+}));
+
+beforeAll(() => {
+  if (!global.crypto) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    global.crypto = require('crypto').webcrypto as any;
+  }
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+function fillRequiredFields() {
+  fireEvent.change(screen.getByPlaceholderText('e.g., X1 Card'), { target: { value: 'Test Debt' } });
+  fireEvent.change(screen.getByPlaceholderText('5.5'), { target: { value: '5' } });
+  fireEvent.change(screen.getByPlaceholderText('5000'), { target: { value: '1000' } });
+  fireEvent.change(screen.getByPlaceholderText('3250'), { target: { value: '1000' } });
+  fireEvent.change(screen.getByPlaceholderText('150'), { target: { value: '100' } });
+}
+
+test('adds a debt', async () => {
+  render(<DebtCalendar storageKey="test" initialDebts={[]} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /new/i }));
+  fillRequiredFields();
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  expect(await screen.findByText('Test Debt')).toBeInTheDocument();
+});
+
+test('updates a debt', async () => {
+  render(<DebtCalendar storageKey="test" initialDebts={[]} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /new/i }));
+  fillRequiredFields();
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  const [chip] = await screen.findAllByText('Test Debt');
+  fireEvent.click(chip);
+  fireEvent.change(screen.getByPlaceholderText('e.g., X1 Card'), { target: { value: 'Updated Debt' } });
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  expect(await screen.findByText('Updated Debt')).toBeInTheDocument();
+});
+
+test('deletes a debt', async () => {
+  render(<DebtCalendar storageKey="test" initialDebts={[]} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /new/i }));
+  fillRequiredFields();
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  const [chip] = await screen.findAllByText('Test Debt');
+  fireEvent.click(chip);
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+  await waitFor(() => {
+    expect(screen.queryByText('Test Debt')).not.toBeInTheDocument();
+  });
+});
+
+test('marks and unmarks a debt as paid', async () => {
+  render(<DebtCalendar storageKey="test" initialDebts={[]} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /new/i }));
+  fillRequiredFields();
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  const [chip] = await screen.findAllByText('Test Debt');
+  fireEvent.click(chip);
+  fireEvent.click(screen.getByRole('button', { name: /mark paid/i }));
+  fireEvent.click(screen.getByLabelText('Close'));
+  await waitFor(() => expect(screen.getAllByText('Test Debt')[0]).toHaveClass('line-through'));
+
+  const [chip2] = await screen.findAllByText('Test Debt');
+  fireEvent.click(chip2);
+  fireEvent.click(screen.getByRole('button', { name: /undo paid/i }));
+  fireEvent.click(screen.getByLabelText('Close'));
+  await waitFor(() => expect(screen.getAllByText('Test Debt')[0]).not.toHaveClass('line-through'));
+});

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from 'next/server';
-import type { Transaction } from '@/lib/types';
-import { saveTransactions } from '@/lib/transactions';
+import { NextResponse } from "next/server";
+import type { Transaction } from "@/lib/types";
+import { saveTransactions } from "@/lib/transactions";
 
 // This route would typically call a banking provider such as Plaid
 // to fetch recent transactions. For the purposes of this demo we
@@ -13,17 +13,20 @@ export async function POST() {
     const transactions: Transaction[] = [
       {
         id: crypto.randomUUID(),
-        date: new Date().toISOString().split('T')[0],
-        description: 'Imported Sample Transaction',
-        amount: 100.0,
-        type: 'Income',
-        category: 'Bank Import',
+        date: new Date().toISOString().split("T")[0],
+        description: "Imported Sample Transaction",
+        amount: 100,
+        type: "Income",
+        category: "Bank Import",
       },
     ];
 
     await saveTransactions(transactions);
     return NextResponse.json({ transactions });
   } catch (error) {
-    return NextResponse.json({ error: 'Failed to import transactions' }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to import transactions" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,15 +1,28 @@
 "use client";
 
-import { useState, useMemo, useTransition, useDeferredValue } from "react";
+import {
+  useState,
+  useMemo,
+  useTransition,
+  useDeferredValue,
+  useRef,
+  useCallback,
+} from "react";
 import { useRouter } from "next/navigation";
 import { mockTransactions } from "@/lib/data";
-import { importTransactions } from "@/lib/transactions";
 import type { Transaction } from "@/lib/types";
 import { AddTransactionDialog } from "@/components/transactions/add-transaction-dialog";
 import { TransactionsTable } from "@/components/transactions/transactions-table";
 import { Button } from "@/components/ui/button";
-import { File, ScanLine, Loader2, Download } from "lucide-react";
 import { TransactionsFilter } from "@/components/transactions/transactions-filter";
+import { parseCsv, downloadCsv } from "@/lib/csv";
+import {
+  validateTransactions,
+  TransactionRowType,
+  importBankTransactions,
+} from "@/lib/transactions";
+import { addCategory, getCategories } from "@/lib/categories";
+import { Upload, Download, ScanLine, Loader2, File } from "lucide-react";
 
 export default function TransactionsPage() {
   const [transactions, setTransactions] = useState<Transaction[]>(mockTransactions);
@@ -22,63 +35,134 @@ export default function TransactionsPage() {
   const isPending = isTransitionPending || deferredSearchTerm !== searchTerm;
   const [filterType, setFilterType] = useState("all");
   const [filterCategory, setFilterCategory] = useState("all");
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const categories = useMemo(() => {
-    const allCategories = transactions.map(t => t.category);
-    return ['all', ...Array.from(new Set(allCategories))];
+    // Start with categories stored externally (e.g. in localStorage)
+    const map = new Map<string, string>();
+    for (const cat of getCategories()) {
+      const key = cat.toLowerCase();
+      if (!map.has(key)) map.set(key, cat);
+    }
+    // Merge in categories from current transactions
+    for (const t of transactions) {
+      const key = t.category.toLowerCase();
+      if (!map.has(key)) map.set(key, t.category);
+    }
+    return ["all", ...Array.from(map.values())];
   }, [transactions]);
 
-  const addTransaction = (transaction: Omit<Transaction, 'id' | 'date'>) => {
-    setTransactions(prev => [
-      { ...transaction, id: crypto.randomUUID(), date: new Date().toISOString().split('T')[0] },
-      ...prev
-    ]);
+  const addTransaction = useCallback(
+    (transaction: Omit<Transaction, "id" | "date">) => {
+      setTransactions((prev) => [
+        {
+          ...transaction,
+          id: crypto.randomUUID(),
+          date: new Date().toISOString().split("T")[0],
+        },
+        ...prev,
+      ]);
+      addCategory(transaction.category);
+    },
+    [setTransactions]
+  );
+
+  const handleUploadClick = () => fileInputRef.current?.click();
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const rows = await parseCsv<TransactionRowType>(file);
+      const parsed = validateTransactions(rows);
+      parsed.forEach((t) => addCategory(t.category));
+      setTransactions((prev) => [...parsed, ...prev]);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      e.target.value = "";
+    }
   };
 
-  const handleImport = async () => {
+  const handleDownload = () => {
+    downloadCsv(
+      transactions.map(({ id, ...rest }) => rest),
+      "transactions.csv"
+    );
+  };
+
+  const handleBankImport = async () => {
     setImporting(true);
     try {
-      const imported = await importTransactions();
-      setTransactions(prev => [...imported, ...prev]);
+      const imported = await importBankTransactions();
+      imported.forEach((t) => addCategory(t.category));
+      setTransactions((prev) => [...imported, ...prev]);
     } finally {
       setImporting(false);
     }
   };
 
   const filteredTransactions = useMemo(() => {
-    return transactions.filter(transaction => {
-        const matchesSearch = transaction.description.toLowerCase().includes(deferredSearchTerm.toLowerCase());
-        const matchesType = filterType === 'all' || transaction.type === filterType;
-        const matchesCategory = filterCategory === 'all' || transaction.category === filterCategory;
-        return matchesSearch && matchesType && matchesCategory;
+    return transactions.filter((transaction) => {
+      const matchesSearch = transaction.description
+        .toLowerCase()
+        .includes(deferredSearchTerm.toLowerCase());
+      const matchesType =
+        filterType === "all" || transaction.type === filterType;
+      const matchesCategory =
+        filterCategory === "all" ||
+        transaction.category.toLowerCase() === filterCategory.toLowerCase();
+      return matchesSearch && matchesType && matchesCategory;
     });
   }, [transactions, deferredSearchTerm, filterType, filterCategory]);
 
-  const handleSearchChange = (value: string) => {
-    startTransition(() => setSearchTerm(value));
-  };
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      startTransition(() => setSearchTerm(value));
+    },
+    [startTransition, setSearchTerm]
+  );
 
   return (
     <div className="space-y-6">
-       <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center justify-between gap-4">
         <div>
-            <h1 className="text-3xl font-bold font-headline tracking-tight">Transactions</h1>
-            <p className="text-muted-foreground">Track and manage your income and expenses.</p>
+          <h1 className="text-3xl font-bold font-headline tracking-tight">
+            Transactions
+          </h1>
+          <p className="text-muted-foreground">
+            Track and manage your income and expenses.
+          </p>
         </div>
-         <div className="flex gap-2 items-center flex-wrap">
-            <Button variant="outline">
-                <File className="mr-2 h-4 w-4" />
-                Export
-            </Button>
-            <Button variant="outline" onClick={handleImport} disabled={importing}>
-                {importing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Download className="mr-2 h-4 w-4" />}
-                Import
-            </Button>
-             <Button variant="outline" onClick={() => router.push('/transactions/scan')}>
-                <ScanLine className="mr-2 h-4 w-4" />
-                Scan Receipt
-            </Button>
-            <AddTransactionDialog onSave={addTransaction} />
+        <div className="flex gap-2 items-center flex-wrap">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          <Button variant="outline" onClick={handleUploadClick}>
+            <Upload className="mr-2 h-4 w-4" />
+            Import
+          </Button>
+          <Button variant="outline" onClick={handleDownload}>
+            <File className="mr-2 h-4 w-4" />
+            Export
+          </Button>
+          <Button variant="outline" onClick={handleBankImport} disabled={importing}>
+            {importing ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="mr-2 h-4 w-4" />
+            )}
+            Import Bank
+          </Button>
+          <Button variant="outline" onClick={() => router.push("/transactions/scan") }>
+            <ScanLine className="mr-2 h-4 w-4" />
+            Scan Receipt
+          </Button>
+          <AddTransactionDialog onSave={addTransaction} />
         </div>
       </div>
 

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -1,22 +1,178 @@
-import type { Transaction } from './types';
-import { mockTransactions } from './data';
+import { z } from "zod";
+import { collection, doc, writeBatch } from "firebase/firestore";
+import { db } from "./firebase";
+import type { Transaction } from "./types";
+
+export const TransactionPayloadSchema = z.object({
+  id: z.string(),
+  date: z.string(),
+  description: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  type: z.enum(["Income", "Expense"]),
+  category: z.string(),
+  isRecurring: z.boolean().optional(),
+});
+
+export type TransactionPayload = z.infer<typeof TransactionPayloadSchema>;
+
+const TransactionRow = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  description: z.string(),
+  amount: z.preprocess(
+    (val) => (typeof val === "number" || typeof val === "string" ? String(val) : val),
+    z.string()
+  ),
+  type: z.enum(["Income", "Expense"]),
+  category: z.string(),
+  isRecurring: z.union([z.boolean(), z.string()]).optional(),
+});
+
+export type TransactionRowType = z.infer<typeof TransactionRow>;
 
 /**
- * Persist a batch of transactions.
- * In the current demo this simply updates the in-memory mock dataset.
- * In a real application this would interface with a database or API.
+ * Split an array of transactions into chunks of at most 500 items.
+ *
+ * Firestore limits batch writes to 500 operations. This helper ensures that
+ * transaction arrays are partitioned accordingly so they can be written in
+ * multiple batches if necessary.
+ *
+ * @param transactions - Transactions to split into chunks.
+ * @param chunkSize - Maximum size of each chunk. Defaults to 500.
+ * @returns Array of transaction chunks.
  */
-export async function saveTransactions(newTransactions: Transaction[]): Promise<void> {
-  // Prepend transactions so newest appear first
-  mockTransactions.unshift(...newTransactions);
+export function chunkTransactions<T>(
+  transactions: T[],
+  chunkSize = 500
+): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < transactions.length; i += chunkSize) {
+    chunks.push(transactions.slice(i, i + chunkSize));
+  }
+  return chunks;
 }
 
 /**
- * Request transaction import from the banking provider via API route.
+ * Validate a list of raw transaction rows and normalize them into the
+ * internal {@link Transaction} format.
+ *
+ * Each row should contain a `date` in `YYYY-MM-DD` format, a `description`,
+ * an `amount` that can be parsed into a number, a `type` of either
+ * "Income" or "Expense", a `category`, and an optional `isRecurring` flag
+ * (boolean or string).
+ *
+ * A new UUID is generated for every transaction and the `currency` field is
+ * set to the default of `"USD"` until import sources supply currency data.
+ *
+ * @param rows - Array of transaction-like objects to validate and normalize.
+ * @returns Array of validated transactions ready for persistence.
+ * @throws {Error} If any row fails validation or if an amount cannot be
+ *   parsed into a number.
+ * @remarks This function performs no external I/O but generates new UUIDs for
+ *   each transaction.
  */
-export async function importTransactions(): Promise<Transaction[]> {
-  const res = await fetch('/api/bank/import', { method: 'POST' });
-  if (!res.ok) throw new Error('Failed to import transactions');
+export function validateTransactions(rows: TransactionRowType[]): Transaction[] {
+  return rows.map((row, index) => {
+    const parsed = TransactionRow.safeParse(row);
+    if (!parsed.success) {
+      throw new Error(`Invalid row ${index + 1}: ${parsed.error.message}`);
+    }
+    const data = parsed.data;
+    const amountString = data.amount.trim();
+    const parsedAmount = parseFloat(amountString);
+    if (isNaN(parsedAmount)) {
+      throw new Error(
+        `Invalid amount in row ${index + 1}: "${data.amount}" cannot be parsed as a number`
+      );
+    }
+
+    return {
+      id: crypto.randomUUID(),
+      date: data.date,
+      description: data.description,
+      amount: parsedAmount,
+      type: data.type,
+      category: data.category,
+      // Default to USD until currency is provided in import sources
+      currency: "USD",
+      isRecurring:
+        typeof data.isRecurring === "boolean"
+          ? data.isRecurring
+          : data.isRecurring === "true",
+    };
+  });
+}
+
+/**
+ * Persist a collection of transactions to Firestore using a batch write.
+ *
+ * @param transactions - Validated transaction objects to be written.
+ * @throws {Error} If the Firestore batch commit fails.
+ * @remarks Writes to Firestore and performs network I/O.
+ */
+export async function saveTransactions(transactions: Transaction[]): Promise<void> {
+  const colRef = collection(db, "transactions");
+  const chunks = chunkTransactions(transactions);
+  for (const chunk of chunks) {
+    const batch = writeBatch(db);
+    chunk.forEach((tx) => {
+      const docRef = doc(colRef);
+      batch.set(docRef, tx);
+    });
+
+    try {
+      await batch.commit();
+    } catch (err) {
+      throw new Error(
+        `Failed to save transactions batch: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+}
+
+/**
+ * Validate raw transaction rows and persist the resulting transactions to
+ * Firestore.
+ *
+ * @param rows - Raw transaction rows to validate and import.
+ * @throws {Error} If validation fails or if saving to Firestore encounters an
+ *   error.
+ * @remarks Generates UUIDs during validation and writes data to Firestore.
+ */
+export async function importTransactions(rows: TransactionRowType[]): Promise<void> {
+  const transactions = validateTransactions(rows);
+  try {
+    await saveTransactions(transactions);
+  } catch (err) {
+    throw new Error(
+      `Failed to import transactions: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+}
+
+export interface TransactionPersistence {
+  validateTransactions: typeof validateTransactions;
+  saveTransactions: typeof saveTransactions;
+  importTransactions: typeof importTransactions;
+}
+
+export const transactionPersistence: TransactionPersistence = {
+  validateTransactions,
+  saveTransactions,
+  importTransactions,
+};
+
+/**
+ * Request transaction import from the banking provider via API route.
+ * Returns the newly imported transactions.
+ */
+export async function importBankTransactions(): Promise<Transaction[]> {
+  const res = await fetch("/api/bank/import", { method: "POST" });
+  if (!res.ok) throw new Error("Failed to import transactions");
   const data = (await res.json()) as { transactions: Transaction[] };
   return data.transactions;
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary
- expand bank import route to save transactions and return them
- expose `importBankTransactions` helper
- allow Transactions page to import bank data via new helper

## Testing
- `npm run lint` *(fails: auth-provider.test.tsx, debt-calendar.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ddc886b083318e1d77476b3ea125