### PR TITLE
Validate request origin before setting CORS header

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,11 +34,19 @@ export function middleware(request: NextRequest) {
     'max-age=63072000; includeSubDomains; preload'
   )
 
-  if (process.env.NODE_ENV === 'development') {
-    response.headers.set(
-      'Access-Control-Allow-Origin',
-      'https://*-firebase-studio-*.cloudworkstations.dev, http://localhost:6006'
+  const origin = request.headers.get('origin')
+  const allowedOrigins = [
+    /^https:\/\/.*-firebase-studio-.*\.cloudworkstations\.dev$/,
+    'http://localhost:6006',
+  ]
+
+  if (
+    origin &&
+    allowedOrigins.some((allowed) =>
+      typeof allowed === 'string' ? allowed === origin : allowed.test(origin)
     )
+  ) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
   }
 
   return response


### PR DESCRIPTION
## Summary
- Inspect the request's `Origin` header and only set `Access-Control-Allow-Origin` when the value matches an allowed list

## Testing
- `npm test`
- `npm run lint` *(fails: unexpected any / unused vars across existing test files)*


------
https://chatgpt.com/codex/tasks/task_e_68b0fabf9dd88331add75349bc13053a