### PR TITLE
fix: resolve flow export merge conflict

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -28,3 +28,6 @@ export type { SpendingForecastInput, SpendingForecastOutput } from './spendingFo
 
 export { calculateCostOfLiving } from './cost-of-living';
 export type { CostOfLivingInput, CostOfLivingOutput } from './cost-of-living';
+
+export { suggestCategory } from './suggest-category';
+export type { SuggestCategoryInput, SuggestCategoryOutput } from './suggest-category';


### PR DESCRIPTION
## Summary
- ensure flow index exports both cost-of-living and category suggestion helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0eb4073908331bf7a3a56c823a6c0