### PR TITLE
Validate cutoff date in housekeeping service

### DIFF
--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -20,11 +20,14 @@ import { getCurrentTime } from "../lib/internet-time";
  * and removes them from the main transactions collection.
  */
 export async function archiveOldTransactions(cutoffDate: string): Promise<void> {
-  const parsed = new Date(cutoffDate);
-  if (isNaN(parsed.getTime())) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(cutoffDate)) {
     throw new Error(`Invalid cutoff date: ${cutoffDate}`);
   }
-  const cutoff = parsed.toISOString().slice(0, 10);
+  const parsed = new Date(cutoffDate);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== cutoffDate) {
+    throw new Error(`Invalid cutoff date: ${cutoffDate}`);
+  }
+  const cutoff = cutoffDate;
   const transCol = collection(db, "transactions");
   const pageSize = 100;
   let lastDoc: QueryDocumentSnapshot<unknown> | undefined;


### PR DESCRIPTION
## Summary
- enforce strict YYYY-MM-DD format when parsing archive cutoff dates and reject mismatches

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / other lint errors in many test files)*
- `npx eslint src/services/housekeeping.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1bc723f9483318e8278f86ca751ff