### PR TITLE
fix: bridge category suggestion via API

### DIFF
--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -32,25 +32,21 @@ jest.mock('@/components/ui/switch', () => ({
   ),
 }));
 
-jest.mock('@/ai/flows/categorize-transaction', () => ({
-  suggestCategory: jest.fn(),
-}));
-const { suggestCategory: suggestCategoryMock } = require('@/ai/flows/categorize-transaction') as {
-  suggestCategory: jest.Mock;
-};
-suggestCategoryMock.mockResolvedValue('Misc');
+const fetchMock = jest.fn();
 
 beforeEach(() => {
+  (global as any).fetch = fetchMock;
+  fetchMock.mockResolvedValue({ ok: true, json: async () => ({ category: 'Misc' }) });
   onSave.mockClear();
   toastMock.mockClear();
-  suggestCategoryMock.mockClear();
+  fetchMock.mockClear();
 });
 
 async function openAndFill(amount: string) {
   render(<AddTransactionDialog onSave={onSave} />);
   fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'Test' } });
   fireEvent.blur(screen.getByLabelText(/description/i));
-  await waitFor(() => expect(suggestCategoryMock).toHaveBeenCalled());
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
   fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: amount } });
   fireEvent.click(screen.getByText(/save transaction/i));
 }

--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -47,6 +47,7 @@ async function openAndFill(amount: string) {
   fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'Test' } });
   fireEvent.blur(screen.getByLabelText(/description/i));
   await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+  await waitFor(() => expect(screen.getByLabelText(/category/i)).toHaveValue('Misc'));
   fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: amount } });
   fireEvent.click(screen.getByText(/save transaction/i));
 }

--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -11,19 +11,19 @@
 export { analyzeReceipt } from './analyze-receipt';
 export type { AnalyzeReceiptInput, AnalyzeReceiptOutput } from './analyze-receipt';
 
-export { estimateTax } from './tax-estimation';
-export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
-
 export { analyzeSpendingHabits } from './analyze-spending-habits';
 export type { AnalyzeSpendingHabitsInput, AnalyzeSpendingHabitsOutput } from './analyze-spending-habits';
 
-export { suggestDebtStrategy } from './suggest-debt-strategy';
-export type { SuggestDebtStrategyInput, SuggestDebtStrategyOutput } from './suggest-debt-strategy';
-
 export { calculateCashflow } from './calculate-cashflow';
 export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculate-cashflow';
+
+export { estimateTax } from './tax-estimation';
+export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
 
 export { predictSpending } from './spendingForecast';
 export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
 
 export { suggestCategory } from './categorize-transaction';
+
+export { suggestDebtStrategy } from './suggest-debt-strategy';
+export type { SuggestDebtStrategyInput, SuggestDebtStrategyOutput } from './suggest-debt-strategy';

--- a/src/app/api/suggest-category/route.ts
+++ b/src/app/api/suggest-category/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { suggestCategory } from "@/ai/flows";
+
+const bodySchema = z.object({ description: z.string() });
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json();
+    const { description } = bodySchema.parse(json);
+    const category = await suggestCategory(description);
+    return NextResponse.json({ category });
+  } catch (err) {
+    return NextResponse.json({ error: "Failed to suggest category" }, { status: 500 });
+  }
+}

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -69,14 +69,14 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
         if (suggested) {
             setCategory(suggested)
             setCategories(prev => prev.includes(suggested) ? prev : [...prev, suggested])
-            addCategory(suggested)
         }
     }
 
     const handleSave = () => {
         const numericAmount = Number(amount)
+        const trimmedCategory = category.trim()
 
-        if (!description || !amount || !type || !category || !Number.isFinite(numericAmount)) {
+        if (!description || !amount || !type || !trimmedCategory || !Number.isFinite(numericAmount)) {
             toast({ title: "Invalid amount", description: "Please enter a valid amount.", variant: "destructive" })
             return
         }
@@ -86,10 +86,10 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             amount: numericAmount,
             currency,
             type,
-            category,
+            category: trimmedCategory,
             isRecurring
         })
-        addCategory(category)
+        setCategories(addCategory(trimmedCategory))
         setOpen(false)
         // Reset form
         setDescription("")


### PR DESCRIPTION
## Summary
- call suggestCategory through a new `/api/suggest-category` endpoint instead of importing server code in a client component
- allow manual category entry with datalist suggestions and persist selections
- organize AI flow exports alphabetically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0e828d3f8833187230ef6b9904683