### PR TITLE
fix: resolve add transaction dialog merge conflicts

### DIFF
--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -47,6 +47,7 @@ async function openAndFill(amount: string) {
   fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'Test' } });
   fireEvent.blur(screen.getByLabelText(/description/i));
   await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+  await waitFor(() => expect(screen.getByLabelText(/category/i)).toHaveValue('Misc'));
   fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: amount } });
   fireEvent.click(screen.getByText(/save transaction/i));
 }

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -69,14 +69,14 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
         if (suggested) {
             setCategory(suggested)
             setCategories(prev => prev.includes(suggested) ? prev : [...prev, suggested])
-            addCategory(suggested)
         }
     }
 
     const handleSave = () => {
         const numericAmount = Number(amount)
+        const trimmedCategory = category.trim()
 
-        if (!description || !amount || !type || !category || !Number.isFinite(numericAmount)) {
+        if (!description || !amount || !type || !trimmedCategory || !Number.isFinite(numericAmount)) {
             toast({ title: "Invalid amount", description: "Please enter a valid amount.", variant: "destructive" })
             return
         }
@@ -86,10 +86,10 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             amount: numericAmount,
             currency,
             type,
-            category,
+            category: trimmedCategory,
             isRecurring
         })
-        addCategory(category)
+        setCategories(addCategory(trimmedCategory))
         setOpen(false)
         // Reset form
         setDescription("")


### PR DESCRIPTION
## Summary
- trim and persist categories only on save
- update dialog test to wait for suggestion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ea4d13c88331bc17a8a8db6fb93c