### PR TITLE
feat: apply filing status to state tax brackets

### DIFF
--- a/src/ai/flows/__tests__/stateTax.test.ts
+++ b/src/ai/flows/__tests__/stateTax.test.ts
@@ -1,12 +1,13 @@
-import { calculateStateTax } from '@/data/stateTaxRates';
+import { calculateStateTax, FilingStatus } from '@/data/stateTaxRates';
 
 describe('state tax calculations', () => {
-  it.each([
-    ['CA', 50000, 1664.41],
-    ['NY', 50000, 2749.42],
-    ['TX', 50000, 0],
-  ])('computes %s tax for income %d', (state, income, expected) => {
-    const tax = calculateStateTax(income, state as string);
+  it.each<readonly [string, FilingStatus, number, number]>([
+    ['CA', 'single', 50000, 1664.41],
+    ['NY', 'single', 50000, 2749.42],
+    ['TX', 'single', 50000, 0],
+    ['CA', 'married_jointly', 200000, 12106.95],
+  ])('computes %s tax for %s filer with income %d', (state, status, income, expected) => {
+    const tax = calculateStateTax(income, state as string, status);
     expect(tax).toBeCloseTo(expected, 2);
   });
 });

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -100,7 +100,7 @@ export async function estimateTax(input: TaxEstimationInput): Promise<TaxEstimat
   const parsed = TaxEstimationInputSchema.parse(input);
   const taxableIncome = Math.max(0, parsed.income - parsed.deductions);
   const federalTax = calculateFederalTax(taxableIncome, parsed.filingStatus);
-  const stateTax = calculateStateTax(taxableIncome, parsed.state);
+  const stateTax = calculateStateTax(taxableIncome, parsed.state, parsed.filingStatus);
   const total = federalTax + stateTax;
   const rate = parsed.income > 0 ? (total / parsed.income) * 100 : 0;
   const breakdown = `Federal Tax: $${federalTax.toFixed(2)}\nState Tax (${parsed.state}): $${stateTax.toFixed(2)}`;


### PR DESCRIPTION
## Summary
- extend state tax datasets to map brackets for each filing status
- calculate state taxes using selected filing status and adjust CA/NY thresholds

## Testing
- `npm test src/ai/flows/__tests__/stateTax.test.ts src/ai/flows/__tests__/validation.test.ts src/ai/flows/__tests__/no-output.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0ea7de5ec8331afe26867b9dbf775