### PR TITLE
fix: persist suggested categories & sort AI flow exports

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -8,6 +8,9 @@
  * ```
  */
 
+// Exports in this module are grouped with their associated types and
+// kept in alphabetical order for easier maintenance.
+
 export {
   analyzeReceipt,
   type AnalyzeReceiptInput,

--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -8,21 +8,40 @@
  * ```
  */
 
-export { analyzeReceipt } from './analyze-receipt';
-export type { AnalyzeReceiptInput, AnalyzeReceiptOutput } from './analyze-receipt';
+export {
+  analyzeReceipt,
+  type AnalyzeReceiptInput,
+  type AnalyzeReceiptOutput,
+} from './analyze-receipt';
 
-export { analyzeSpendingHabits } from './analyze-spending-habits';
-export type { AnalyzeSpendingHabitsInput, AnalyzeSpendingHabitsOutput } from './analyze-spending-habits';
+export {
+  analyzeSpendingHabits,
+  type AnalyzeSpendingHabitsInput,
+  type AnalyzeSpendingHabitsOutput,
+} from './analyze-spending-habits';
 
-export { calculateCashflow } from './calculate-cashflow';
-export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculate-cashflow';
+export {
+  calculateCashflow,
+  type CalculateCashflowInput,
+  type CalculateCashflowOutput,
+} from './calculate-cashflow';
 
-export { estimateTax } from './tax-estimation';
-export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
+export {
+  estimateTax,
+  type TaxEstimationInput,
+  type TaxEstimationOutput,
+} from './tax-estimation';
 
-export { predictSpending } from './spendingForecast';
-export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
+export {
+  predictSpending,
+  type SpendingForecastInput,
+  type SpendingForecastOutput,
+} from './spendingForecast';
 
 export { suggestCategory } from './categorize-transaction';
-export { suggestDebtStrategy } from './suggest-debt-strategy';
-export type { SuggestDebtStrategyInput, SuggestDebtStrategyOutput } from './suggest-debt-strategy';
+
+export {
+  suggestDebtStrategy,
+  type SuggestDebtStrategyInput,
+  type SuggestDebtStrategyOutput,
+} from './suggest-debt-strategy';

--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -11,19 +11,18 @@
 export { analyzeReceipt } from './analyze-receipt';
 export type { AnalyzeReceiptInput, AnalyzeReceiptOutput } from './analyze-receipt';
 
-export { estimateTax } from './tax-estimation';
-export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
-
 export { analyzeSpendingHabits } from './analyze-spending-habits';
 export type { AnalyzeSpendingHabitsInput, AnalyzeSpendingHabitsOutput } from './analyze-spending-habits';
 
-export { suggestDebtStrategy } from './suggest-debt-strategy';
-export type { SuggestDebtStrategyInput, SuggestDebtStrategyOutput } from './suggest-debt-strategy';
-
 export { calculateCashflow } from './calculate-cashflow';
 export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculate-cashflow';
+
+export { estimateTax } from './tax-estimation';
+export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
 
 export { predictSpending } from './spendingForecast';
 export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
 
 export { suggestCategory } from './categorize-transaction';
+export { suggestDebtStrategy } from './suggest-debt-strategy';
+export type { SuggestDebtStrategyInput, SuggestDebtStrategyOutput } from './suggest-debt-strategy';

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -24,7 +24,7 @@ import { Switch } from "@/components/ui/switch"
 import { PlusCircle } from "lucide-react"
 import type { Transaction } from "@/lib/types"
 import { useToast } from "@/hooks/use-toast"
-import { getCategories } from "@/lib/categories"
+import { addCategory, getCategories } from "@/lib/categories"
 import { suggestCategoryAction } from "@/app/actions"
 
 interface AddTransactionDialogProps {
@@ -54,7 +54,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             const suggested = await suggestCategoryAction(description)
             if (suggested) {
                 setCategory(suggested)
-                setCategories(prev => prev.includes(suggested) ? prev : [...prev, suggested])
+                setCategories(addCategory(suggested))
             }
         } catch (err) {
             console.error("suggestCategory failed", err)
@@ -68,6 +68,8 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             toast({ title: "Invalid amount", description: "Please enter a valid amount.", variant: "destructive" })
             return
         }
+
+        setCategories(addCategory(category))
 
         onSave({
             description,

--- a/src/lib/category-feedback.ts
+++ b/src/lib/category-feedback.ts
@@ -1,0 +1,7 @@
+export async function recordCategoryFeedback(description: string, category: string): Promise<void> {
+  // Placeholder implementation: in a real app, this would persist feedback to a backend service.
+  // For now, it simply resolves immediately.
+  void description;
+  void category;
+  return;
+}


### PR DESCRIPTION
## Summary
- persist suggested and manual categories in AddTransactionDialog
- keep AI flow central exports alphabetical

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ead98acc8331b29bd29ea4fc6f04