### PR TITLE
fix: handle pay day comparison across UTC boundary

### DIFF
--- a/src/__tests__/payroll.test.ts
+++ b/src/__tests__/payroll.test.ts
@@ -2,6 +2,7 @@ import {
   getPayPeriodStart,
   calculateOvertimeDates,
   calculatePayPeriodSummary,
+  getNextPayDay,
   type Shift,
 } from '../lib/payroll';
 import type { DateRange } from 'react-day-picker';
@@ -67,6 +68,18 @@ describe('payroll utilities', () => {
       overtimeHours: 10,
       totalHours: 90,
     });
+  });
+
+  test('getNextPayDay returns next period after the pay day ends', () => {
+    const date = new Date('2024-01-08T00:00:00Z');
+    const next = getNextPayDay(date);
+    expect(next.toISOString().slice(0, 10)).toBe('2024-01-21');
+  });
+
+  test('getNextPayDay keeps the current pay day within 24 hours of start', () => {
+    const date = new Date('2024-01-07T12:00:00Z');
+    const current = getNextPayDay(date);
+    expect(current.toISOString().slice(0, 10)).toBe('2024-01-07');
   });
 });
 

--- a/src/lib/payroll.ts
+++ b/src/lib/payroll.ts
@@ -61,10 +61,10 @@ export const getPayPeriodStart = (
 // already the start of a pay period, that date is considered the pay day.
 export const getNextPayDay = (date: Date = new Date()): Date => {
   const payDayStart = getPayPeriodStart(date);
-  const startOfDay = new Date(date);
-  startOfDay.setUTCHours(0, 0, 0, 0);
+  const payDayEnd = new Date(payDayStart);
+  payDayEnd.setUTCDate(payDayEnd.getUTCDate() + 1);
 
-  if (payDayStart < startOfDay) {
+  if (date >= payDayEnd) {
     const next = new Date(payDayStart);
     next.setUTCDate(payDayStart.getUTCDate() + 14);
     return next;


### PR DESCRIPTION
## Summary
- compare current date directly against end of pay day instead of truncating in UTC
- add tests for next pay day calculation

## Testing
- `npm test --silent 2>&1 | tail -n 7`


------
https://chatgpt.com/codex/tasks/task_e_68b240daca7483318e1410627b12114e