### PR TITLE
Resolve conflicts and remove global i18n state

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,22 +1,22 @@
 
 import OverviewCards from "@/components/dashboard/overview-cards";
+import TimeCard from "@/components/dashboard/time-card";
+import PaydayCountdownCard from "@/components/dashboard/payday-countdown-card";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
-import DashboardCharts from '@/app/dashboard/dashboard-charts';
+import DashboardCharts from "@/app/dashboard/dashboard-charts";
 import { mockTransactions } from "@/lib/data";
-import type { Transaction } from "@/lib/types";
+import type { Transaction, ChartPoint } from "@/lib/types";
 import { getTranslation } from "@/lib/i18n";
 
 // Server-side data fetching now happens in the page component.
 const getTransactions = async (): Promise<Transaction[]> => {
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 500));
+  // Replace with real data fetching when an API is available
   return mockTransactions;
 };
 
-const getChartData = async () => {
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 800));
+const getChartData = async (): Promise<ChartPoint[]> => {
+  // Replace with real data fetching when an API is available
   return [
     { month: "Jan", income: 4000, expenses: 2400 },
     { month: "Feb", income: 3000, expenses: 1398 },
@@ -29,17 +29,21 @@ const getChartData = async () => {
 };
 
 export default async function DashboardPage() {
-  const [transactions, chartData] = await Promise.all([
+  const [transactions, chartData]: [Transaction[], ChartPoint[]] = await Promise.all([
     getTransactions(),
-    getChartData()
+    getChartData(),
   ]);
-  const t = getTranslation()
+  const t = getTranslation("en");
 
   return (
     <main role="main" tabIndex={-1} className="space-y-6">
       <div className="space-y-1">
         <h1 className="text-3xl font-bold tracking-tight">{t("dashboard.title")}</h1>
         <p className="text-muted-foreground">{t("dashboard.overview")}</p>
+      </div>
+      <div className="grid gap-6 sm:grid-cols-2">
+        <TimeCard />
+        <PaydayCountdownCard />
       </div>
       <Suspense fallback={<Skeleton className="h-[126px] w-full" />}>
         <OverviewCards transactions={transactions} />

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/components/ui/sheet"
 import { NurseFinAILogo } from "@/components/icons"
 import { useToast } from "@/hooks/use-toast"
-import { ThemeSwitcher } from "./theme-switcher"
+import { ThemeToggle } from "@/components/ThemeToggle"
 
 export default function AppHeader() {
   const router = useRouter()
@@ -121,10 +121,10 @@ export default function AppHeader() {
         <Input
           type="search"
           placeholder={t("search.placeholder")}
-          className="w-full rounded-lg bg-secondary pl-8 md:w-[200px] lg:w-[336px]"
+          className="w-full rounded-lg bg-secondary pl-8 md:w-[200px] lg:w-[336px] dark:bg-secondary"
         />
       </div>
-      <ThemeSwitcher />
+      <ThemeToggle />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,3 +1,4 @@
+import { useCallback, useState } from "react"
 import en from "../../public/locales/en.json"
 import es from "../../public/locales/es.json"
 
@@ -8,17 +9,15 @@ const dictionaries: Record<Locale, Record<string, string>> = {
   es,
 }
 
-let currentLocale: Locale = "en"
-
-export const setLocale = (locale: Locale) => {
-  currentLocale = locale
+export function useTranslation(initialLocale: Locale = "en") {
+  const [locale, setLocale] = useState<Locale>(initialLocale)
+  const t = useCallback(
+    (key: string) => dictionaries[locale][key] || key,
+    [locale],
+  )
+  return { t, locale, setLocale }
 }
 
-export function useTranslation() {
-  const t = (key: string) => dictionaries[currentLocale][key] || key
-  return { t, locale: currentLocale }
-}
-
-export function getTranslation(locale: Locale = currentLocale) {
+export function getTranslation(locale: Locale) {
   return (key: string) => dictionaries[locale][key] || key
 }


### PR DESCRIPTION
## Summary
- remove global locale state and make translations locale-aware per hook
- merge dashboard and header changes with latest main and translations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0dda51e108331b9c8ada7b1f56985