### PR TITLE
Reject pending tasks when destroying worker pool

### DIFF
--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -59,4 +59,16 @@ describe("WorkerPool", () => {
 
     await pool.destroy()
   })
+
+  it("rejects queued tasks when destroyed", async () => {
+    const pool = new WorkerPool<number, number>("fake", 0)
+
+    const first = pool.run(1)
+    const second = pool.run(2)
+
+    await pool.destroy()
+
+    await expect(first).rejects.toThrow("Worker pool destroyed")
+    await expect(second).rejects.toThrow("Worker pool destroyed")
+  })
 })


### PR DESCRIPTION
## Summary
- ensure worker pool destroy rejects queued tasks with `Worker pool destroyed`
- document new rejection behavior in `destroy`
- add tests covering queued task rejection

## Testing
- `npm test src/__tests__/worker-pool.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0fac4910483319f6534c0350ac4e9