### PR TITLE
fix nonce headers in root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,12 +15,13 @@ export const metadata: Metadata = {
   description: 'Financial management for nursing professionals.',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const nonce = headers().get('x-nonce') || undefined
+  const nonceHeader = await headers();
+  const nonce = nonceHeader.get('x-nonce') || undefined
 
   return (
     <html lang="en" suppressHydrationWarning>


### PR DESCRIPTION
## Summary
- await nonce headers in RootLayout to satisfy Next.js headers API

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / require import errors)*
- `NEXT_PUBLIC_FIREBASE_API_KEY=1 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=1 NEXT_PUBLIC_FIREBASE_PROJECT_ID=1 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=1 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1 NEXT_PUBLIC_FIREBASE_APP_ID=1 npm run dev & curl -I http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_68b23fc1aed08331954331756c2985b0