### PR TITLE
feat: add category feedback and local classifier

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -25,3 +25,6 @@ export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculat
 
 export { predictSpending } from './spendingForecast';
 export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
+
+export { suggestCategory } from './suggest-category';
+export type { SuggestCategoryInput, SuggestCategoryOutput } from './suggest-category';

--- a/src/ai/flows/suggest-category.ts
+++ b/src/ai/flows/suggest-category.ts
@@ -1,0 +1,53 @@
+// This file uses server-side code.
+'use server';
+
+import { ai } from '@/ai/genkit';
+import { z } from 'genkit';
+
+import { classifyCategory } from '../train/category-model';
+
+const SuggestCategoryInputSchema = z.object({
+  description: z.string().describe('Description of the transaction'),
+});
+export type SuggestCategoryInput = z.infer<typeof SuggestCategoryInputSchema>;
+
+const SuggestCategoryOutputSchema = z.object({
+  category: z.string().describe('Suggested category for the transaction'),
+});
+export type SuggestCategoryOutput = z.infer<typeof SuggestCategoryOutputSchema>;
+
+const prompt = ai.definePrompt({
+  name: 'suggestCategoryPrompt',
+  input: { schema: SuggestCategoryInputSchema },
+  output: { schema: SuggestCategoryOutputSchema },
+  prompt: `You are a financial assistant. Suggest a spending category for the following transaction description suitable for personal budgeting (e.g., Food, Transport, Utilities, Salary, Other).
+
+Description: {{description}}`,
+});
+
+const suggestCategoryFlow = ai.defineFlow(
+  {
+    name: 'suggestCategoryFlow',
+    inputSchema: SuggestCategoryInputSchema,
+    outputSchema: SuggestCategoryOutputSchema,
+  },
+  async (input) => {
+    const { output } = await prompt(input);
+    if (!output) {
+      throw new Error('No output returned from suggestCategoryFlow');
+    }
+    return output;
+  }
+);
+
+/**
+ * Suggest a category for a transaction description. Attempts to use the local
+ * classifier first, falling back to the AI model if no prediction is available.
+ */
+export async function suggestCategory(input: SuggestCategoryInput): Promise<SuggestCategoryOutput> {
+  const local = classifyCategory(input.description);
+  if (local) {
+    return { category: local };
+  }
+  return await suggestCategoryFlow(input);
+}

--- a/src/ai/train/category-model.ts
+++ b/src/ai/train/category-model.ts
@@ -1,0 +1,93 @@
+import { collection, getDocs, onSnapshot } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+
+interface FeedbackPair {
+  description: string;
+  category: string;
+}
+
+class NaiveBayesClassifier {
+  private vocab = new Set<string>();
+  private categoryCounts: Record<string, number> = {};
+  private tokenCounts: Record<string, Record<string, number>> = {};
+  private totalDocs = 0;
+
+  train(pairs: FeedbackPair[]): void {
+    this.vocab.clear();
+    this.categoryCounts = {};
+    this.tokenCounts = {};
+    this.totalDocs = pairs.length;
+
+    for (const { description, category } of pairs) {
+      const tokens = this.tokenize(description);
+      this.categoryCounts[category] = (this.categoryCounts[category] || 0) + 1;
+      if (!this.tokenCounts[category]) this.tokenCounts[category] = {};
+      for (const token of tokens) {
+        this.vocab.add(token);
+        this.tokenCounts[category][token] =
+          (this.tokenCounts[category][token] || 0) + 1;
+      }
+    }
+  }
+
+  predict(text: string): string | null {
+    if (this.totalDocs < 1) return null;
+    const tokens = this.tokenize(text);
+    let bestCategory: string | null = null;
+    let bestScore = -Infinity;
+    const vocabSize = this.vocab.size || 1;
+
+    for (const category of Object.keys(this.categoryCounts)) {
+      const logPrior = Math.log(this.categoryCounts[category] / this.totalDocs);
+      const tokenCounts = this.tokenCounts[category];
+      const totalTokens = Object.values(tokenCounts).reduce((a, b) => a + b, 0);
+      let logLikelihood = 0;
+      for (const token of tokens) {
+        const count = tokenCounts[token] || 0;
+        // Laplace smoothing
+        const prob = (count + 1) / (totalTokens + vocabSize);
+        logLikelihood += Math.log(prob);
+      }
+      const score = logPrior + logLikelihood;
+      if (score > bestScore) {
+        bestScore = score;
+        bestCategory = category;
+      }
+    }
+
+    return bestCategory;
+  }
+
+  private tokenize(text: string): string[] {
+    return text.toLowerCase().match(/[a-z0-9]+/g) || [];
+  }
+}
+
+let classifier: NaiveBayesClassifier | null = null;
+
+async function fetchPairs(): Promise<FeedbackPair[]> {
+  const snap = await getDocs(collection(db, "categoryFeedback"));
+  return snap.docs.map((d) => d.data() as FeedbackPair);
+}
+
+export async function trainCategoryModel(): Promise<void> {
+  const pairs = await fetchPairs();
+  classifier = new NaiveBayesClassifier();
+  classifier.train(pairs);
+}
+
+export function classifyCategory(description: string): string | null {
+  if (!classifier) return null;
+  return classifier.predict(description);
+}
+
+// Initial training
+trainCategoryModel();
+// Retrain when new feedback is added
+onSnapshot(collection(db, "categoryFeedback"), () => {
+  trainCategoryModel();
+});
+// Periodic retraining as a safety net (every hour)
+setInterval(() => {
+  trainCategoryModel();
+}, 60 * 60 * 1000);

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -48,7 +48,6 @@ export default function TransactionsPage() {
     return ["all", ...Array.from(map.values())];
   }, [transactions]);
 
-<<<<<<< HEAD
   const addTransaction = useCallback(
     (transaction: Omit<Transaction, "id" | "date">) => {
       setTransactions((prev) => [
@@ -86,15 +85,6 @@ export default function TransactionsPage() {
       transactions.map(({ id, ...rest }) => rest),
       "transactions.csv"
     );
-=======
-  const addTransaction = (transaction: Omit<Transaction, 'id' | 'date'>) => {
-    // Using a function with setTransactions ensures we get the latest state
-    // and correctly triggers re-renders for derived state like `categories`.
-    setTransactions(prev => [
-      { ...transaction, id: crypto.randomUUID(), date: new Date().toISOString().split('T')[0] },
-      ...prev
-    ]);
->>>>>>> d96745a (code review)
   };
 
   const filteredTransactions = useMemo(() => {

--- a/src/lib/category-feedback.ts
+++ b/src/lib/category-feedback.ts
@@ -1,0 +1,15 @@
+import { collection, addDoc, serverTimestamp } from "firebase/firestore";
+import { db } from "./firebase";
+
+/**
+ * Persist a (description, category) feedback pair. This is used when a user
+ * overrides the AI suggested category so the model can improve over time.
+ */
+export async function recordCategoryFeedback(description: string, category: string): Promise<void> {
+  const colRef = collection(db, "categoryFeedback");
+  await addDoc(colRef, {
+    description,
+    category,
+    createdAt: serverTimestamp(),
+  });
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -25,26 +25,13 @@ const envSchema = z.object({
 
 const env = envSchema.parse(process.env);
 
-<<<<<<< HEAD
-const firebaseConfig = {
-<<<<<<< HEAD
+const firebaseConfig: FirebaseOptions = {
   apiKey: env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
   projectId: env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
   storageBucket: env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: env.NEXT_PUBLIC_FIREBASE_APP_ID
-=======
-=======
-const firebaseConfig: FirebaseOptions = {
->>>>>>> b8806e7 (I see this error with the app, reported by NextJS, please fix it. The er)
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
->>>>>>> d96745a (code review)
+  appId: env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
 // A function to check if all required environment variables are present.


### PR DESCRIPTION
## Summary
- store user category overrides in Firestore for continuous learning
- train a lightweight Naive Bayes model from override feedback and keep it updated
- use local classifier for category suggestions before hitting the LLM

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0e5122ed88331b50db1ddb80edf10