### PR TITLE
Generate per-request CSP nonce

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 
 import type { NextConfig } from 'next'
-import crypto from 'crypto'
-
 const nextConfig: NextConfig = {
   // Enforce type checking and linting during builds
   typescript: { ignoreBuildErrors: false },
@@ -12,48 +10,6 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'picsum.photos', pathname: '/**' },
     ],
   },
-
-  async headers() {
-    const cspNonce = crypto.randomBytes(16).toString('base64')
-    const securityHeaders = [
-      {
-        key: 'Content-Security-Policy',
-        value: [
-          "default-src 'self'",
-          `script-src 'self' 'nonce-${cspNonce}'`,
-          "style-src 'self' 'unsafe-inline' 'https://fonts.googleapis.com'",
-          "img-src 'self' data: https:",
-          "font-src 'self' https://fonts.gstatic.com",
-          "connect-src 'self' https:",
-          "base-uri 'self'",
-          "form-action 'self'",
-          "frame-ancestors 'none'",
-        ].join('; '),
-      },
-      { key: 'X-Frame-Options', value: 'DENY' },
-      { key: 'X-Content-Type-Options', value: 'nosniff' },
-      { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-      {
-        key: 'Strict-Transport-Security',
-        value: 'max-age=63072000; includeSubDomains; preload',
-      },
-    ]
-    
-    if (process.env.NODE_ENV === 'development') {
-        securityHeaders.push({
-            key: 'Access-Control-Allow-Origin',
-            value: 'https://*-firebase-studio-*.cloudworkstations.dev, http://localhost:6006',
-        })
-    }
-
-    return [
-      {
-        source: '/(.*)',
-        headers: securityHeaders,
-      },
-    ]
-  },
-
   experimental: {},
   webpack: (config, { isServer, webpack }) => {
     if (isServer) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,12 @@
-import type { Metadata } from 'next';
-import { Inter } from "next/font/google";
-import './globals.css';
-import { Toaster } from "@/components/ui/toaster";
-import { AuthProvider } from '@/components/auth/auth-provider';
-import { ThemeProvider } from 'next-themes';
-import { ErrorBoundary, SuspenseBoundary } from '@/components/layout/boundaries';
-import { ServiceWorker } from '@/components/service-worker';
+import type { Metadata } from 'next'
+import { headers } from 'next/headers'
+import { Inter } from "next/font/google"
+import './globals.css'
+import { Toaster } from "@/components/ui/toaster"
+import { AuthProvider } from '@/components/auth/auth-provider'
+import { ThemeProvider } from 'next-themes'
+import { ErrorBoundary, SuspenseBoundary } from '@/components/layout/boundaries'
+import { ServiceWorker } from '@/components/service-worker'
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -17,10 +18,18 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
+  const nonce = headers().get('x-nonce') || undefined
+
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          nonce={nonce}
+          dangerouslySetInnerHTML={{ __html: 'window.__nonce=1' }}
+        />
+      </head>
       <body
         className={`${inter.variable} min-h-screen bg-background text-foreground font-sans antialiased dark:bg-background dark:text-foreground`}
       >
@@ -35,5 +44,5 @@ export default function RootLayout({
         </ThemeProvider>
       </body>
     </html>
-  );
+  )
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const cspNonce = btoa(crypto.randomUUID())
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-nonce', cspNonce)
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
+
+  const csp = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${cspNonce}'`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "img-src 'self' data: https:",
+    "font-src 'self' https://fonts.gstatic.com",
+    "connect-src 'self' https:",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join('; ')
+
+  response.headers.set('Content-Security-Policy', csp)
+  response.headers.set('X-Frame-Options', 'DENY')
+  response.headers.set('X-Content-Type-Options', 'nosniff')
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+  response.headers.set(
+    'Strict-Transport-Security',
+    'max-age=63072000; includeSubDomains; preload'
+  )
+
+  if (process.env.NODE_ENV === 'development') {
+    response.headers.set(
+      'Access-Control-Allow-Origin',
+      'https://*-firebase-studio-*.cloudworkstations.dev, http://localhost:6006'
+    )
+  }
+
+  return response
+}
+
+export const config = {
+  matcher: '/:path*',
+}
+


### PR DESCRIPTION
## Summary
- Remove build-time CSP nonce from configuration
- Add middleware generating a nonce each request and injecting security headers
- Propagate nonce to script tags in the root layout

## Testing
- `npm test`
- `npx next build --no-lint` *(fails: `CookieJar` type error in @types/request)*
- `curl -I http://localhost:3001` *(500: `indexedDB is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f06c50388331a78696c95eb1b2b6