### PR TITLE
fix: pass structured category to API

### DIFF
--- a/src/app/api/suggest-category/route.ts
+++ b/src/app/api/suggest-category/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
   try {
     const json = await req.json();
     const { description } = bodySchema.parse(json);
-    const category = await suggestCategory(description);
+    const { category } = await suggestCategory({ description });
     return NextResponse.json({ category });
   } catch (err) {
     return NextResponse.json({ error: "Failed to suggest category" }, { status: 500 });


### PR DESCRIPTION
## Summary
- pass `{ description }` to `suggestCategory`
- return category string from `suggestCategory` result

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f42b5fe08331a11932731e9e5b4a