### PR TITLE
Fix negative week parity for pay period calculation

### DIFF
--- a/src/__tests__/payroll.test.ts
+++ b/src/__tests__/payroll.test.ts
@@ -20,6 +20,12 @@ describe('payroll utilities', () => {
     expect(start.toISOString().slice(0, 10)).toBe('2024-01-14');
   });
 
+  test('getPayPeriodStart handles dates before the anchor', () => {
+    const date = new Date('2023-12-31T12:00:00Z');
+    const start = getPayPeriodStart(date);
+    expect(start.toISOString().slice(0, 10)).toBe('2023-12-24');
+  });
+
   test('calculateOvertimeDates identifies shifts after 40 hours', () => {
     const shifts: Shift[] = [
       { date: new Date('2024-01-08'), hours: 8, rate: 10 },

--- a/src/lib/payroll.ts
+++ b/src/lib/payroll.ts
@@ -29,8 +29,9 @@ export const getPayPeriodStart = (
   d.setDate(d.getDate() - dayOfWeek);
 
   const diffWeeks = Math.floor((d.getTime() - anchor.getTime()) / (1000 * 60 * 60 * 24 * 7));
+  const parity = Math.abs(diffWeeks) % 2;
 
-  if (diffWeeks % 2 !== 0) {
+  if (parity !== 0) {
     // It's in the second week of a pay period, so the start was the *previous* Sunday
     d.setDate(d.getDate() - 7);
   }


### PR DESCRIPTION
## Summary
- normalize diff week parity in `getPayPeriodStart` to handle dates before the anchor
- add regression test for pay period calculations with dates before the anchor

## Testing
- `npm test src/__tests__/payroll.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0f0688a2c8331a60f52939330def0