### PR TITLE
Validate transaction categories against Firestore list

### DIFF
--- a/src/__tests__/transactions.test.ts
+++ b/src/__tests__/transactions.test.ts
@@ -10,21 +10,31 @@ const baseRow = {
 describe("validateTransactions", () => {
   it.each(["abc", "", "NaN"])("throws for invalid amount '%s'", (amount) => {
     const rows = [{ ...baseRow, amount }];
-    expect(() => validateTransactions(rows)).toThrow(
+    expect(() => validateTransactions(rows, ["Misc"])).toThrow(
       /Invalid amount in row 1/
     );
   });
 
   it("accepts valid ISO date", () => {
     const rows = [{ ...baseRow, amount: "10.00", date: "2024-12-31" }];
-    expect(() => validateTransactions(rows)).not.toThrow();
+    expect(() => validateTransactions(rows, ["Misc"])).not.toThrow();
   });
 
   it.each(["2024/01/01", "2024-1-1", "01-01-2024"])(
     "throws for invalid date '%s'",
     (date) => {
       const rows = [{ ...baseRow, amount: "10.00", date }];
-      expect(() => validateTransactions(rows)).toThrow(/Invalid row 1/);
+      expect(() => validateTransactions(rows, ["Misc"])).toThrow(/Invalid row 1/);
     }
   );
+
+  it("throws for unknown category", () => {
+    const rows = [{ ...baseRow, amount: "10.00", category: "Unknown" }];
+    expect(() => validateTransactions(rows, ["Misc"])).toThrow(/Unknown category/);
+  });
+
+  it("accepts known category", () => {
+    const rows = [{ ...baseRow, amount: "10.00" }];
+    expect(() => validateTransactions(rows, ["Misc"])).not.toThrow();
+  });
 });

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -71,7 +71,7 @@ export default function TransactionsPage() {
     if (!file) return;
     try {
       const rows = await parseCsv<TransactionRowType>(file);
-      const parsed = validateTransactions(rows);
+      const parsed = validateTransactions(rows, getCategories());
       parsed.forEach((t) => addCategory(t.category));
       setTransactions((prev) => [...parsed, ...prev]);
     } catch (err) {


### PR DESCRIPTION
## Summary
- enforce category validation in transaction schemas using Firestore-provided list
- fail imports when categories are unknown and fetch valid categories from Firestore
- add unit tests for valid and invalid category handling

## Testing
- `npm test` *(fails: Merge conflict marker encountered in src/lib/firebase.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e51374c8833198a5caab4299769b