### PR TITLE
fix: route category suggestions via server action and use web crypto nonce

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,8 +1,7 @@
 'use server'
 
-import { suggestCategory } from '@/ai/flows'
-
 export async function suggestCategoryAction(description: string): Promise<string> {
+  const { suggestCategory } = await import('@/ai/flows')
   const { category } = await suggestCategory({ description })
   return category
 }

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -26,6 +26,7 @@ import type { Transaction } from "@/lib/types"
 import { useToast } from "@/hooks/use-toast"
 import { recordCategoryFeedback } from "@/lib/category-feedback"
 import { logger } from "@/lib/logger"
+import { suggestCategoryAction } from "@/app/actions"
 
 interface AddTransactionDialogProps {
   onSave: (transaction: Omit<Transaction, 'id' | 'date'>) => void;
@@ -56,12 +57,11 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
         let active = true
         const fetchSuggestion = async () => {
             try {
-                const { suggestCategory } = await import("@/ai/flows/suggest-category")
-                const res = await suggestCategory({ description })
+                const category = await suggestCategoryAction(description)
                 if (active) {
-                    setSuggestedCategory(res.category)
+                    setSuggestedCategory(category)
                     if (!userModifiedCategory.current) {
-                        setCategory(res.category)
+                        setCategory(category)
                     }
                 }
             } catch (error) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,15 @@
-import { randomBytes } from 'crypto'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+function generateNonce() {
+  const bytes = crypto.getRandomValues(new Uint8Array(16))
+  let binary = ''
+  bytes.forEach((b) => (binary += String.fromCharCode(b)))
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
 export function middleware(request: NextRequest) {
-  const cspNonce = randomBytes(16).toString('base64url')
+  const cspNonce = generateNonce()
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- call server-side `suggestCategoryAction` to fetch category suggestions without bundling server-only modules
- replace Node `crypto` with Web Crypto API when generating CSP nonces in edge middleware

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bf6271ac833199b7c623a0cf947c