### PR TITLE
fix: validate category names

### DIFF
--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -1,0 +1,40 @@
+import { addCategory, getCategories, removeCategory, clearCategories } from "@/lib/categoryService";
+
+jest.mock("@/lib/firebase", () => ({ db: {}, categoriesCollection: {} }));
+
+const mockSetDoc = jest.fn().mockResolvedValue(undefined);
+const mockDeleteDoc = jest.fn().mockResolvedValue(undefined);
+const mockGetDocs = jest.fn().mockResolvedValue({ forEach: () => {} });
+const mockWriteBatch = jest.fn(() => ({ delete: jest.fn(), commit: jest.fn().mockResolvedValue(undefined) }));
+const mockDoc = jest.fn(() => ({}));
+
+jest.mock("firebase/firestore", () => ({
+  setDoc: (...args: unknown[]) => mockSetDoc(...args),
+  deleteDoc: (...args: unknown[]) => mockDeleteDoc(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  writeBatch: (...args: unknown[]) => mockWriteBatch(...args),
+  doc: (...args: unknown[]) => mockDoc(...args),
+}));
+
+describe("categoryService validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearCategories();
+  });
+
+  it("ignores invalid category names when adding", () => {
+    addCategory("");
+    addCategory("has/slash");
+    expect(getCategories()).toEqual([]);
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+
+  it("ignores invalid category names when removing", () => {
+    addCategory("Food");
+    removeCategory("");
+    removeCategory("bad/slash");
+    expect(getCategories()).toEqual(["Food"]);
+    expect(mockDeleteDoc).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure categories are non-empty and contain no slashes before writing to Firestore
- add tests verifying invalid category names are ignored

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1262809d08331bb85d45629185bd1