### PR TITLE
fix: initialize category model before local classification

### DIFF
--- a/src/ai/flows/suggest-category.ts
+++ b/src/ai/flows/suggest-category.ts
@@ -4,7 +4,7 @@
 import { ai } from '@/ai/genkit';
 import { z } from 'genkit';
 
-import { classifyCategory } from '../train/category-model';
+import { classifyCategory, initCategoryModel } from '../train/category-model';
 
 const SuggestCategoryInputSchema = z.object({
   description: z.string().describe('Description of the transaction'),
@@ -45,9 +45,11 @@ const suggestCategoryFlow = ai.defineFlow(
  * classifier first, falling back to the AI model if no prediction is available.
  */
 export async function suggestCategory(input: SuggestCategoryInput): Promise<SuggestCategoryOutput> {
+  initCategoryModel();
   const local = classifyCategory(input.description);
   if (local) {
     return { category: local };
   }
   return await suggestCategoryFlow(input);
 }
+


### PR DESCRIPTION
## Summary
- initialize the category model before the first classification

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b245d08b048331b6d164f3e030962c