### PR TITLE
fix: generate base64 CSP nonce in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,9 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const cspNonce = crypto.randomUUID()
+  const cspNonce = btoa(
+    String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16)))
+  )
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- generate CSP nonce with base64 to satisfy CSP grammar

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc. in tests)*
- `NEXT_PUBLIC_FIREBASE_API_KEY=a NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=a NEXT_PUBLIC_FIREBASE_PROJECT_ID=a NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=a NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=a NEXT_PUBLIC_FIREBASE_APP_ID=a npx next build --no-lint` *(fails: Module not found: Can't resolve '@genkit-ai/googleai')*


------
https://chatgpt.com/codex/tasks/task_e_68b240eb13d083318b145108a13131d7