### PR TITLE
Avoid duplicate category writes

### DIFF
--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -37,4 +37,11 @@ describe("categoryService", () => {
     expect(getCategories()).toEqual(["Groceries"]);
     expect(setDoc).toHaveBeenCalledTimes(1);
   });
+
+  it("does not write to Firestore for duplicate category with same casing", () => {
+    addCategory("Utilities");
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    addCategory("Utilities");
+    expect(setDoc).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -94,11 +94,11 @@ export function addCategory(category: string): string[] {
   const exists = categories.some((c) => normalize(c) === key);
   if (!exists) {
     categories.push(trimmed);
-    save(categories);
     void setDoc(doc(categoriesCollection, key), { name: trimmed }).catch(
       console.error
     );
   }
+  save(categories);
   return categories;
 }
 


### PR DESCRIPTION
## Summary
- Only write categories to Firestore when they are new
- Test that duplicate categories do not trigger writes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b128677e9c8331865e561b2d8cf7f9