### PR TITLE
fix: allow CSV import of new categories

### DIFF
--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -56,12 +56,12 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
         let active = true
         const fetchSuggestion = async () => {
             try {
-                const { suggestCategory } = await import("@/ai/flows/suggest-category")
-                const res = await suggestCategory({ description })
+                const { suggestCategoryAction } = await import("@/app/actions")
+                const res = await suggestCategoryAction(description)
                 if (active) {
-                    setSuggestedCategory(res.category)
+                    setSuggestedCategory(res)
                     if (!userModifiedCategory.current) {
-                        setCategory(res.category)
+                        setCategory(res)
                     }
                 }
             } catch (error) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,8 @@
-import { randomBytes } from 'crypto'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const cspNonce = randomBytes(16).toString('base64url')
+  const cspNonce = crypto.randomUUID()
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- resolve merge conflicts with `main`
- keep wildcard CORS header for dev
- validate CSV imports with existing and incoming categories
- generate CSP nonce with Web Crypto API
- fetch category suggestions via server action

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bf6289488331b4e76baf002bdca4