### PR TITLE
fix: compare pay periods consistently

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,12 +15,13 @@ export const metadata: Metadata = {
   description: 'Financial management for nursing professionals.',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const nonce = headers().get('x-nonce') || undefined
+  const nonceHeader = await headers();
+  const nonce = nonceHeader.get('x-nonce') || undefined
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -2,13 +2,7 @@
 // with a local cache for offline support. Categories are compared in a
 // case-insensitive manner while preserving their original casing for display.
 
-import {
-  doc,
-  getDocs,
-  setDoc,
-  deleteDoc,
-  writeBatch,
-} from "firebase/firestore";
+import { doc, getDocs, setDoc, deleteDoc, writeBatch } from "firebase/firestore";
 import { db, categoriesCollection } from "./firebase";
 
 const STORAGE_KEY = "categories";

--- a/src/lib/payroll.ts
+++ b/src/lib/payroll.ts
@@ -32,7 +32,7 @@ export interface PayPeriodSummary {
  */
 export const getPayPeriodStart = (
   date: Date,
-  anchor: Date = new Date(Date.UTC(2024, 0, 7)),
+  anchor: Date = new Date(Date.UTC(2024, 0, 7))
 ): Date => {
   const d = new Date(
     Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,12 +2,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const bytes = new Uint8Array(16)
-  crypto.getRandomValues(bytes)
-  const cspNonce = btoa(String.fromCharCode(...bytes))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '')
+  const cspNonce = crypto.randomUUID()
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- merge latest main and resolve conflicts
- keep pay period calculations in UTC and always sync categories to Firestore
- await nonce headers and simplify CSP nonce generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b244701a4883318179836ff3f60303