### PR TITLE
fix: call category suggestion via server action

### DIFF
--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -27,6 +27,7 @@ import { useToast } from "@/hooks/use-toast"
 import { addCategory, getCategories } from "@/lib/categoryService"
 import { recordCategoryFeedback } from "@/lib/category-feedback"
 import { logger } from "@/lib/logger"
+import { suggestCategoryAction } from "@/app/actions"
 
 interface AddTransactionDialogProps {
   onSave: (transaction: Omit<Transaction, "id" | "date">) => void
@@ -65,14 +66,13 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
     let active = true
     const fetchSuggestion = async () => {
       try {
-        const { suggestCategory } = await import("@/ai/flows/suggest-category")
-        const res = await suggestCategory({ description })
+        const categorySuggestion = await suggestCategoryAction(description)
         if (active) {
-          setSuggestedCategory(res.category)
+          setSuggestedCategory(categorySuggestion)
           if (!userModifiedCategory.current) {
-            setCategory(res.category)
+            setCategory(categorySuggestion)
           }
-          setCategories(addCategory(res.category))
+          setCategories(addCategory(categorySuggestion))
         }
       } catch (error) {
         logger.error("Failed to suggest category", error)


### PR DESCRIPTION
## Summary
- avoid server-only category imports in add transaction dialog
- use suggestCategoryAction to provide suggestions

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2443cd6a8833197d6744e866dfe04