### PR TITLE
Ensure stable transaction IDs and idempotent writes

### DIFF
--- a/src/__tests__/saveTransactions.integration.test.ts
+++ b/src/__tests__/saveTransactions.integration.test.ts
@@ -1,0 +1,60 @@
+import { saveTransactions } from "../lib/transactions";
+import type { Transaction } from "../lib/types";
+
+jest.mock("../lib/firebase", () => ({ db: {} }));
+
+const store = new Map<string, Transaction>();
+
+function mockCollection(_db: unknown, name: string) {
+  return { name } as const;
+}
+
+function mockDoc(col: { name: string }, id: string) {
+  return { col: col.name, id };
+}
+
+function mockWriteBatch(_db: unknown) {
+  const ops: { ref: { id: string }; data: Transaction }[] = [];
+  return {
+    set(ref: { id: string }, data: Transaction) {
+      ops.push({ ref, data });
+    },
+    async commit() {
+      ops.forEach(({ ref, data }) => {
+        store.set(ref.id, data);
+      });
+    },
+  };
+}
+
+jest.mock("firebase/firestore", () => ({
+  collection: mockCollection,
+  doc: mockDoc,
+  writeBatch: mockWriteBatch,
+}));
+
+describe("saveTransactions integration", () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it("overwrites existing documents with the same id", async () => {
+    const tx: Transaction = {
+      id: "t1",
+      date: "2024-01-01",
+      description: "first",
+      amount: 100,
+      type: "Income",
+      category: "Misc",
+      currency: "USD",
+      isRecurring: false,
+    };
+
+    await saveTransactions([tx]);
+    const updated = { ...tx, description: "updated" };
+    await saveTransactions([updated]);
+
+    expect(store.size).toBe(1);
+    expect(store.get("t1")?.description).toBe("updated");
+  });
+});

--- a/src/__tests__/saveTransactions.test.ts
+++ b/src/__tests__/saveTransactions.test.ts
@@ -6,7 +6,7 @@ const mockSet = jest.fn();
 const mockCommit = jest.fn();
 const mockWriteBatch = jest.fn(() => ({ set: mockSet, commit: mockCommit }));
 const mockDoc = jest.fn(() => ({}));
-const mockCollection = jest.fn();
+const mockCollection = jest.fn(() => ({}));
 
 jest.mock("firebase/firestore", () => ({
   writeBatch: (...args: unknown[]) => mockWriteBatch(...args),
@@ -48,6 +48,8 @@ describe("saveTransactions", () => {
     expect(mockSet).toHaveBeenCalledTimes(transactions.length);
     expect(mockWriteBatch).toHaveBeenCalledTimes(1);
     expect(mockCommit).toHaveBeenCalledTimes(1);
+    expect(mockDoc).toHaveBeenNthCalledWith(1, expect.anything(), "1");
+    expect(mockDoc).toHaveBeenNthCalledWith(2, expect.anything(), "2");
   });
 
   it("splits transactions into multiple batches when over 500", async () => {

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -128,7 +128,7 @@ export async function saveTransactions(transactions: Transaction[]): Promise<voi
   for (const chunk of chunks) {
     const batch = writeBatch(db);
     chunk.forEach((tx) => {
-      const docRef = doc(colRef);
+      const docRef = doc(colRef, tx.id);
       batch.set(docRef, tx);
     });
 

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -46,7 +46,7 @@ export async function archiveOldTransactions(cutoffDate: string): Promise<void> 
 
     const batch = writeBatch(db);
     for (const snap of snapshot.docs) {
-      const data = snap.data() as Transaction;
+      const data = { id: snap.id, ...(snap.data() as Omit<Transaction, "id">) };
       batch.set(doc(db, "transactions_archive", snap.id), data);
       batch.delete(doc(db, "transactions", snap.id));
     }
@@ -154,7 +154,9 @@ export async function backupData(
       if (snap.empty) break;
 
       for (const d of snap.docs) {
-        items.push(d.data() as T);
+        const data = d.data() as T;
+        (data as any).id = d.id;
+        items.push(data);
       }
 
       lastDoc = snap.docs[snap.docs.length - 1];


### PR DESCRIPTION
## Summary
- save transactions using deterministic document IDs
- derive transaction IDs from document IDs when archiving and backing up
- add integration test verifying repeated saves overwrite existing transactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0fac3cf7c8331ad0dd526525b0d1a