### PR TITLE
chore: tighten test typings

### DIFF
--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -10,25 +10,46 @@ jest.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: toastMock }),
 }));
 jest.mock('lucide-react', () => ({ PlusCircle: () => null }));
-jest.mock('@/components/ui/dialog', () => ({
-  Dialog: ({ children }: any) => <div>{children}</div>,
-  DialogTrigger: ({ children }: any) => <div>{children}</div>,
-  DialogContent: ({ children }: any) => <div>{children}</div>,
-  DialogDescription: ({ children }: any) => <div>{children}</div>,
-  DialogFooter: ({ children }: any) => <div>{children}</div>,
-  DialogHeader: ({ children }: any) => <div>{children}</div>,
-  DialogTitle: ({ children }: any) => <div>{children}</div>,
-}));
-jest.mock('@/components/ui/select', () => ({
-  Select: ({ children }: any) => <div>{children}</div>,
-  SelectContent: ({ children }: any) => <div>{children}</div>,
-  SelectItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-  SelectTrigger: ({ children }: any) => <div>{children}</div>,
-  SelectValue: ({ children }: any) => <div>{children}</div>,
-}));
+jest.mock('@/components/ui/dialog', () => {
+  const Mock = ({ children }: React.PropsWithChildren) => <div>{children}</div>;
+  return {
+    Dialog: Mock,
+    DialogTrigger: Mock,
+    DialogContent: Mock,
+    DialogDescription: Mock,
+    DialogFooter: Mock,
+    DialogHeader: Mock,
+    DialogTitle: Mock,
+  };
+});
+jest.mock('@/components/ui/select', () => {
+  const Mock = ({ children }: React.PropsWithChildren) => <div>{children}</div>;
+  return {
+    Select: Mock,
+    SelectContent: Mock,
+    SelectItem: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    ),
+    SelectTrigger: Mock,
+    SelectValue: Mock,
+  };
+});
 jest.mock('@/components/ui/switch', () => ({
-  Switch: ({ onCheckedChange, ...props }: any) => (
-    <input type="checkbox" onChange={onCheckedChange} {...props} />
+  Switch: ({
+    onCheckedChange,
+    ...props
+  }: {
+    onCheckedChange: (checked: boolean) => void;
+    [key: string]: unknown;
+  }) => (
+    <input
+      type="checkbox"
+      onChange={(e) => onCheckedChange(e.target.checked)}
+      {...props}
+    />
   ),
 }));
 

--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -18,16 +18,21 @@ jest.mock('@/lib/firebase', () => ({
     app: { options: { apiKey: 'test' }, name: '[DEFAULT]' },
   },
 }));
-const { auth: authStub } = require('@/lib/firebase');
+import { auth as authStub } from '@/lib/firebase';
 
-let mockUser: any = null;
-const onAuthStateChanged = jest.fn((_auth: unknown, cb: (u: any) => void) => {
-  cb(mockUser);
-  return () => {};
-});
+type User = { uid: string } | null;
+let mockUser: User = null;
+const onAuthStateChanged = jest.fn(
+  (_auth: unknown, cb: (u: User) => void) => {
+    cb(mockUser);
+    return () => {};
+  }
+);
 
 jest.mock('firebase/auth', () => ({
-  onAuthStateChanged: (...args: any[]) => (onAuthStateChanged as any)(...args),
+  onAuthStateChanged: (
+    ...args: Parameters<typeof onAuthStateChanged>
+  ) => onAuthStateChanged(...args),
 }));
 
 function DisplayUser() {
@@ -45,7 +50,7 @@ beforeEach(() => {
 
 test('redirects to dashboard when authenticated on "/" and updates context', async () => {
   mockPathname = '/';
-  mockUser = { uid: 'abc' } as any;
+  mockUser = { uid: 'abc' };
 
   render(
     <AuthProvider>

--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -10,7 +10,7 @@ describe('currency code validation', () => {
       ok: true,
       json: async () => ({ rates: { EUR: 0.85 } }),
     });
-    (global as any).fetch = mockFetch;
+    (globalThis as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
 
     const rate = await getFxRate('usd', 'eur');
 
@@ -23,7 +23,7 @@ describe('currency code validation', () => {
 
   it('getFxRate throws on invalid code', async () => {
     const mockFetch = jest.fn();
-    (global as any).fetch = mockFetch;
+    (globalThis as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
 
     await expect(getFxRate('US', 'EUR')).rejects.toThrow('Invalid currency code');
     expect(mockFetch).not.toHaveBeenCalled();
@@ -34,7 +34,7 @@ describe('currency code validation', () => {
       ok: true,
       json: async () => ({ rates: { EUR: 0.5 } }),
     });
-    (global as any).fetch = mockFetch;
+    (globalThis as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
 
     const converted = await convertCurrency(10, 'usd', 'eur');
 
@@ -43,7 +43,7 @@ describe('currency code validation', () => {
 
   it('convertCurrency returns original amount for invalid codes', async () => {
     const mockFetch = jest.fn();
-    (global as any).fetch = mockFetch;
+    (globalThis as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
 
     const converted = await convertCurrency(10, 'u$', 'eur');
 

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -17,33 +17,45 @@ jest.mock("@/lib/firebase", () => ({ db: {} }));
 
 jest.mock("firebase/firestore", () => {
   const store: { lastRun?: number } = {};
+  interface Tx {
+    get: () => Promise<{
+      exists: () => boolean;
+      data: () => { lastRun: number | undefined };
+    }>;
+    set: (ref: unknown, data: { lastRun: number }) => void;
+  }
   return {
-    doc: (_db: any, _col: string, _id: string) => ({}),
-    runTransaction: jest.fn(async (_db: any, updateFn: any) => {
-      while (true) {
-        let write: any;
-        const lastBefore = store.lastRun;
-        const tx = {
-          get: async () => ({
-            exists: () => store.lastRun !== undefined,
-            data: () => ({ lastRun: store.lastRun }),
-          }),
-          set: (_ref: any, data: any) => {
-            write = data;
-          },
-        };
-        const result = await updateFn(tx);
-        if (write && lastBefore !== store.lastRun) {
-          // retry due to concurrent modification
-          continue;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    doc: (_db: unknown, _col: string, _id: string) => ({}),
+    runTransaction: jest.fn(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      async (_db: unknown, updateFn: (tx: Tx) => Promise<unknown>) => {
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          let write: { lastRun: number } | undefined;
+          const lastBefore = store.lastRun;
+          const tx: Tx = {
+            get: async () => ({
+              exists: () => store.lastRun !== undefined,
+              data: () => ({ lastRun: store.lastRun }),
+            }),
+            set: (_ref, data) => {
+              write = data;
+            },
+          };
+          const result = await updateFn(tx);
+          if (write && lastBefore !== store.lastRun) {
+            // retry due to concurrent modification
+            continue;
+          }
+          if (write) {
+            store.lastRun = write.lastRun;
+          }
+          return result;
         }
-        if (write) {
-          store.lastRun = write.lastRun;
-        }
-        return result;
       }
-    }),
-    setDoc: jest.fn(async (_ref: any, data: any) => {
+    ),
+    setDoc: jest.fn(async (_ref: unknown, data: { lastRun: number }) => {
       store.lastRun = data.lastRun;
     }),
     __store: store,

--- a/src/__tests__/internet-time.test.ts
+++ b/src/__tests__/internet-time.test.ts
@@ -8,7 +8,7 @@ describe("internet time", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     __resetInternetTimeOffset();
-    (global as any).fetch = jest.fn();
+    (globalThis as { fetch: jest.Mock }).fetch = jest.fn();
     delete process.env.DEFAULT_TZ;
   });
 
@@ -76,7 +76,7 @@ describe("internet time", () => {
         new Promise((_resolve, reject) => {
           opts.signal.addEventListener("abort", () => {
             const err = new Error("aborted");
-            (err as any).name = "AbortError";
+            (err as Error).name = "AbortError";
             reject(err);
           });
         })

--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -38,12 +38,17 @@ import { ServiceWorker } from "../components/service-worker"
 import * as offline from "../lib/offline"
 import React from "react"
 
+const globalAny = globalThis as {
+  indexedDB?: unknown
+  fetch?: typeof fetch
+}
+
 beforeAll(() => {
-  ;(global as any).indexedDB = {}
+  globalAny.indexedDB = {}
 })
 
 afterAll(() => {
-  delete (global as any).indexedDB
+  delete globalAny.indexedDB
 })
 
 describe("offline fallbacks", () => {
@@ -79,7 +84,7 @@ describe("ServiceWorker", () => {
       .mockResolvedValueOnce(null)
 
     const fetchMock = jest.fn()
-    ;(global as any).fetch = fetchMock
+    globalAny.fetch = fetchMock as unknown as typeof fetch
 
     render(React.createElement(ServiceWorker))
 
@@ -91,6 +96,6 @@ describe("ServiceWorker", () => {
     expect(fetchMock).not.toHaveBeenCalled()
 
     jest.useRealTimers()
-    delete (global as any).fetch
+    delete globalAny.fetch
   })
 })

--- a/src/__tests__/payload-size-limit.test.ts
+++ b/src/__tests__/payload-size-limit.test.ts
@@ -24,8 +24,8 @@ function createOversizedRequest() {
     },
     body: stream,
     // Node's Request type requires duplex when using a stream body
-    duplex: "half" as any,
-  })
+    duplex: "half",
+  } as RequestInit & { duplex: "half" })
   return { req, read: () => read }
 }
 

--- a/src/__tests__/saveTransactions.integration.test.ts
+++ b/src/__tests__/saveTransactions.integration.test.ts
@@ -13,7 +13,7 @@ function mockDoc(col: { name: string }, id: string) {
   return { col: col.name, id };
 }
 
-function mockWriteBatch(_db: unknown) {
+function mockWriteBatch() {
   const ops: { ref: { id: string }; data: Transaction }[] = [];
   return {
     set(ref: { id: string }, data: Transaction) {

--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -24,10 +24,12 @@ describe("ServiceWorker aborts in-flight sync", () => {
 
   it("aborts fetch on unmount", async () => {
     let signal: AbortSignal | undefined
-    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
-      signal = options.signal
-      return new Promise(() => {})
-    })
+    ;(fetch as jest.Mock).mockImplementation(
+      (_url: string, options: { signal: AbortSignal }) => {
+        signal = options.signal
+        return new Promise(() => {})
+      }
+    )
 
     Object.defineProperty(navigator, "onLine", {
       value: true,
@@ -49,10 +51,12 @@ describe("ServiceWorker aborts in-flight sync", () => {
 
   it("aborts previous fetch when new sync starts", async () => {
     const signals: AbortSignal[] = []
-    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
-      signals.push(options.signal)
-      return new Promise(() => {})
-    })
+    ;(fetch as jest.Mock).mockImplementation(
+      (_url: string, options: { signal: AbortSignal }) => {
+        signals.push(options.signal)
+        return new Promise(() => {})
+      }
+    )
 
     Object.defineProperty(navigator, "onLine", {
       value: true,

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -25,6 +25,7 @@ export async function archiveOldTransactions(cutoffDate: string): Promise<void> 
   const pageSize = 100;
   let lastDoc: QueryDocumentSnapshot<unknown> | undefined;
 
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     const q = lastDoc
       ? query(
@@ -66,6 +67,7 @@ export async function cleanupDebts(): Promise<void> {
   const pageSize = 100;
   let lastDoc: QueryDocumentSnapshot<unknown> | undefined;
 
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     const q = lastDoc
       ? query(
@@ -145,6 +147,7 @@ export async function backupData(
     const items: T[] = [];
     let lastDoc: QueryDocumentSnapshot<unknown> | undefined;
 
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       const q = lastDoc
         ? query(col, orderBy(orderField), startAfter(lastDoc), limit(pageSize))


### PR DESCRIPTION
## Summary
- remove `any` usage in test mocks and replace with explicit types
- clean up unused variables and require imports in tests
- note: silenced constant-condition warnings in housekeeping loops

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b24499c3a883318c958c41fe8a25b0