### PR TITLE
fix: resolve merge conflicts in category suggestion flow

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -11,17 +11,26 @@
 export { analyzeReceipt } from './analyze-receipt';
 export type { AnalyzeReceiptInput, AnalyzeReceiptOutput } from './analyze-receipt';
 
+export { estimateTax } from './tax-estimation';
+export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
+
 export { analyzeSpendingHabits } from './analyze-spending-habits';
 export type {
   AnalyzeSpendingHabitsInput,
   AnalyzeSpendingHabitsOutput,
 } from './analyze-spending-habits';
 
+export { suggestDebtStrategy } from './suggest-debt-strategy';
+export type {
+  SuggestDebtStrategyInput,
+  SuggestDebtStrategyOutput,
+} from './suggest-debt-strategy';
+
+export { suggestCategory } from './suggest-category';
+export type { SuggestCategoryInput, SuggestCategoryOutput } from './suggest-category';
+
 export { calculateCashflow } from './calculate-cashflow';
 export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculate-cashflow';
-
-export { estimateTax } from './tax-estimation';
-export type { TaxEstimationInput, TaxEstimationOutput } from './tax-estimation';
 
 export { predictSpending } from './spendingForecast';
 export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
@@ -31,11 +40,3 @@ export type {
   CalculateCostOfLivingInput,
   CostOfLivingBreakdown,
 } from './cost-of-living';
-export { suggestCategory } from './suggest-category';
-export type { SuggestCategoryInput, SuggestCategoryOutput } from './suggest-category';
-
-export { suggestDebtStrategy } from './suggest-debt-strategy';
-export type {
-  SuggestDebtStrategyInput,
-  SuggestDebtStrategyOutput,
-} from './suggest-debt-strategy';

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -166,7 +166,10 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
               id="category"
               placeholder="e.g. Uniforms, Salary"
               value={category}
-              onChange={(e) => {setCategory(e.target.value); userModifiedCategory.current = true;}}
+              onChange={(e) => {
+                setCategory(e.target.value)
+                userModifiedCategory.current = true
+              }}
               list="category-options"
               className="col-span-3 capitalize"
             />


### PR DESCRIPTION
## Summary
- merge main and keep exports for category and debt strategy flows
- ensure transaction dialog loads categories and uses server action for suggestions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f82ff0b083318b52401ce0a7ab22