### PR TITLE
fix: validate Firestore category IDs

### DIFF
--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -1,0 +1,32 @@
+import { addCategory, getCategories, removeCategory, clearCategories } from "@/lib/categoryService";
+import { setDoc, deleteDoc } from "firebase/firestore";
+
+jest.mock("@/lib/firebase", () => ({ db: {}, categoriesCollection: {} }));
+
+jest.mock("firebase/firestore", () => ({
+  doc: jest.fn(() => ({})),
+  setDoc: jest.fn(() => Promise.resolve()),
+  deleteDoc: jest.fn(() => Promise.resolve()),
+  getDocs: jest.fn(async () => ({ forEach: () => {} })),
+  writeBatch: jest.fn(() => ({ delete: jest.fn(), commit: jest.fn() })),
+}));
+
+describe("categoryService", () => {
+  beforeEach(() => {
+    clearCategories();
+    jest.clearAllMocks();
+  });
+
+  it("rejects categories with illegal Firestore characters", () => {
+    addCategory("Food/Drink");
+    expect(getCategories()).toEqual([]);
+    expect(setDoc).not.toHaveBeenCalled();
+  });
+
+  it("ignores removal of invalid category names", () => {
+    addCategory("Groceries");
+    removeCategory("Bad[Cat]");
+    expect(getCategories()).toEqual(["Groceries"]);
+    expect(deleteDoc).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -16,6 +16,8 @@ const hasLocalStorage = () =>
 
 const normalize = (value: string) => value.trim().toLowerCase();
 
+const isValidKey = (key: string) => key.length > 0 && !/[\/\*\[\]]/.test(key);
+
 function load(): string[] {
   if (hasLocalStorage()) {
     const raw = window.localStorage.getItem(STORAGE_KEY);
@@ -85,6 +87,10 @@ export function addCategory(category: string): string[] {
   const categories = getCategories();
   const trimmed = category.trim();
   const key = normalize(trimmed);
+  if (!isValidKey(key)) {
+    console.error("Invalid category name");
+    return categories;
+  }
   const exists = categories.some((c) => normalize(c) === key);
   if (!exists) {
     categories.push(trimmed);
@@ -102,6 +108,10 @@ export function addCategory(category: string): string[] {
  */
 export function removeCategory(category: string): string[] {
   const key = normalize(category);
+  if (!isValidKey(key)) {
+    console.error("Invalid category name");
+    return getCategories();
+  }
   const categories = getCategories().filter((c) => normalize(c) !== key);
   save(categories);
   void deleteDoc(doc(categoriesCollection, key)).catch(console.error);


### PR DESCRIPTION
## Summary
- validate category names and skip writes when Firestore ID would be invalid
- test categoryService rejects invalid characters

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, require imports, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e84b6f8083319a23c8799b59454a