### PR TITLE
fix: guard category suggestion errors

### DIFF
--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -25,7 +25,6 @@ import { PlusCircle } from "lucide-react"
 import type { Transaction } from "@/lib/types"
 import { useToast } from "@/hooks/use-toast"
 import { recordCategoryFeedback } from "@/lib/category-feedback"
-import { logger } from "@/lib/logger"
 
 interface AddTransactionDialogProps {
   onSave: (transaction: Omit<Transaction, 'id' | 'date'>) => void;
@@ -65,7 +64,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
                     }
                 }
             } catch (error) {
-                logger.error("Failed to suggest category", error)
+                console.error("Failed to suggest category", error)
                 toast({
                     title: "Failed to suggest category",
                     description: "Could not fetch category suggestion.",


### PR DESCRIPTION
## Summary
- use console.error to report category suggestion failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bf4eb6d88331bf85e76e19dbb91b