### PR TITLE
refactor: use url-safe nonce generation

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,11 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const cspNonce = btoa(crypto.randomUUID())
+  const cspNonce = Buffer.from(crypto.randomUUID())
+    .toString('base64')
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- use Buffer to create a base64 nonce and make it URL safe for CSP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0fac0a8988331ae7e63ef4254a4d3