### PR TITLE
feat: add error handling for category feedback

### DIFF
--- a/src/lib/category-feedback.ts
+++ b/src/lib/category-feedback.ts
@@ -1,15 +1,25 @@
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "./firebase";
+import { logger } from "./logger";
 
 /**
  * Persist a (description, category) feedback pair. This is used when a user
  * overrides the AI suggested category so the model can improve over time.
  */
-export async function recordCategoryFeedback(description: string, category: string): Promise<void> {
+export async function recordCategoryFeedback(
+  description: string,
+  category: string
+): Promise<boolean> {
   const colRef = collection(db, "categoryFeedback");
-  await addDoc(colRef, {
-    description,
-    category,
-    createdAt: serverTimestamp(),
-  });
+  try {
+    await addDoc(colRef, {
+      description,
+      category,
+      createdAt: serverTimestamp(),
+    });
+    return true;
+  } catch (error) {
+    logger.error("Failed to record category feedback", error);
+    return false;
+  }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -4,4 +4,9 @@ export const logger = {
       console.log(message, ...args);
     }
   },
+  error: (message: string, ...args: unknown[]) => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error(message, ...args);
+    }
+  },
 };


### PR DESCRIPTION
## Summary
- add error logging and boolean return when recording category feedback fails
- extend shared logger with `error` method

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fbe14af08331af4b8b3cc3f6a4a9