### PR TITLE
feat: add error handling for category feedback

### DIFF
--- a/src/lib/category-feedback.ts
+++ b/src/lib/category-feedback.ts
@@ -18,7 +18,7 @@ export async function recordCategoryFeedback(
       createdAt: serverTimestamp(),
     });
     return true;
-  } catch (error) {
+  } catch (error: unknown) {
     logger.error("Failed to record category feedback", error);
     return false;
   }


### PR DESCRIPTION
## Summary
- type catch error as unknown to satisfy lint

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, A `require()` style import is forbidden, etc.)*
- `npx eslint --no-ignore src/lib/category-feedback.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1223b00908331be25f4813e359aff