### PR TITLE
fix: align next pay day calculation with UTC

### DIFF
--- a/src/lib/payroll.ts
+++ b/src/lib/payroll.ts
@@ -60,18 +60,18 @@ export const getPayPeriodStart = (
 // Determine the next pay day for a biweekly schedule. If the provided date is
 // already the start of a pay period, that date is considered the pay day.
 export const getNextPayDay = (date: Date = new Date()): Date => {
-  const payDayStart = getPayPeriodStart(date)
-  const startOfDay = new Date(date)
-  startOfDay.setHours(0, 0, 0, 0)
+  const payDayStart = getPayPeriodStart(date);
+  const startOfDay = new Date(date);
+  startOfDay.setUTCHours(0, 0, 0, 0);
 
   if (payDayStart < startOfDay) {
-    const next = new Date(payDayStart)
-    next.setDate(payDayStart.getDate() + 14)
-    return next
+    const next = new Date(payDayStart);
+    next.setUTCDate(payDayStart.getUTCDate() + 14);
+    return next;
   }
 
-  return payDayStart
-}
+  return payDayStart;
+};
 
 export const calculateOvertimeDates = (shifts: Shift[]): Date[] => {
   const weeklyShifts: Record<string, Shift[]> = {};


### PR DESCRIPTION
## Summary
- normalize `getNextPayDay` comparisons to UTC
- add UTC-based date arithmetic for next pay period

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and related lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b169ed29e08331b78ac4e965e01353