### PR TITLE
fix: apply filing status to state tax brackets

### DIFF
--- a/src/ai/flows/__tests__/stateTax.test.ts
+++ b/src/ai/flows/__tests__/stateTax.test.ts
@@ -2,11 +2,16 @@ import { calculateStateTax } from '@/data/stateTaxRates';
 
 describe('state tax calculations', () => {
   it.each([
-    ['CA', 50000, 1664.41],
-    ['NY', 50000, 2749.42],
-    ['TX', 50000, 0],
-  ])('computes %s tax for income %d', (state, income, expected) => {
-    const tax = calculateStateTax(income, state as string);
-    expect(tax).toBeCloseTo(expected, 2);
-  });
+    ['CA', 'single', 50000, 1664.41],
+    ['NY', 'single', 50000, 2749.42],
+    ['TX', 'single', 50000, 0],
+    ['CA', 'married_jointly', 50000, 840.34],
+    ['NY', 'married_jointly', 50000, 2513.84],
+  ])(
+    'computes %s tax for %s filers with income %d',
+    (state, status, income, expected) => {
+      const tax = calculateStateTax(income, state as string, status as any);
+      expect(tax).toBeCloseTo(expected, 2);
+    }
+  );
 });

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -100,7 +100,7 @@ export async function estimateTax(input: TaxEstimationInput): Promise<TaxEstimat
   const parsed = TaxEstimationInputSchema.parse(input);
   const taxableIncome = Math.max(0, parsed.income - parsed.deductions);
   const federalTax = calculateFederalTax(taxableIncome, parsed.filingStatus);
-  const stateTax = calculateStateTax(taxableIncome, parsed.state);
+  const stateTax = calculateStateTax(taxableIncome, parsed.state, parsed.filingStatus);
   const total = federalTax + stateTax;
   const rate = parsed.income > 0 ? (total / parsed.income) * 100 : 0;
   const breakdown = `Federal Tax: $${federalTax.toFixed(2)}\nState Tax (${parsed.state}): $${stateTax.toFixed(2)}`;


### PR DESCRIPTION
## Summary
- handle per-filing-status state tax brackets
- include filing status when calculating state taxes
- cover multiple filing statuses in state tax tests

## Testing
- `npm test src/ai/flows/__tests__/stateTax.test.ts`
- `npm test src/ai/flows/__tests__/validation.test.ts`
- `npm test src/ai/flows/__tests__/no-output.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0ea8c7eac8331b804c656496bd2ef