### PR TITLE
fix: resolve dashboard merge conflicts

### DIFF
--- a/src/app/dashboard/dashboard-charts.tsx
+++ b/src/app/dashboard/dashboard-charts.tsx
@@ -62,7 +62,7 @@ interface DashboardChartsProps {
 
 export default function DashboardCharts({ transactions, chartData, categorySummaries }: DashboardChartsProps) {
   return (
-    <div className="grid gap-6 lg:grid-cols-3">
+    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       <div className="lg:col-span-2">
         <IncomeExpenseChartClient data={chartData} />
       </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,7 @@
 
 import OverviewCards from "@/components/dashboard/overview-cards";
+import TimeCard from "@/components/dashboard/time-card";
+import PaydayCountdownCard from "@/components/dashboard/payday-countdown-card";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import DashboardCharts from '@/app/dashboard/dashboard-charts';
@@ -46,6 +48,10 @@ export default async function DashboardPage() {
       <div className="space-y-1">
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
         <p className="text-muted-foreground">Here's a high-level overview of your finances.</p>
+      </div>
+      <div className="grid gap-6 sm:grid-cols-2">
+        <TimeCard />
+        <PaydayCountdownCard />
       </div>
       <Suspense fallback={<Skeleton className="h-[126px] w-full" />}>
         <OverviewCards transactions={transactions} />


### PR DESCRIPTION
## Summary
- restore time and payday countdown cards on the dashboard
- ensure dashboard charts remain responsive and include category summaries

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b0dc6dd9d4833197ebfee19292f0ad