### PR TITLE
feat: add Firestore category service

### DIFF
--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -18,7 +18,7 @@ import { Button } from "@/components/ui/button";
 import { TransactionsFilter } from "@/components/transactions/transactions-filter";
 import { parseCsv, downloadCsv } from "@/lib/csv";
 import { validateTransactions, TransactionRowType } from "@/lib/transactions";
-import { addCategory, getCategories } from "@/lib/categories";
+import { addCategory, getCategories } from "@/lib/categoryService";
 import { Upload, Download, ScanLine, Loader2 } from "lucide-react";
 
 export default function TransactionsPage() {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,9 +1,14 @@
 import { config } from "dotenv";
-config(); // Load environment variables from .env file
+config();
 
-import { initializeApp, getApps, getApp, type FirebaseOptions } from "firebase/app";
+import {
+  initializeApp,
+  getApps,
+  getApp,
+  type FirebaseOptions,
+} from "firebase/app";
 import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import { getFirestore, collection } from "firebase/firestore";
 import { z } from "zod";
 
 const nonPlaceholder = z
@@ -25,40 +30,31 @@ const envSchema = z.object({
 
 const env = envSchema.parse(process.env);
 
-<<<<<<< HEAD
-const firebaseConfig = {
-<<<<<<< HEAD
+const firebaseConfig: FirebaseOptions = {
   apiKey: env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
   projectId: env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
   storageBucket: env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: env.NEXT_PUBLIC_FIREBASE_APP_ID
-=======
-=======
-const firebaseConfig: FirebaseOptions = {
->>>>>>> b8806e7 (I see this error with the app, reported by NextJS, please fix it. The er)
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
->>>>>>> d96745a (code review)
+  appId: env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
 // A function to check if all required environment variables are present.
 // This provides a clearer error message than the generic Firebase error.
 function validateFirebaseConfig(config: FirebaseOptions): void {
   const requiredKeys: (keyof FirebaseOptions)[] = [
-    'apiKey',
-    'authDomain',
-    'projectId',
+    "apiKey",
+    "authDomain",
+    "projectId",
   ];
   for (const key of requiredKeys) {
     if (!config[key] || config[key] === "YOUR_API_KEY_HERE") {
-      const envVarName = `NEXT_PUBLIC_FIREBASE_${key.replace(/([A-Z])/g, '_$1').toUpperCase()}`;
-      throw new Error(`Firebase configuration error: Missing or invalid value for ${key}. Please check your .env file for the ${envVarName} variable.`);
+      const envVarName = `NEXT_PUBLIC_FIREBASE_${key
+        .replace(/([A-Z])/g, "_$1")
+        .toUpperCase()}`;
+      throw new Error(
+        `Firebase configuration error: Missing or invalid value for ${key}. Please check your .env file for the ${envVarName} variable.`
+      );
     }
   }
 }
@@ -71,4 +67,8 @@ const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const auth = getAuth(app);
 const db = getFirestore(app);
 
-export { app, auth, db };
+// Firestore collection reference for categories
+const categoriesCollection = collection(db, "categories");
+
+export { app, auth, db, categoriesCollection };
+


### PR DESCRIPTION
## Summary
- export categories collection from Firebase setup
- add categoryService with Firestore-backed CRUD and local cache
- update transactions page to use categoryService

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, require imports, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e50984148331ae3ac5f6488a0dff