### PR TITLE
codex: initialize category model on startup

### DIFF
--- a/src/ai/init.ts
+++ b/src/ai/init.ts
@@ -1,0 +1,13 @@
+import { initCategoryModel, teardownCategoryModel } from "./train/category-model";
+
+initCategoryModel().catch((err) => {
+  console.error("Failed to initialize category model", err);
+});
+
+if (typeof process !== "undefined") {
+  process.once("exit", () => teardownCategoryModel());
+  process.once("SIGINT", () => {
+    teardownCategoryModel();
+    process.exit(0);
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { headers } from 'next/headers'
 import { Inter } from "next/font/google"
 import './globals.css'
+import "@/ai/init"
 import { Toaster } from "@/components/ui/toaster"
 import { AuthProvider } from '@/components/auth/auth-provider'
 import { ThemeProvider } from 'next-themes'


### PR DESCRIPTION
## Summary
- add explicit init and teardown hooks for category classifier
- initialize category model at server startup so suggestions use local predictions

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b245b3cb288331a7db463342ebffd1