### PR TITLE
fix: resolve merge conflict artifacts in AI flows and category service

### DIFF
--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -48,18 +48,18 @@ describe("categoryService validation", () => {
     expect(mockDeleteDoc).not.toHaveBeenCalled();
   });
 
-  it("writes to Firestore even when category already exists case-insensitively", () => {
+  it("avoids Firestore writes when category already exists case-insensitively", () => {
     addCategory("Groceries");
     expect(mockSetDoc).toHaveBeenCalledTimes(1);
     addCategory("groceries");
     expect(getCategories()).toEqual(["Groceries"]);
-    expect(mockSetDoc).toHaveBeenCalledTimes(2);
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
   });
 
-  it("writes to Firestore for duplicate category with same casing", () => {
+  it("avoids Firestore writes for duplicate category with same casing", () => {
     addCategory("Utilities");
     expect(mockSetDoc).toHaveBeenCalledTimes(1);
     addCategory("Utilities");
-    expect(mockSetDoc).toHaveBeenCalledTimes(2);
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -39,9 +39,3 @@ export type {
 
 export { predictSpending } from './spendingForecast';
 export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
-
-export { calculateCostOfLiving } from './cost-of-living';
-export type {
-  CalculateCostOfLivingInput,
-  CostOfLivingBreakdown,
-} from './cost-of-living';

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -100,10 +100,10 @@ export function addCategory(category: string): string[] {
   const exists = categories.some((c) => normalize(c) === key);
   if (!exists) {
     categories.push(trimmed);
+    void setDoc(doc(categoriesCollection, key), { name: trimmed }).catch(
+      console.error,
+    );
   }
-  void setDoc(doc(categoriesCollection, key), { name: trimmed }).catch(
-    console.error,
-  );
   save(categories);
   return categories;
 }


### PR DESCRIPTION
## Summary
- remove duplicated cost-of-living exports from AI flow barrel file
- write new categories to Firestore only once and update tests accordingly

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b24569a458833196dd44887e2774e3