### PR TITLE
fix: rebase AI flows and transaction dialog

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -31,12 +31,11 @@ export type { SuggestCategoryInput, SuggestCategoryOutput } from './suggest-cate
 
 export { calculateCashflow } from './calculate-cashflow';
 export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculate-cashflow';
-
-export { predictSpending } from './spendingForecast';
-export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
-
 export { calculateCostOfLiving } from './cost-of-living';
 export type {
   CalculateCostOfLivingInput,
   CostOfLivingBreakdown,
 } from './cost-of-living';
+
+export { predictSpending } from './spendingForecast';
+export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,7 +1,19 @@
 'use server'
 
+import type {
+  SuggestDebtStrategyInput,
+  SuggestDebtStrategyOutput,
+} from '@/ai/flows'
+
 export async function suggestCategoryAction(description: string): Promise<string> {
   const { suggestCategory } = await import('@/ai/flows')
   const { category } = await suggestCategory({ description })
   return category
+}
+
+export async function suggestDebtStrategyAction(
+  input: SuggestDebtStrategyInput,
+): Promise<SuggestDebtStrategyOutput> {
+  const { suggestDebtStrategy } = await import('@/ai/flows')
+  return suggestDebtStrategy(input)
 }

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -91,7 +91,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             isRecurring
         })
         setCategories(addCategory(category))
-        if(suggestedCategory && category !== suggestedCategory){
+        if (suggestedCategory && category !== suggestedCategory) {
             recordCategoryFeedback(description, category)
         }
         setOpen(false)


### PR DESCRIPTION
## Summary
- reorder cost-of-living and spending forecast exports to avoid merge conflicts
- add server action to request debt strategy suggestions
- tidy transaction dialog feedback logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0fb23a72483319dbcec3833152359