### PR TITLE
Use Web Crypto for URL-safe nonce in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,13 @@
-import { randomBytes } from 'crypto'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const cspNonce = randomBytes(16).toString('base64url')
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  const cspNonce = btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- replace Node `crypto.randomBytes` with Web Crypto `getRandomValues`
- manually encode nonce to base64url for CSP header

## Testing
- `npm test`
- `npx eslint src/middleware.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1697b1d2883318a9049b6799425b6