### PR TITLE
fix: use isomorphic layout effect for mobile hook

### DIFF
--- a/src/__tests__/use-mobile-ssr.test.tsx
+++ b/src/__tests__/use-mobile-ssr.test.tsx
@@ -1,0 +1,17 @@
+/** @jest-environment node */
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { useIsMobile } from "../hooks/use-mobile";
+
+describe("useIsMobile SSR", () => {
+  it("renders without warnings", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    function TestComponent() {
+      useIsMobile();
+      return null;
+    }
+    renderToString(React.createElement(TestComponent));
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/__tests__/use-mobile.test.tsx
+++ b/src/__tests__/use-mobile.test.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { render, screen, act } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
-import { useIsMobile, MOBILE_BREAKPOINT } from "../hooks/use-mobile";
 
 describe("useIsMobile", () => {
   let listeners: Array<() => void>;
+  let MOBILE_BREAKPOINT: number;
+  let useIsMobile: () => boolean;
 
   beforeEach(() => {
     listeners = [];
+    ({ useIsMobile, MOBILE_BREAKPOINT } = require("../hooks/use-mobile"));
     window.innerWidth = MOBILE_BREAKPOINT + 100;
     window.matchMedia = jest.fn().mockImplementation(() => ({
       matches: window.innerWidth < MOBILE_BREAKPOINT,
@@ -42,17 +44,4 @@ describe("useIsMobile", () => {
     expect(screen.getByText("mobile")).toBeInTheDocument();
   });
 
-  it("renders on the server without warnings", () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-
-    function TestComponent() {
-      useIsMobile();
-      return null;
-    }
-
-    renderToString(<TestComponent />);
-
-    expect(errorSpy).not.toHaveBeenCalled();
-    errorSpy.mockRestore();
-  });
 });

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,5 +1,8 @@
 import * as React from "react"
 
+const useIsoLayoutEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect
+
 /**
  * Screen width (in pixels) below which layout is considered mobile.
  * Exported for reuse to ensure consistent breakpoint behavior.
@@ -9,7 +12,7 @@ export const MOBILE_BREAKPOINT = 768
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState(false)
 
-  React.useEffect(() => {
+  useIsoLayoutEffect(() => {
     if (typeof window === "undefined") return
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {


### PR DESCRIPTION
## Summary
- run `useIsMobile` effect synchronously on the client via an isomorphic layout effect
- restructure tests and add an SSR-specific suite to ensure no warnings on the server

## Testing
- `npm test`
- `npx tsx -e "import React from 'react'; import { renderToString } from 'react-dom/server'; import { SidebarProvider } from './src/components/ui/sidebar'; renderToString(React.createElement(SidebarProvider, null, React.createElement('div')));" >/tmp/sidebar.log 2>&1 && tail -n 20 /tmp/sidebar.log`


------
https://chatgpt.com/codex/tasks/task_e_68b16e12c1b483319103eecfcbe7f649