### PR TITLE
refactor: extract readBodyWithLimit helper

### DIFF
--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
 import { TransactionPayloadSchema } from "@/lib/transactions"
+import { readBodyWithLimit } from "@/lib/http"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -14,34 +15,6 @@ const bodySchema = z.object({
 })
 
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
-
-async function readBodyWithLimit(req: Request, limit: number) {
-  const contentLength = req.headers.get("content-length")
-  if (contentLength && Number(contentLength) > limit) {
-    return null
-  }
-
-  const reader = req.body?.getReader()
-  if (!reader) {
-    return ""
-  }
-  const decoder = new TextDecoder()
-  let total = 0
-  let result = ""
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    if (value) {
-      total += value.length
-      if (total > limit) {
-        return null
-      }
-      result += decoder.decode(value, { stream: true })
-    }
-  }
-  result += decoder.decode()
-  return result
-}
 
 export async function POST(req: Request) {
   try {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,27 @@
+export async function readBodyWithLimit(req: Request, limit: number) {
+  const contentLength = req.headers.get("content-length")
+  if (contentLength && Number(contentLength) > limit) {
+    return null
+  }
+
+  const reader = req.body?.getReader()
+  if (!reader) {
+    return ""
+  }
+  const decoder = new TextDecoder()
+  let total = 0
+  let result = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) {
+      total += value.length
+      if (total > limit) {
+        return null
+      }
+      result += decoder.decode(value, { stream: true })
+    }
+  }
+  result += decoder.decode()
+  return result
+}


### PR DESCRIPTION
## Summary
- move duplicated `readBodyWithLimit` helper to `src/lib/http.ts`
- use the shared helper in bank import and transaction sync routes

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in test files, requires existing fixes)*

------
https://chatgpt.com/codex/tasks/task_e_68b1287d50208331b011ee60154e389c