### PR TITLE
fix: use server action for category suggestions

### DIFF
--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -26,6 +26,7 @@ import type { Transaction } from "@/lib/types"
 import { useToast } from "@/hooks/use-toast"
 import { recordCategoryFeedback } from "@/lib/category-feedback"
 import { logger } from "@/lib/logger"
+import { suggestCategoryAction } from "@/app/actions"
 
 interface AddTransactionDialogProps {
   onSave: (transaction: Omit<Transaction, 'id' | 'date'>) => void;
@@ -56,12 +57,11 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
         let active = true
         const fetchSuggestion = async () => {
             try {
-                const { suggestCategory } = await import("@/ai/flows/suggest-category")
-                const res = await suggestCategory({ description })
+                const category = await suggestCategoryAction(description)
                 if (active) {
-                    setSuggestedCategory(res.category)
+                    setSuggestedCategory(category)
                     if (!userModifiedCategory.current) {
-                        setCategory(res.category)
+                        setCategory(category)
                     }
                 }
             } catch (error) {


### PR DESCRIPTION
## Summary
- use server action instead of importing server-only module in add transaction dialog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2460750b883318b4e744347599faf