### PR TITLE
codex: dedupe cost-of-living export and add category model initializer

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -39,9 +39,3 @@ export type {
 
 export { predictSpending } from './spendingForecast';
 export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
-
-export { calculateCostOfLiving } from './cost-of-living';
-export type {
-  CalculateCostOfLivingInput,
-  CostOfLivingBreakdown,
-} from './cost-of-living';


### PR DESCRIPTION
## Summary
- remove duplicate cost-of-living export from AI flow barrel file
- gate category model training behind explicit init/teardown

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b243f03934833183c1abe92fc0c02b