### PR TITLE
fix: drop nonexistent suggest-category export

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -26,9 +26,6 @@ export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculat
 export { predictSpending } from './spendingForecast';
 export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
 
-export { suggestCategory } from './suggest-category';
-export type { SuggestCategoryInput, SuggestCategoryOutput } from './suggest-category';
-
 export { calculateCostOfLiving } from './cost-of-living';
 export type {
   CalculateCostOfLivingInput,

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -53,7 +53,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             return
         }
         let active = true
-        import("@/ai/flows").then(({ suggestCategory }) =>
+        import("@/ai/flows/suggest-category").then(({ suggestCategory }) =>
             suggestCategory({ description }).then(res => {
                 if (active) {
                     setSuggestedCategory(res.category)


### PR DESCRIPTION
## Summary
- remove broken suggest-category re-export
- import suggest-category flow directly where used

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ee6df480833185ce79f65a55341a