### PR TITLE
fix: ensure category writes sync offline and compare pay days in UTC

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,6 @@
+
 import type { NextConfig } from 'next'
 import crypto from 'crypto'
-
 const nextConfig: NextConfig = {
   // Enforce type checking and linting during builds
   typescript: { ignoreBuildErrors: false },

--- a/scripts/update-cost-of-living.ts
+++ b/scripts/update-cost-of-living.ts
@@ -25,7 +25,7 @@ async function main() {
   const dryRun = process.argv.includes('--dry-run')
   const rows = await fetchRpp(year, apiKey)
   const regions = rows.reduce((acc, row) => {
-    const index = Number(row.DataValue.replace(/,/g, '')) / 100
+    const index = Number(row.DataValue.replace(/,/g, '')) / 100 // convert index to multiplier
     acc[row.GeoName] = {
       housing: index * 20000,
       groceries: index * 5000,
@@ -59,4 +59,3 @@ main().catch((err) => {
   console.error(err)
   process.exit(1)
 })
-

--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -49,19 +49,18 @@ describe("categoryService validation", () => {
     expect(mockDeleteDoc).not.toHaveBeenCalled()
   })
 
-  it("does not write to Firestore when category already exists case-insensitively", () => {
+  it("writes to Firestore even when category exists case-insensitively", () => {
     addCategory("Groceries")
     expect(mockSetDoc).toHaveBeenCalledTimes(1)
     addCategory("groceries")
     expect(getCategories()).toEqual(["Groceries"])
-    expect(mockSetDoc).toHaveBeenCalledTimes(1)
+    expect(mockSetDoc).toHaveBeenCalledTimes(2)
   })
 
-  it("does not write to Firestore for duplicate category with same casing", () => {
+  it("writes to Firestore for duplicate category with same casing", () => {
     addCategory("Utilities")
     expect(mockSetDoc).toHaveBeenCalledTimes(1)
     addCategory("Utilities")
-    expect(mockSetDoc).toHaveBeenCalledTimes(1)
+    expect(mockSetDoc).toHaveBeenCalledTimes(2)
   })
 })
-

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -233,4 +233,3 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
     </Dialog>
   )
 }
-

--- a/src/lib/category-feedback.ts
+++ b/src/lib/category-feedback.ts
@@ -24,4 +24,3 @@ export async function recordCategoryFeedback(
     return false
   }
 }
-

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -1,7 +1,3 @@
-// Utility functions for managing transaction categories stored in Firestore
-// with a local cache for offline support. Categories are compared in a
-// case-insensitive manner while preserving their original casing for display.
-
 import { doc, getDocs, setDoc, deleteDoc, writeBatch } from "firebase/firestore"
 import { db, categoriesCollection } from "./firebase"
 
@@ -94,10 +90,10 @@ export function addCategory(category: string): string[] {
   const exists = categories.some((c) => normalize(c) === key)
   if (!exists) {
     categories.push(trimmed)
-    void setDoc(doc(categoriesCollection, key), { name: trimmed }).catch(
-      console.error,
-    )
   }
+  void setDoc(doc(categoriesCollection, key), { name: trimmed }).catch(
+    console.error,
+  )
   save(categories)
   return categories
 }
@@ -132,4 +128,3 @@ export function clearCategories() {
     }
   })()
 }
-

--- a/src/lib/payroll.ts
+++ b/src/lib/payroll.ts
@@ -50,7 +50,6 @@ export const getPayPeriodStart = (
   const parity = Math.abs(diffWeeks) % 2;
 
   if (parity !== 0) {
-    // It's in the second week of a pay period, so the start was the *previous* Sunday
     d.setUTCDate(d.getUTCDate() - 7);
   }
 
@@ -60,18 +59,19 @@ export const getPayPeriodStart = (
 // Determine the next pay day for a biweekly schedule. If the provided date is
 // already the start of a pay period, that date is considered the pay day.
 export const getNextPayDay = (date: Date = new Date()): Date => {
-  const payDayStart = getPayPeriodStart(date)
-  const startOfDay = new Date(date)
-  startOfDay.setHours(0, 0, 0, 0)
+  const payDayStart = getPayPeriodStart(date);
+  const startOfDay = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
 
   if (payDayStart < startOfDay) {
-    const next = new Date(payDayStart)
-    next.setDate(payDayStart.getDate() + 14)
-    return next
+    const next = new Date(payDayStart);
+    next.setUTCDate(payDayStart.getUTCDate() + 14);
+    return next;
   }
 
-  return payDayStart
-}
+  return payDayStart;
+};
 
 export const calculateOvertimeDates = (shifts: Shift[]): Date[] => {
   const weeklyShifts: Record<string, Shift[]> = {};
@@ -182,4 +182,3 @@ export const getShiftsInPayPeriod = (
     .filter(shift => shift.date >= payPeriod.from && shift.date <= payPeriod.to)
     .sort((a, b) => a.date.getTime() - b.date.getTime());
 };
-


### PR DESCRIPTION
## Summary
- resolve merge conflicts
- always attempt Firestore category write so offline additions sync
- compare next pay day dates in UTC to avoid skipping current period

## Testing
- `npm test --silent 2>&1 | tail -n 7`


------
https://chatgpt.com/codex/tasks/task_e_68b23bb7a5c48331b4934fa563eeaeb4