### PR TITLE
feat: support legacy media query listeners

### DIFF
--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -18,9 +18,17 @@ export function useIsMobile() {
     const onChange = (event: MediaQueryListEvent) => {
       setIsMobile(event.matches)
     }
-    mql.addEventListener("change", onChange)
+    const supportsEventListener = typeof mql.addEventListener === "function"
+    if (supportsEventListener) {
+      mql.addEventListener("change", onChange)
+    } else {
+      mql.addListener(onChange)
+    }
     setIsMobile(mql.matches)
-    return () => mql.removeEventListener("change", onChange)
+    return () =>
+      supportsEventListener
+        ? mql.removeEventListener("change", onChange)
+        : mql.removeListener(onChange)
   }, [])
 
   return isMobile


### PR DESCRIPTION
## Summary
- support legacy MediaQueryList listeners by falling back to `addListener`/`removeListener`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b12879e03c833184276d7ef9ba5d76