### PR TITLE
Implement 2025 tax bracket calculation

### DIFF
--- a/src/ai/flows/__tests__/no-output.test.ts
+++ b/src/ai/flows/__tests__/no-output.test.ts
@@ -30,18 +30,3 @@ describe('suggestDebtStrategyFlow', () => {
   });
 });
 
-describe('taxEstimationFlow', () => {
-  it('throws an error when prompt returns no output', async () => {
-    jest.resetModules();
-    setupNoOutputMocks();
-    const { estimateTax } = await import('@/ai/flows/tax-estimation');
-    await expect(
-      estimateTax({
-        income: 50000,
-        deductions: 10000,
-        location: 'NY',
-        filingStatus: 'single',
-      })
-    ).rejects.toThrow('No output returned from taxEstimationFlow');
-  });
-});

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -24,20 +24,23 @@ describe('calculateCashflow validation', () => {
 describe('taxEstimation validation', () => {
   it('rejects negative income', async () => {
     jest.resetModules();
-    setupSuccessMocks({ estimatedTax: 0, taxRate: 10, breakdown: '' });
     const { estimateTax } = await import('@/ai/flows/tax-estimation');
     await expect(
       estimateTax({ income: -1, deductions: 0, location: 'NY', filingStatus: 'single' })
     ).rejects.toThrow();
   });
 
-  it('rejects tax rate over 100', async () => {
+  it('calculates tax using 2025 brackets', async () => {
     jest.resetModules();
-    setupSuccessMocks({ estimatedTax: 1000, taxRate: 150, breakdown: '' });
     const { estimateTax } = await import('@/ai/flows/tax-estimation');
-    await expect(
-      estimateTax({ income: 50000, deductions: 10000, location: 'NY', filingStatus: 'single' })
-    ).rejects.toThrow();
+    const result = await estimateTax({
+      income: 80000,
+      deductions: 0,
+      location: 'NY',
+      filingStatus: 'single',
+    });
+    expect(result.estimatedTax).toBeCloseTo(9214, 0);
+    expect(result.taxRate).toBeCloseTo(11.52, 2);
   });
 });
 

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -9,8 +9,8 @@
  * - TaxEstimationOutput - The return type for the estimateTax function.
  */
 
-import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
+import {calculateIncomeTax} from '@/lib/taxes';
 
 const TaxEstimationInputSchema = z.object({
   income: z
@@ -46,40 +46,16 @@ const TaxEstimationOutputSchema = z.object({
 export type TaxEstimationOutput = z.infer<typeof TaxEstimationOutputSchema>;
 
 export async function estimateTax(input: TaxEstimationInput): Promise<TaxEstimationOutput> {
-  return taxEstimationFlow(input);
+  const parsed = TaxEstimationInputSchema.parse(input);
+  const {tax, breakdown} = calculateIncomeTax(
+    parsed.income,
+    parsed.deductions,
+    parsed.filingStatus
+  );
+  const taxRate = parsed.income === 0 ? 0 : (tax / parsed.income) * 100;
+  return TaxEstimationOutputSchema.parse({
+    estimatedTax: tax,
+    taxRate,
+    breakdown,
+  });
 }
-
-const taxEstimationPrompt = ai.definePrompt({
-  name: 'taxEstimationPrompt',
-  input: {schema: TaxEstimationInputSchema},
-  output: {schema: TaxEstimationOutputSchema},
-  prompt: `You are an expert tax estimator. Your calculations must be based on the official **2025 U.S. federal tax brackets**.
-
-Based on the user's income, filing status, deductions, and location, provide an estimate of their tax obligations.
-
-Income: {{{income}}}
-Deductions: {{{deductions}}}
-Location: {{{location}}}
-Filing Status: {{{filingStatus}}}
-
-Provide a detailed breakdown of how the tax was estimated, explaining how the filing status affects the standard deduction and the applicable tax brackets.
-
-Consider federal, state, and local taxes where applicable.
-
-Output the estimated tax, the tax rate, and the breakdown.`,
-});
-
-const taxEstimationFlow = ai.defineFlow(
-  {
-    name: 'taxEstimationFlow',
-    inputSchema: TaxEstimationInputSchema,
-    outputSchema: TaxEstimationOutputSchema,
-  },
-  async input => {
-    const {output} = await taxEstimationPrompt(input);
-    if (!output) {
-      throw new Error('No output returned from taxEstimationFlow');
-    }
-    return output;
-  }
-);

--- a/src/lib/taxes.ts
+++ b/src/lib/taxes.ts
@@ -1,0 +1,100 @@
+export type FilingStatus =
+  | 'single'
+  | 'married_jointly'
+  | 'married_separately'
+  | 'head_of_household';
+
+const STANDARD_DEDUCTION_2025: Record<FilingStatus, number> = {
+  single: 15000,
+  married_jointly: 30000,
+  married_separately: 15000,
+  head_of_household: 22500,
+};
+
+interface TaxBracket {
+  rate: number;
+  threshold: number;
+}
+
+const TAX_BRACKETS_2025: Record<FilingStatus, TaxBracket[]> = {
+  single: [
+    { rate: 0.1, threshold: 11925 },
+    { rate: 0.12, threshold: 48475 },
+    { rate: 0.22, threshold: 103350 },
+    { rate: 0.24, threshold: 197300 },
+    { rate: 0.32, threshold: 250525 },
+    { rate: 0.35, threshold: 626350 },
+    { rate: 0.37, threshold: Infinity },
+  ],
+  married_jointly: [
+    { rate: 0.1, threshold: 23850 },
+    { rate: 0.12, threshold: 96950 },
+    { rate: 0.22, threshold: 206700 },
+    { rate: 0.24, threshold: 394600 },
+    { rate: 0.32, threshold: 501050 },
+    { rate: 0.35, threshold: 751600 },
+    { rate: 0.37, threshold: Infinity },
+  ],
+  married_separately: [
+    { rate: 0.1, threshold: 11925 },
+    { rate: 0.12, threshold: 48475 },
+    { rate: 0.22, threshold: 103350 },
+    { rate: 0.24, threshold: 197300 },
+    { rate: 0.32, threshold: 250525 },
+    { rate: 0.35, threshold: 626350 },
+    { rate: 0.37, threshold: Infinity },
+  ],
+  head_of_household: [
+    { rate: 0.1, threshold: 17000 },
+    { rate: 0.12, threshold: 64850 },
+    { rate: 0.22, threshold: 103350 },
+    { rate: 0.24, threshold: 197300 },
+    { rate: 0.32, threshold: 250500 },
+    { rate: 0.35, threshold: 626350 },
+    { rate: 0.37, threshold: Infinity },
+  ],
+};
+
+export interface TaxCalculation {
+  tax: number;
+  breakdown: string;
+  taxableIncome: number;
+}
+
+export function calculateIncomeTax(
+  income: number,
+  deductions: number,
+  filingStatus: FilingStatus,
+): TaxCalculation {
+  const standardDeduction = STANDARD_DEDUCTION_2025[filingStatus];
+  const deductionUsed = Math.max(deductions, standardDeduction);
+  const taxableIncome = Math.max(0, income - deductionUsed);
+
+  const brackets = TAX_BRACKETS_2025[filingStatus];
+  let remaining = taxableIncome;
+  let prevThreshold = 0;
+  let tax = 0;
+  const parts: string[] = [];
+  for (const bracket of brackets) {
+    if (remaining <= 0) break;
+    const cap = bracket.threshold;
+    const amountInBracket = Math.min(remaining, cap - prevThreshold);
+    const taxForBracket = amountInBracket * bracket.rate;
+    tax += taxForBracket;
+    if (amountInBracket > 0) {
+      parts.push(
+        `${(bracket.rate * 100).toFixed(0)}% on $${amountInBracket.toFixed(2)} = $${taxForBracket.toFixed(2)}`
+      );
+    }
+    remaining -= amountInBracket;
+    prevThreshold = cap;
+  }
+
+  const breakdown = [
+    `Standard deduction used: $${standardDeduction.toLocaleString()}`,
+    `Taxable income: $${taxableIncome.toFixed(2)}`,
+    ...parts,
+  ].join('\n');
+
+  return { tax, breakdown, taxableIncome };
+}


### PR DESCRIPTION
## Summary
- add 2025 federal tax brackets and standard deductions
- replace AI tax estimation flow with deterministic logic
- cover new tax calculator with tests

## Testing
- `npm test` *(fails: TS1185 merge conflict marker in src/lib/firebase.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e55b1ac083318f8e16d83618dbc7