### PR TITLE
Document worker pool destruction rejection

### DIFF
--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -66,9 +66,11 @@ describe("WorkerPool", () => {
     const first = pool.run(1)
     const second = pool.run(2)
 
-    await pool.destroy()
+    const destroyPromise = pool.destroy()
 
     await expect(first).rejects.toThrow("Worker pool destroyed")
     await expect(second).rejects.toThrow("Worker pool destroyed")
+
+    await destroyPromise
   })
 })

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -105,9 +105,10 @@ export class WorkerPool<T = unknown, R = unknown> {
   /**
    * Shut down all workers and reject pending tasks.
    *
-   * Workers are terminated and the internal queues are cleared. Any tasks that
-   * have not yet started are rejected with an error so that callers waiting on
-   * their promises are notified the pool has been destroyed.
+   * Any work still waiting in the queue is rejected with a
+   * `Worker pool destroyed` error <em>before</em> the queue is cleared so that
+   * callers receive a rejection instead of hanging indefinitely. All workers
+   * are terminated and removed from the pool afterwards.
    */
   async destroy(): Promise<void> {
     this.destroyed = true
@@ -115,7 +116,7 @@ export class WorkerPool<T = unknown, R = unknown> {
     for (const task of this.queue) {
       task.reject(new Error("Worker pool destroyed"))
     }
-    this.queue = []
+    this.queue.length = 0
     this.idle.length = 0
   }
 }


### PR DESCRIPTION
## Summary
- Document that `destroy` rejects all queued tasks before clearing the queue
- Test that pending work is rejected when the pool is destroyed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1286ab7ec8331a30a78d82dae4c28