### PR TITLE
Remove dev origin override and document proxy-based CORS

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,12 +2,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const bytes = new Uint8Array(16)
-  crypto.getRandomValues(bytes)
-  const cspNonce = btoa(String.fromCharCode(...bytes))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '')
+  const cspNonce = crypto.randomUUID()
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- replace Node crypto import with Web Crypto API in middleware to ensure edge runtime compatibility

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc. in tests)*
- `NEXT_PUBLIC_FIREBASE_API_KEY=a NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=a NEXT_PUBLIC_FIREBASE_PROJECT_ID=a NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=a NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=a NEXT_PUBLIC_FIREBASE_APP_ID=a npx next build --no-lint` *(fails: Type error in @types/request*)


------
https://chatgpt.com/codex/tasks/task_e_68b23b8b37cc8331b4e9dbf95ebbd353