### PR TITLE
refactor: harden test typings

### DIFF
--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import React from 'react';
+import React, { ReactNode, InputHTMLAttributes } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { AddTransactionDialog } from '@/components/transactions/add-transaction-dialog';
 
@@ -11,24 +11,33 @@ jest.mock('@/hooks/use-toast', () => ({
 }));
 jest.mock('lucide-react', () => ({ PlusCircle: () => null }));
 jest.mock('@/components/ui/dialog', () => ({
-  Dialog: ({ children }: any) => <div>{children}</div>,
-  DialogTrigger: ({ children }: any) => <div>{children}</div>,
-  DialogContent: ({ children }: any) => <div>{children}</div>,
-  DialogDescription: ({ children }: any) => <div>{children}</div>,
-  DialogFooter: ({ children }: any) => <div>{children}</div>,
-  DialogHeader: ({ children }: any) => <div>{children}</div>,
-  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 jest.mock('@/components/ui/select', () => ({
-  Select: ({ children }: any) => <div>{children}</div>,
-  SelectContent: ({ children }: any) => <div>{children}</div>,
-  SelectItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-  SelectTrigger: ({ children }: any) => <div>{children}</div>,
-  SelectValue: ({ children }: any) => <div>{children}</div>,
+  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children, ...props }: { children: ReactNode } & Record<string, unknown>) => (
+    <div {...props}>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 jest.mock('@/components/ui/switch', () => ({
-  Switch: ({ onCheckedChange, ...props }: any) => (
-    <input type="checkbox" onChange={onCheckedChange} {...props} />
+  Switch: (
+    { onCheckedChange, ...props }: { onCheckedChange: (checked: boolean) => void } &
+      InputHTMLAttributes<HTMLInputElement>
+  ) => (
+    <input
+      type="checkbox"
+      onChange={(e) => onCheckedChange(e.target.checked)}
+      {...props}
+    />
   ),
 }));
 

--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../components/auth/auth-provider';
+import { auth as authStub } from '@/lib/firebase';
 
 let mockPathname = '/';
 const pushMock = jest.fn();
@@ -18,16 +19,20 @@ jest.mock('@/lib/firebase', () => ({
     app: { options: { apiKey: 'test' }, name: '[DEFAULT]' },
   },
 }));
-const { auth: authStub } = require('@/lib/firebase');
 
-let mockUser: any = null;
-const onAuthStateChanged = jest.fn((_auth: unknown, cb: (u: any) => void) => {
-  cb(mockUser);
-  return () => {};
-});
+type MockUser = { uid: string } | null;
+let mockUser: MockUser = null;
+const onAuthStateChanged = jest.fn(
+  (_auth: unknown, cb: (u: MockUser) => void) => {
+    cb(mockUser);
+    return () => {};
+  }
+);
 
 jest.mock('firebase/auth', () => ({
-  onAuthStateChanged: (...args: any[]) => (onAuthStateChanged as any)(...args),
+  onAuthStateChanged: (
+    ...args: Parameters<typeof onAuthStateChanged>
+  ) => onAuthStateChanged(...args),
 }));
 
 function DisplayUser() {
@@ -45,7 +50,7 @@ beforeEach(() => {
 
 test('redirects to dashboard when authenticated on "/" and updates context', async () => {
   mockPathname = '/';
-  mockUser = { uid: 'abc' } as any;
+  mockUser = { uid: 'abc' };
 
   render(
     <AuthProvider>

--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -10,7 +10,7 @@ describe('currency code validation', () => {
       ok: true,
       json: async () => ({ rates: { EUR: 0.85 } }),
     });
-    (global as any).fetch = mockFetch;
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
 
     const rate = await getFxRate('usd', 'eur');
 
@@ -23,7 +23,7 @@ describe('currency code validation', () => {
 
   it('getFxRate throws on invalid code', async () => {
     const mockFetch = jest.fn();
-    (global as any).fetch = mockFetch;
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
 
     await expect(getFxRate('US', 'EUR')).rejects.toThrow('Invalid currency code');
     expect(mockFetch).not.toHaveBeenCalled();
@@ -34,7 +34,7 @@ describe('currency code validation', () => {
       ok: true,
       json: async () => ({ rates: { EUR: 0.5 } }),
     });
-    (global as any).fetch = mockFetch;
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
 
     const converted = await convertCurrency(10, 'usd', 'eur');
 
@@ -43,7 +43,7 @@ describe('currency code validation', () => {
 
   it('convertCurrency returns original amount for invalid codes', async () => {
     const mockFetch = jest.fn();
-    (global as any).fetch = mockFetch;
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
 
     const converted = await convertCurrency(10, 'u$', 'eur');
 

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -18,32 +18,45 @@ jest.mock("@/lib/firebase", () => ({ db: {} }));
 jest.mock("firebase/firestore", () => {
   const store: { lastRun?: number } = {};
   return {
-    doc: (_db: any, _col: string, _id: string) => ({}),
-    runTransaction: jest.fn(async (_db: any, updateFn: any) => {
-      while (true) {
-        let write: any;
-        const lastBefore = store.lastRun;
-        const tx = {
-          get: async () => ({
-            exists: () => store.lastRun !== undefined,
-            data: () => ({ lastRun: store.lastRun }),
-          }),
-          set: (_ref: any, data: any) => {
-            write = data;
-          },
-        };
-        const result = await updateFn(tx);
-        if (write && lastBefore !== store.lastRun) {
-          // retry due to concurrent modification
-          continue;
+    doc: () => ({}),
+    runTransaction: jest.fn(
+      async (
+        _db: unknown,
+        updateFn: (
+          tx: {
+            get: () => Promise<{
+              exists: () => boolean;
+              data: () => { lastRun: number | undefined };
+            }>;
+            set: (_ref: unknown, data: { lastRun: number }) => void;
+          }
+        ) => Promise<unknown>
+      ) => {
+        for (;;) {
+          let write: { lastRun: number } | undefined;
+          const lastBefore = store.lastRun;
+          const tx = {
+            get: async () => ({
+              exists: () => store.lastRun !== undefined,
+              data: () => ({ lastRun: store.lastRun }),
+            }),
+            set: (_ref: unknown, data: { lastRun: number }) => {
+              write = data;
+            },
+          };
+          const result = await updateFn(tx);
+          if (write && lastBefore !== store.lastRun) {
+            // retry due to concurrent modification
+            continue;
+          }
+          if (write) {
+            store.lastRun = write.lastRun;
+          }
+          return result;
         }
-        if (write) {
-          store.lastRun = write.lastRun;
-        }
-        return result;
       }
-    }),
-    setDoc: jest.fn(async (_ref: any, data: any) => {
+    ),
+    setDoc: jest.fn(async (_ref: unknown, data: { lastRun: number }) => {
       store.lastRun = data.lastRun;
     }),
     __store: store,

--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -5,7 +5,7 @@ process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'test';
 process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'test';
 process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'test';
 
-const dataStore: Record<string, Map<string, any>> = {
+const dataStore: Record<string, Map<string, Record<string, unknown>>> = {
   transactions: new Map(),
   transactions_archive: new Map(),
   debts: new Map(),
@@ -28,34 +28,41 @@ jest.mock('../lib/internet-time', () => ({
 }));
 
 jest.mock('firebase/firestore', () => {
-  const where = (field: string, op: string, value: any) => ({
+  type Constraint = { type: string; [key: string]: unknown };
+  const where = (field: string, op: string, value: unknown): Constraint => ({
     type: 'where',
     field,
     op,
     value,
   });
-  const orderBy = (field: string) => ({ type: 'orderBy', field });
-  const limit = (n: number) => ({ type: 'limit', n });
-  const startAfter = (doc: any) => ({ type: 'startAfter', doc });
-  const query = (colRef: any, ...constraints: any[]) => ({ ...colRef, constraints });
+  const orderBy = (field: string): Constraint => ({ type: 'orderBy', field });
+  const limit = (n: number): Constraint => ({ type: 'limit', n });
+  const startAfter = (doc: { data: () => Record<string, unknown> }): Constraint => ({
+    type: 'startAfter',
+    doc,
+  });
+  const query = (colRef: { name: string }, ...constraints: Constraint[]) => ({
+    ...colRef,
+    constraints,
+  });
 
-  const getDocs = jest.fn(async (q: any) => {
+  const getDocs = jest.fn(async (q: { name: string; constraints?: Constraint[] }) => {
     const colName = q.name;
     let docs = Array.from(dataStore[colName].entries()).map(([id, data]) => ({
       id,
       data: () => data,
     }));
 
-    const constraints = q.constraints || [];
+    const constraints = q.constraints ?? [];
     for (const c of constraints) {
       if (c.type === 'where') {
         docs = docs.filter((d) => {
-          const val = d.data()[c.field];
+          const val = d.data()[c.field as string];
           switch (c.op) {
             case '<':
-              return val < c.value;
+              return (val as number) < c.value!;
             case '<=':
-              return val <= c.value;
+              return (val as number) <= c.value!;
             default:
               return true;
           }
@@ -63,24 +70,32 @@ jest.mock('firebase/firestore', () => {
       }
     }
 
-    const order = constraints.find((c: any) => c.type === 'orderBy');
+    const order = constraints.find((c) => c.type === 'orderBy') as
+      | { type: 'orderBy'; field: string }
+      | undefined;
     if (order) {
       docs.sort((a, b) => {
-        const av = a.data()[order.field];
-        const bv = b.data()[order.field];
+        const av = a.data()[order.field] as number | string;
+        const bv = b.data()[order.field] as number | string;
         if (av > bv) return 1;
         if (av < bv) return -1;
         return 0;
       });
     }
 
-    const start = constraints.find((c: any) => c.type === 'startAfter');
+    const start = constraints.find((c) => c.type === 'startAfter') as
+      | { type: 'startAfter'; doc: { data: () => Record<string, unknown> } }
+      | undefined;
     if (start && order) {
-      const startVal = start.doc.data()[order.field];
-      docs = docs.filter((d) => d.data()[order.field] > startVal);
+      const startVal = start.doc.data()[order.field] as number | string;
+      docs = docs.filter(
+        (d) => (d.data()[order.field] as number | string) > startVal
+      );
     }
 
-    const lim = constraints.find((c: any) => c.type === 'limit');
+    const lim = constraints.find((c) => c.type === 'limit') as
+      | { type: 'limit'; n: number }
+      | undefined;
     if (lim) {
       docs = docs.slice(0, lim.n);
     }
@@ -89,18 +104,22 @@ jest.mock('firebase/firestore', () => {
   });
 
   const writeBatch = jest.fn(() => {
-    const ops: any[] = [];
+    const ops: Array<{
+      type: 'set' | 'delete';
+      docRef: { name: string; id: string };
+      data?: Record<string, unknown>;
+    }> = [];
     const batch = {
-      set: (docRef: any, data: any) => {
+      set: (docRef: { name: string; id: string }, data: Record<string, unknown>) => {
         ops.push({ type: 'set', docRef, data });
       },
-      delete: (docRef: any) => {
+      delete: (docRef: { name: string; id: string }) => {
         ops.push({ type: 'delete', docRef });
       },
       commit: jest.fn(async () => {
         for (const op of ops) {
           if (op.type === 'set') {
-            dataStore[op.docRef.name].set(op.docRef.id, op.data);
+            dataStore[op.docRef.name].set(op.docRef.id, op.data ?? {});
           } else if (op.type === 'delete') {
             dataStore[op.docRef.name].delete(op.docRef.id);
           }
@@ -111,7 +130,7 @@ jest.mock('firebase/firestore', () => {
     return batch;
   });
 
-  const addDoc = jest.fn(async (colRef: any, data: any) => {
+  const addDoc = jest.fn(async (colRef: { name: string }, data: Record<string, unknown>) => {
     const id = Math.random().toString(36).slice(2);
     dataStore[colRef.name].set(id, data);
     return { id };
@@ -119,8 +138,8 @@ jest.mock('firebase/firestore', () => {
 
   return {
     getFirestore: jest.fn(() => ({})),
-    collection: (_db: any, name: string) => ({ name }),
-    doc: (_db: any, name: string, id: string) => ({ name, id }),
+    collection: (_: unknown, name: string) => ({ name }),
+    doc: (_: unknown, name: string, id: string) => ({ name, id }),
     getDocs,
     addDoc,
     query,
@@ -133,9 +152,19 @@ jest.mock('firebase/firestore', () => {
   };
 });
 
-const { archiveOldTransactions, cleanupDebts, backupData, runWithRetry } = require('../services/housekeeping');
-const firestore = require('firebase/firestore');
-const store = firestore.__dataStore as typeof dataStore;
+import {
+  archiveOldTransactions,
+  cleanupDebts,
+  backupData,
+  runWithRetry,
+} from '../services/housekeeping';
+import * as firestoreRaw from 'firebase/firestore';
+const firestore = firestoreRaw as unknown as {
+  __dataStore: typeof dataStore;
+  writeBatch: jest.Mock;
+  getDocs: jest.Mock;
+};
+const store = firestore.__dataStore;
 
 beforeEach(() => {
   for (const col of Object.values(store)) {

--- a/src/__tests__/internet-time.test.ts
+++ b/src/__tests__/internet-time.test.ts
@@ -8,7 +8,7 @@ describe("internet time", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     __resetInternetTimeOffset();
-    (global as any).fetch = jest.fn();
+    (globalThis as unknown as { fetch: jest.Mock }).fetch = jest.fn();
     delete process.env.DEFAULT_TZ;
   });
 
@@ -76,7 +76,7 @@ describe("internet time", () => {
         new Promise((_resolve, reject) => {
           opts.signal.addEventListener("abort", () => {
             const err = new Error("aborted");
-            (err as any).name = "AbortError";
+            (err as { name: string }).name = "AbortError";
             reject(err);
           });
         })

--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -39,11 +39,11 @@ import * as offline from "../lib/offline"
 import React from "react"
 
 beforeAll(() => {
-  ;(global as any).indexedDB = {}
+  (globalThis as unknown as { indexedDB: unknown }).indexedDB = {}
 })
 
 afterAll(() => {
-  delete (global as any).indexedDB
+  delete (globalThis as { indexedDB?: unknown }).indexedDB
 })
 
 describe("offline fallbacks", () => {
@@ -78,8 +78,8 @@ describe("ServiceWorker", () => {
       .spyOn(offline, "getQueuedTransactions")
       .mockResolvedValueOnce(null)
 
-    const fetchMock = jest.fn()
-    ;(global as any).fetch = fetchMock
+    const fetchMock = jest.fn();
+    (globalThis as unknown as { fetch: jest.Mock }).fetch = fetchMock
 
     render(React.createElement(ServiceWorker))
 
@@ -91,6 +91,6 @@ describe("ServiceWorker", () => {
     expect(fetchMock).not.toHaveBeenCalled()
 
     jest.useRealTimers()
-    delete (global as any).fetch
+    delete (globalThis as { fetch?: unknown }).fetch
   })
 })

--- a/src/__tests__/payload-size-limit.test.ts
+++ b/src/__tests__/payload-size-limit.test.ts
@@ -24,7 +24,7 @@ function createOversizedRequest() {
     },
     body: stream,
     // Node's Request type requires duplex when using a stream body
-    duplex: "half" as any,
+    duplex: 'half' as unknown as RequestInit['duplex'],
   })
   return { req, read: () => read }
 }

--- a/src/__tests__/saveTransactions.integration.test.ts
+++ b/src/__tests__/saveTransactions.integration.test.ts
@@ -6,6 +6,7 @@ jest.mock("../lib/firebase", () => ({ db: {} }));
 const store = new Map<string, Transaction>();
 
 function mockCollection(_db: unknown, name: string) {
+  void _db;
   return { name } as const;
 }
 
@@ -14,6 +15,7 @@ function mockDoc(col: { name: string }, id: string) {
 }
 
 function mockWriteBatch(_db: unknown) {
+  void _db;
   const ops: { ref: { id: string }; data: Transaction }[] = [];
   return {
     set(ref: { id: string }, data: Transaction) {

--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -14,8 +14,8 @@ jest.mock("../hooks/use-toast", () => ({ toast: jest.fn() }))
 
 describe("ServiceWorker aborts in-flight sync", () => {
   beforeEach(() => {
-    jest.useFakeTimers()
-    ;(fetch as jest.Mock).mockReset()
+    jest.useFakeTimers();
+    (fetch as jest.MockedFunction<typeof fetch>).mockReset();
   })
 
   afterEach(() => {
@@ -23,11 +23,13 @@ describe("ServiceWorker aborts in-flight sync", () => {
   })
 
   it("aborts fetch on unmount", async () => {
-    let signal: AbortSignal | undefined
-    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
-      signal = options.signal
-      return new Promise(() => {})
-    })
+    let signal: AbortSignal | undefined;
+    (fetch as jest.MockedFunction<typeof fetch>).mockImplementation(
+      (_url: RequestInfo | URL, options: RequestInit) => {
+        signal = options.signal as AbortSignal;
+        return new Promise(() => {});
+      }
+    );
 
     Object.defineProperty(navigator, "onLine", {
       value: true,
@@ -48,11 +50,13 @@ describe("ServiceWorker aborts in-flight sync", () => {
   })
 
   it("aborts previous fetch when new sync starts", async () => {
-    const signals: AbortSignal[] = []
-    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
-      signals.push(options.signal)
-      return new Promise(() => {})
-    })
+    const signals: AbortSignal[] = [];
+    (fetch as jest.MockedFunction<typeof fetch>).mockImplementation(
+      (_url: RequestInfo | URL, options: RequestInit) => {
+        signals.push(options.signal as AbortSignal);
+        return new Promise(() => {});
+      }
+    );
 
     Object.defineProperty(navigator, "onLine", {
       value: true,

--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -3,7 +3,6 @@
  */
 
 jest.mock("node:worker_threads", () => {
-  const { EventEmitter } = require("events")
   return {
     Worker: class MockWorker extends EventEmitter {
       postMessage(data: unknown) {
@@ -22,13 +21,14 @@ jest.mock("node:worker_threads", () => {
   }
 })
 
+import { EventEmitter } from "events"
 import { WorkerPool } from "../lib/worker-pool"
 
 describe("WorkerPool", () => {
   it("continues processing after a worker crash", async () => {
     const pool = new WorkerPool<number | string, number>("fake", 1)
 
-    const fail = pool.run("crash" as any)
+    const fail = pool.run("crash")
     const success = pool.run(5)
 
     await expect(fail).rejects.toThrow("boom")
@@ -40,7 +40,7 @@ describe("WorkerPool", () => {
   it("does not reject when a worker exits normally", async () => {
     const pool = new WorkerPool<number | string, number>("fake", 1)
 
-    const promise = pool.run("exit" as any)
+    const promise = pool.run("exit")
     const timeout = new Promise(resolve => setTimeout(resolve, 10))
 
     await expect(Promise.race([promise, timeout])).resolves.toBeUndefined()
@@ -53,7 +53,9 @@ describe("WorkerPool", () => {
 
     for (let i = 0; i < 50; i++) {
       await pool.run(i)
-      const worker = (pool as any).workers[0]
+      const worker = (
+        pool as unknown as { workers: Array<EventEmitter> }
+      ).workers[0]
       expect(worker.listenerCount("exit")).toBe(1)
     }
 


### PR DESCRIPTION
## Summary
- tighten typings across test suites to replace `any` usage
- remove unused params and switch to ES module imports
- ensure mocks use explicit types to satisfy eslint

## Testing
- `npx eslint src/__tests__`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2447a93ec83318e0a6b582242a9de