### PR TITLE
fix: preserve manual category across description edits

### DIFF
--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -43,10 +43,10 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
     const { toast } = useToast()
 
     useEffect(() => {
-        userModifiedCategory.current = false
         if (!description) {
             setSuggestedCategory(null)
             setCategory("")
+            userModifiedCategory.current = false
             return
         }
         if (process.env.NODE_ENV === "test") {


### PR DESCRIPTION
## Summary
- keep userModifiedCategory flag across description edits
- only clear manual category flag when description is cleared

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f351c5188331a43d005191d598ae