### PR TITLE
Fix Firestore category validation: resolve merge conflicts with main

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,6 @@
-
 import type { NextConfig } from 'next'
 import crypto from 'crypto'
+
 const nextConfig: NextConfig = {
   // Enforce type checking and linting during builds
   typescript: { ignoreBuildErrors: false },

--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -58,4 +58,3 @@ describe("categoryService", () => {
     expect(setDoc).toHaveBeenCalledTimes(1);
   });
 });
-


### PR DESCRIPTION
## Summary
- restore CSP-generating `headers` configuration in `next.config.ts`
- keep expanded category service tests for empty names and invalid removals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bff986b88331b5656200b939c0c2