### PR TITLE
Use crypto.randomBytes for URL-safe nonce in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,9 @@
+import { randomBytes } from 'crypto'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const cspNonce = Buffer.from(crypto.randomUUID())
-    .toString('base64')
-    .replace(/=+$/, '')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
+  const cspNonce = randomBytes(16).toString('base64url')
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- generate CSP nonce with `crypto.randomBytes` and encode using `base64url`

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing ESLint errors in tests)*
- `npx eslint src/middleware.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b12865653c83318c9cd506a7babe54