### PR TITLE
fix: sanitize suggested category names

### DIFF
--- a/src/__tests__/category-service.test.ts
+++ b/src/__tests__/category-service.test.ts
@@ -1,0 +1,32 @@
+jest.mock('firebase/firestore', () => ({
+  collection: () => ({ withConverter: () => ({}) }),
+  doc: () => ({ withConverter: () => ({}) }),
+  onSnapshot: (_ref: any, cb: any) => { cb({ docs: [] }); return () => {}; },
+  setDoc: jest.fn(() => Promise.resolve()),
+  deleteDoc: jest.fn(() => Promise.resolve()),
+  updateDoc: jest.fn(),
+  arrayUnion: jest.fn(),
+  arrayRemove: jest.fn(),
+  getDocs: jest.fn(async () => ({ forEach: () => {} })),
+  writeBatch: () => ({ delete: jest.fn(), commit: jest.fn() }),
+}));
+
+import { addCategory, getCategories, clearCategories, isValidCategoryName } from '@/lib/categoryService';
+
+describe('categoryService', () => {
+  beforeEach(() => {
+    clearCategories();
+  });
+
+  it('rejects invalid category names', () => {
+    addCategory('Food');
+    addCategory('bad/category');
+    addCategory('bad.name');
+    expect(getCategories()).toEqual(['Food']);
+  });
+
+  it('validates category names', () => {
+    expect(isValidCategoryName('Valid')).toBe(true);
+    expect(isValidCategoryName('invalid#name')).toBe(false);
+  });
+});

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -4,11 +4,12 @@ import type {
   SuggestDebtStrategyInput,
   SuggestDebtStrategyOutput,
 } from '@/ai/flows'
+import { isValidCategoryName } from '@/lib/categoryService'
 
 export async function suggestCategoryAction(description: string): Promise<string> {
   const { suggestCategory } = await import('@/ai/flows')
   const { category } = await suggestCategory({ description })
-  return category
+  return isValidCategoryName(category) ? category : 'Misc'
 }
 
 export async function suggestDebtStrategyAction(

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -17,7 +17,7 @@ const hasLocalStorage = () =>
 const normalize = (value: string) => value.trim().toLowerCase();
 
 const INVALID_KEY_CHARS = /[./#$\[\]]/;
-const isValidCategoryName = (value: string) =>
+export const isValidCategoryName = (value: string) =>
   value.trim().length > 0 && !INVALID_KEY_CHARS.test(value);
 
 function load(): string[] {


### PR DESCRIPTION
## Summary
- export category name validator
- sanitize category suggestions in server action
- test category service rejects invalid names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b125f732d4833194afdbad0db363cd