### PR TITLE
feat: allow configurable dev port

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This is a NextJS starter in Firebase Studio.
 To get started, take a look at src/app/page.tsx.
 
 ## Development
+- `npm run dev` – start the development server.
+- On Cloud Workstations, run `PORT=6000 npm run dev` to match the reserved domain.
 - `npm run lint` – run ESLint for code quality.
 - `npm test` – run unit tests with Jest.
 - `node scripts/update-cost-of-living.ts` – refresh cost of living dataset from BEA.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p ${PORT:-3000}",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Summary
- allow `npm run dev` to respect the `PORT` env var
- document Cloud Workstations usage on port 6000

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*
- `PORT=6000 npm run dev` *(fails: Bad port "6000" is reserved for x11)*

------
https://chatgpt.com/codex/tasks/task_e_68b23946a33483319c90c40985c59dd4