### PR TITLE
fix: allow manual category entry and server action

### DIFF
--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -32,25 +32,25 @@ jest.mock('@/components/ui/switch', () => ({
   ),
 }));
 
-jest.mock('@/ai/flows/categorize-transaction', () => ({
-  suggestCategory: jest.fn(),
+jest.mock('@/app/actions', () => ({
+  suggestCategoryAction: jest.fn(),
 }));
-const { suggestCategory: suggestCategoryMock } = require('@/ai/flows/categorize-transaction') as {
-  suggestCategory: jest.Mock;
+const { suggestCategoryAction: suggestCategoryActionMock } = require('@/app/actions') as {
+  suggestCategoryAction: jest.Mock;
 };
-suggestCategoryMock.mockResolvedValue('Misc');
+suggestCategoryActionMock.mockResolvedValue('Misc');
 
 beforeEach(() => {
   onSave.mockClear();
   toastMock.mockClear();
-  suggestCategoryMock.mockClear();
+  suggestCategoryActionMock.mockClear();
 });
 
 async function openAndFill(amount: string) {
   render(<AddTransactionDialog onSave={onSave} />);
   fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'Test' } });
   fireEvent.blur(screen.getByLabelText(/description/i));
-  await waitFor(() => expect(suggestCategoryMock).toHaveBeenCalled());
+  await waitFor(() => expect(suggestCategoryActionMock).toHaveBeenCalled());
   fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: amount } });
   fireEvent.click(screen.getByText(/save transaction/i));
 }

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,7 @@
+'use server'
+
+import { suggestCategory } from '@/ai/flows'
+
+export async function suggestCategoryAction(description: string): Promise<string> {
+  return suggestCategory(description)
+}

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -25,7 +25,7 @@ import { PlusCircle } from "lucide-react"
 import type { Transaction } from "@/lib/types"
 import { useToast } from "@/hooks/use-toast"
 import { getCategories } from "@/lib/categories"
-import { suggestCategory } from "@/ai/flows/categorize-transaction"
+import { suggestCategoryAction } from "@/app/actions"
 
 interface AddTransactionDialogProps {
   onSave: (transaction: Omit<Transaction, 'id' | 'date'>) => void;
@@ -51,7 +51,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
     const handleDescriptionBlur = async () => {
         if (!description.trim()) return
         try {
-            const suggested = await suggestCategory(description)
+            const suggested = await suggestCategoryAction(description)
             if (suggested) {
                 setCategory(suggested)
                 setCategories(prev => prev.includes(suggested) ? prev : [...prev, suggested])
@@ -144,18 +144,20 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="category" className="text-right">Category</Label>
-            <Select onValueChange={setCategory} value={category}>
-              <SelectTrigger id="category" className="col-span-3">
-                <SelectValue placeholder="Select category" />
-              </SelectTrigger>
-              <SelectContent>
+            <Input
+              id="category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              list="category-options"
+              className="col-span-3 capitalize"
+            />
+            {categories.length > 0 && (
+              <datalist id="category-options">
                 {categories.map(cat => (
-                  <SelectItem key={cat} value={cat} className="capitalize">
-                    {cat}
-                  </SelectItem>
+                  <option key={cat} value={cat} />
                 ))}
-              </SelectContent>
-            </Select>
+              </datalist>
+            )}
           </div>
            <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="recurring" className="text-right">Recurring</Label>


### PR DESCRIPTION
## Summary
- bridge AI category suggestions through a server action
- allow manual category entry with datalist suggestions
- update tests for new action and input

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0e8a07cb88331a4116027ace5dd22