### PR TITLE
feat: add timeout and error detail to internet time

### DIFF
--- a/src/lib/internet-time.ts
+++ b/src/lib/internet-time.ts
@@ -9,9 +9,31 @@ function resolveTimezone(tz?: string): string {
 }
 
 export async function fetchInternetTime(tz: string): Promise<Date> {
-  const res = await fetch(`https://worldtimeapi.org/api/timezone/${tz}`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  let res: Response;
+  try {
+    res = await fetch(`https://worldtimeapi.org/api/timezone/${tz}`, {
+      signal: controller.signal,
+    });
+  } catch (err: any) {
+    clearTimeout(timeout);
+    if (err?.name === "AbortError") {
+      throw new Error(`Request to worldtimeapi.org timed out`);
+    }
+    throw err;
+  }
+  clearTimeout(timeout);
   if (!res.ok) {
-    throw new Error(`Failed to fetch time for timezone ${tz}`);
+    let body: string;
+    try {
+      body = await res.text();
+    } catch {
+      body = "";
+    }
+    throw new Error(
+      `Failed to fetch time for timezone ${tz}: ${res.status} ${res.statusText} ${body}`
+    );
   }
   const data = await res.json();
   const networkDate = new Date(data.datetime);


### PR DESCRIPTION
## Summary
- add fetch timeout handling with AbortController and detailed errors
- test internet time errors and timeouts

## Testing
- `npm test src/__tests__/internet-time.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0f06f55bc833193454e4d41eac5a2