### PR TITLE
fix: initialize category model before suggestion

### DIFF
--- a/src/ai/flows/index.ts
+++ b/src/ai/flows/index.ts
@@ -31,12 +31,12 @@ export type { SuggestCategoryInput, SuggestCategoryOutput } from './suggest-cate
 
 export { calculateCashflow } from './calculate-cashflow';
 export type { CalculateCashflowInput, CalculateCashflowOutput } from './calculate-cashflow';
+export { predictSpending } from './spendingForecast';
+export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
+
 export { calculateCostOfLiving } from './cost-of-living';
 export type {
   CalculateCostOfLivingInput,
   CostOfLivingBreakdown,
 } from './cost-of-living';
-
-export { predictSpending } from './spendingForecast';
-export type { SpendingForecastInput, SpendingForecastOutput } from './spendingForecast';
 

--- a/src/ai/flows/suggest-category.ts
+++ b/src/ai/flows/suggest-category.ts
@@ -4,7 +4,7 @@
 import { ai } from '@/ai/genkit';
 import { z } from 'genkit';
 
-import { classifyCategory } from '../train/category-model';
+import { classifyCategory, initCategoryModel } from '../train/category-model';
 
 const SuggestCategoryInputSchema = z.object({
   description: z.string().describe('Description of the transaction'),
@@ -45,6 +45,7 @@ const suggestCategoryFlow = ai.defineFlow(
  * classifier first, falling back to the AI model if no prediction is available.
  */
 export async function suggestCategory(input: SuggestCategoryInput): Promise<SuggestCategoryOutput> {
+  initCategoryModel();
   const local = classifyCategory(input.description);
   if (local) {
     return { category: local };


### PR DESCRIPTION
## Summary
- ensure local classifier initializes before suggesting categories
- sync AI flow barrel with latest main

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b245d816348331aa8cdc46c6d838f2