### PR TITLE
Avoid reusing terminated workers in pool

### DIFF
--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -9,6 +9,7 @@ jest.mock("node:worker_threads", () => {
       postMessage(data: unknown) {
         if (data === "crash") {
           this.emit("error", new Error("boom"))
+          this.emit("exit", 1)
         } else {
           this.emit("message", (data as number) * 2)
         }

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -51,7 +51,7 @@ export class WorkerPool<T = unknown, R = unknown> {
         }
       }
 
-      const finalize = () => {
+      const finalizeSuccess = () => {
         worker.off("exit", handleExit)
         this.idle.push(worker)
         this.process()
@@ -60,13 +60,13 @@ export class WorkerPool<T = unknown, R = unknown> {
       worker.once("message", (result: R) => {
         settled = true
         task.resolve(result)
-        finalize()
+        finalizeSuccess()
       })
 
       worker.once("error", err => {
         settled = true
         task.reject(err)
-        finalize()
+        this.process()
       })
 
       worker.on("exit", handleExit)


### PR DESCRIPTION
## Summary
- keep exit listener until tasks complete and avoid returning errored workers to idle
- update worker pool test mock to emit exit after error

## Testing
- `npm test src/__tests__/parallel.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b16ebd08f8833180ee88a9c683091e