### PR TITLE
fix: streamline nonce handling in root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,8 +20,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const nonceHeader = await headers();
-  const nonce = nonceHeader.get('x-nonce') || undefined;
+  const nonce = (await headers()).get('x-nonce') || undefined;
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,12 +2,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const bytes = new Uint8Array(16)
-  crypto.getRandomValues(bytes)
-  const cspNonce = btoa(String.fromCharCode(...bytes))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '')
+  const cspNonce = crypto.randomUUID()
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- streamline nonce retrieval in root layout by awaiting `headers()` once
- sync middleware nonce generation with `crypto.randomUUID`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-unused-vars and related ESLint errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b2437509348331b454e83302892df2