### PR TITLE
fix: persist suggested categories

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -11,19 +11,19 @@
 export { analyzeReceipt } from './analyze-receipt';
 export type { AnalyzeReceiptInput, AnalyzeReceiptOutput } from './analyze-receipt';
 
-export { estimateTax } from './tax-estimation';
-export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
-
 export { analyzeSpendingHabits } from './analyze-spending-habits';
 export type { AnalyzeSpendingHabitsInput, AnalyzeSpendingHabitsOutput } from './analyze-spending-habits';
 
-export { suggestDebtStrategy } from './suggest-debt-strategy';
-export type { SuggestDebtStrategyInput, SuggestDebtStrategyOutput } from './suggest-debt-strategy';
-
 export { calculateCashflow } from './calculate-cashflow';
 export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculate-cashflow';
+
+export { estimateTax } from './tax-estimation';
+export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
 
 export { predictSpending } from './spendingForecast';
 export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
 
 export { suggestCategory } from './categorize-transaction';
+
+export { suggestDebtStrategy } from './suggest-debt-strategy';
+export type { SuggestDebtStrategyInput, SuggestDebtStrategyOutput } from './suggest-debt-strategy';

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -24,7 +24,7 @@ import { Switch } from "@/components/ui/switch"
 import { PlusCircle } from "lucide-react"
 import type { Transaction } from "@/lib/types"
 import { useToast } from "@/hooks/use-toast"
-import { getCategories } from "@/lib/categories"
+import { addCategory, getCategories } from "@/lib/categories"
 import { suggestCategoryAction } from "@/app/actions"
 
 interface AddTransactionDialogProps {
@@ -54,7 +54,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             const suggested = await suggestCategoryAction(description)
             if (suggested) {
                 setCategory(suggested)
-                setCategories(prev => prev.includes(suggested) ? prev : [...prev, suggested])
+                setCategories(addCategory(suggested))
             }
         } catch (err) {
             console.error("suggestCategory failed", err)
@@ -68,6 +68,8 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             toast({ title: "Invalid amount", description: "Please enter a valid amount.", variant: "destructive" })
             return
         }
+
+        setCategories(addCategory(category))
 
         onSave({
             description,


### PR DESCRIPTION
## Summary
- persist AI-suggested and user-entered categories in AddTransactionDialog
- alphabetize AI flow exports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0eadd4e2c83318c3d0061407102c8