### PR TITLE
Add timeout to currency fetch

### DIFF
--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -17,6 +17,7 @@ describe('currency code validation', () => {
     expect(rate).toBe(0.85);
     expect(mockFetch).toHaveBeenCalledWith(
       'https://api.exchangerate.host/latest?base=USD&symbols=EUR',
+      expect.objectContaining({ signal: expect.any(Object) }),
     );
   });
 

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -14,17 +14,25 @@ export async function getFxRate(from: string, to: string): Promise<number> {
   const fromCode = parseCurrencyCode(from);
   const toCode = parseCurrencyCode(to);
   if (fromCode === toCode) return 1;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
   let res: Response;
   try {
     res = await fetch(
       `https://api.exchangerate.host/latest?base=${fromCode}&symbols=${toCode}`,
+      { signal: controller.signal },
     );
   } catch (err) {
+    if (controller.signal.aborted || (err instanceof Error && err.name === 'AbortError')) {
+      throw new Error('FX rate request timed out after 5s');
+    }
     throw new Error(
       `Network error while fetching FX rates: ${
         err instanceof Error ? err.message : err
       }`,
     );
+  } finally {
+    clearTimeout(timeout);
   }
   if (!res.ok) {
     throw new Error('Failed to fetch FX rates');


### PR DESCRIPTION
## Summary
- abort currency fetch requests after 5 seconds
- expect abort signal in currency tests

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / no-explicit-any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b0fbe53f248331b4551f56d9c07318