### PR TITLE
docs: clarify firebase env variable source

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,4 +1,4 @@
-// Environment variables are provided by Next.js at build time.
+// Environment variables are provided by Next.js (e.g., via .env.local) at build time.
 
 import {
   initializeApp,


### PR DESCRIPTION
## Summary
- clarify that Firebase env vars come from Next.js via `.env.local`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12866db108331ab20791af7383d04