### PR TITLE
fix: resolve dashboard import conflicts

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
-import OverviewCards from "@/components/dashboard/overview-cards";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+import OverviewCards from "@/components/dashboard/overview-cards";
 import CurrentTimeCard from "@/components/dashboard/current-time-card";
 import DashboardCharts from "@/app/dashboard/dashboard-charts";
 import { mockTransactions } from "@/lib/data";


### PR DESCRIPTION
## Summary
- reorder dashboard page imports so React Suspense and its skeleton appear before the CurrentTimeCard

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-require-imports, no-constant-condition errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e65d9c98833196ef1d321567856f