### PR TITLE
Fix worker pool exit listener leakage

### DIFF
--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -47,4 +47,16 @@ describe("WorkerPool", () => {
 
     await pool.destroy()
   })
+
+  it("does not accumulate exit listeners", async () => {
+    const pool = new WorkerPool<number, number>("fake", 1)
+
+    for (let i = 0; i < 50; i++) {
+      await pool.run(i)
+      const worker = (pool as any).workers[0]
+      expect(worker.listenerCount("exit")).toBe(1)
+    }
+
+    await pool.destroy()
+  })
 })

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -18,14 +18,39 @@ interface Task<T, R> {
 export class WorkerPool<T = unknown, R = unknown> {
   private readonly workers: Worker[] = []
   private readonly idle: Worker[] = []
+  private readonly tasks = new Map<Worker, Task<T, R>>()
   private queue: Task<T, R>[] = []
+  private destroyed = false
 
   constructor(private readonly file: string, size: number) {
     for (let i = 0; i < size; i++) {
-      const worker = new Worker(file)
-      this.workers.push(worker)
-      this.idle.push(worker)
+      this.spawn()
     }
+  }
+
+  private spawn() {
+    const worker = new Worker(this.file)
+    worker.once("exit", code => {
+      this.workers.splice(this.workers.indexOf(worker), 1)
+      const idleIndex = this.idle.indexOf(worker)
+      if (idleIndex !== -1) this.idle.splice(idleIndex, 1)
+
+      const task = this.tasks.get(worker)
+      this.tasks.delete(worker)
+
+      if (!this.destroyed) {
+        this.spawn()
+        this.process()
+      }
+
+      if (code !== 0 && task) {
+        task.reject(new Error(`Worker stopped with exit code ${code}`))
+      }
+    })
+
+    this.workers.push(worker)
+    this.idle.push(worker)
+    return worker
   }
 
   /**
@@ -55,7 +80,10 @@ export class WorkerPool<T = unknown, R = unknown> {
       const worker = this.idle.shift()!
       const task = this.queue.shift()!
 
+      this.tasks.set(worker, task)
+
       const finalize = () => {
+        this.tasks.delete(worker)
         this.idle.push(worker)
         this.process()
       }
@@ -70,25 +98,6 @@ export class WorkerPool<T = unknown, R = unknown> {
         finalize()
       })
 
-      worker.once("exit", code => {
-        this.workers.splice(this.workers.indexOf(worker), 1)
-        const idleIndex = this.idle.indexOf(worker)
-        if (idleIndex !== -1) this.idle.splice(idleIndex, 1)
-
-        if (code !== 0) {
-          const replacement = new Worker(this.file)
-          this.workers.push(replacement)
-          this.idle.push(replacement)
-          this.process()
-          task.reject(new Error(`Worker stopped with exit code ${code}`))
-        } else {
-          // A zero exit code indicates a graceful shutdown. No need to reject
-          // the pending task; just continue processing with the remaining
-          // workers.
-          this.process()
-        }
-      })
-
       worker.postMessage(task.data)
     }
   }
@@ -101,6 +110,7 @@ export class WorkerPool<T = unknown, R = unknown> {
    * will not receive a resolution.
    */
   async destroy(): Promise<void> {
+    this.destroyed = true
     await Promise.all(this.workers.map(worker => worker.terminate()))
     this.queue = []
     this.idle.length = 0


### PR DESCRIPTION
## Summary
- move worker exit listener to constructor and track active tasks
- replace workers on exit and reject active task on non-zero exit
- add test ensuring exit listener count stays constant across many tasks

## Testing
- `npm test src/__tests__/worker-pool.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0f06abf5c833196a4845640ded175