### PR TITLE
Avoid writing existing categories

### DIFF
--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -29,4 +29,12 @@ describe("categoryService", () => {
     expect(getCategories()).toEqual(["Groceries"]);
     expect(deleteDoc).not.toHaveBeenCalled();
   });
+
+  it("does not write to Firestore when category already exists", () => {
+    addCategory("Groceries");
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    addCategory("groceries");
+    expect(getCategories()).toEqual(["Groceries"]);
+    expect(setDoc).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -95,10 +95,10 @@ export function addCategory(category: string): string[] {
   if (!exists) {
     categories.push(trimmed);
     save(categories);
+    void setDoc(doc(categoriesCollection, key), { name: trimmed }).catch(
+      console.error
+    );
   }
-  void setDoc(doc(categoriesCollection, key), { name: trimmed }).catch(
-    console.error
-  );
   return categories;
 }
 


### PR DESCRIPTION
## Summary
- Only write to Firestore when adding new categories
- Test that existing categories don't trigger a Firestore write

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0fac2ccb88331867c41e6f8034f28