### PR TITLE
fix: dev CORS header and isolate category training in tests

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -40,10 +40,10 @@ const nextConfig: NextConfig = {
     ]
     
     if (process.env.NODE_ENV === 'development') {
-        securityHeaders.push({
-            key: 'Access-Control-Allow-Origin',
-            value: 'https://*-firebase-studio-*.cloudworkstations.dev, http://localhost:6006',
-        })
+      securityHeaders.push({
+        key: 'Access-Control-Allow-Origin',
+        value: '*',
+      })
     }
 
     return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextn",
       "version": "0.1.0",
       "dependencies": {
+        "@genkit-ai/googleai": "^1.17.1",
         "@genkit-ai/next": "^1.14.1",
         "@hookform/resolvers": "^4.1.3",
         "@radix-ui/react-accordion": "^1.2.3",
@@ -2152,6 +2153,20 @@
         "genkit": "^1.17.1"
       }
     },
+    "node_modules/@genkit-ai/googleai": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/googleai/-/googleai-1.17.1.tgz",
+      "integrity": "sha512-OQjPw5+z+OvknfWVDk8Mj7W7/zZJLPYyTPHjN9hiWnaVqFpcXF+QEY7fbfIW0kUS+4ealrAPlzM2/6XUSWw90w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google/generative-ai": "^0.24.0",
+        "google-auth-library": "^9.6.3",
+        "node-fetch": "^3.3.2"
+      },
+      "peerDependencies": {
+        "genkit": "^1.17.1"
+      }
+    },
     "node_modules/@genkit-ai/next": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@genkit-ai/next/-/next-1.17.1.tgz",
@@ -2506,6 +2521,15 @@
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@genkit-ai/googleai": "^1.17.1",
     "@genkit-ai/next": "^1.14.1",
     "@hookform/resolvers": "^4.1.3",
     "@radix-ui/react-accordion": "^1.2.3",

--- a/src/ai/train/category-model.ts
+++ b/src/ai/train/category-model.ts
@@ -81,13 +81,16 @@ export function classifyCategory(description: string): string | null {
   return classifier.predict(description);
 }
 
-// Initial training
-trainCategoryModel();
-// Retrain when new feedback is added
-onSnapshot(collection(db, "categoryFeedback"), () => {
+// Avoid side effects like Firestore access during tests
+if (process.env.NODE_ENV !== 'test') {
+  // Initial training
   trainCategoryModel();
-});
-// Periodic retraining as a safety net (every hour)
-setInterval(() => {
-  trainCategoryModel();
-}, 60 * 60 * 1000);
+  // Retrain when new feedback is added
+  onSnapshot(collection(db, "categoryFeedback"), () => {
+    trainCategoryModel();
+  });
+  // Periodic retraining as a safety net (every hour)
+  setInterval(() => {
+    trainCategoryModel();
+  }, 60 * 60 * 1000);
+}


### PR DESCRIPTION
## Summary
- use wildcard Access-Control-Allow-Origin header in dev mode
- skip category-model training when NODE_ENV is "test" and add missing googleai dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12672b9c08331af296da4bf194681