### PR TITLE
Refactor mobile hook to use media query events

### DIFF
--- a/src/__tests__/use-mobile.test.tsx
+++ b/src/__tests__/use-mobile.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, act } from "@testing-library/react";
 import { useIsMobile, MOBILE_BREAKPOINT } from "../hooks/use-mobile";
 
 describe("useIsMobile", () => {
-  let listeners: Array<() => void>;
+  let listeners: Array<(e: { matches: boolean }) => void>;
 
   beforeEach(() => {
     listeners = [];
@@ -11,17 +11,17 @@ describe("useIsMobile", () => {
     window.matchMedia = jest.fn().mockImplementation(() => ({
       matches: window.innerWidth < MOBILE_BREAKPOINT,
       media: "",
-      addEventListener: (_event: string, cb: () => void) => {
+      addEventListener: (_event: string, cb: (e: { matches: boolean }) => void) => {
         listeners.push(cb);
       },
-      removeEventListener: (_event: string, cb: () => void) => {
+      removeEventListener: (_event: string, cb: (e: { matches: boolean }) => void) => {
         listeners = listeners.filter((l) => l !== cb);
       },
     }));
   });
 
-  function triggerChange() {
-    listeners.forEach((cb) => cb());
+  function triggerChange(matches: boolean) {
+    listeners.forEach((cb) => cb({ matches }));
   }
 
   it("returns false initially and updates on resize", () => {
@@ -35,9 +35,35 @@ describe("useIsMobile", () => {
 
     act(() => {
       window.innerWidth = MOBILE_BREAKPOINT - 50;
-      triggerChange();
+      triggerChange(window.innerWidth < MOBILE_BREAKPOINT);
     });
 
+    expect(screen.getByText("mobile")).toBeInTheDocument();
+  });
+
+  it("handles transitions across the breakpoint", () => {
+    function TestComponent() {
+      const mobile = useIsMobile();
+      return <span>{mobile ? "mobile" : "desktop"}</span>;
+    }
+
+    // start below breakpoint
+    window.innerWidth = MOBILE_BREAKPOINT - 50;
+    render(<TestComponent />);
+    expect(screen.getByText("mobile")).toBeInTheDocument();
+
+    // transition to desktop
+    act(() => {
+      window.innerWidth = MOBILE_BREAKPOINT + 50;
+      triggerChange(window.innerWidth < MOBILE_BREAKPOINT);
+    });
+    expect(screen.getByText("desktop")).toBeInTheDocument();
+
+    // back to mobile
+    act(() => {
+      window.innerWidth = MOBILE_BREAKPOINT - 50;
+      triggerChange(window.innerWidth < MOBILE_BREAKPOINT);
+    });
     expect(screen.getByText("mobile")).toBeInTheDocument();
   });
 });

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -15,11 +15,11 @@ export function useIsMobile() {
     if (typeof window === "undefined") return
 
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    const onChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(mql.matches)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 


### PR DESCRIPTION
## Summary
- use MediaQueryList events to update mobile state
- test mobile hook transitions across breakpoint

## Testing
- `npm test src/__tests__/use-mobile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0f07072608331bffff251265262cc