### PR TITLE
codex: ensure category model for server actions

### DIFF
--- a/src/ai/flows/suggest-category.ts
+++ b/src/ai/flows/suggest-category.ts
@@ -4,7 +4,7 @@
 import { ai } from '@/ai/genkit';
 import { z } from 'genkit';
 
-import { classifyCategory } from '../train/category-model';
+import { classifyCategory, initCategoryModel } from '../train/category-model';
 
 const SuggestCategoryInputSchema = z.object({
   description: z.string().describe('Description of the transaction'),
@@ -45,6 +45,7 @@ const suggestCategoryFlow = ai.defineFlow(
  * classifier first, falling back to the AI model if no prediction is available.
  */
 export async function suggestCategory(input: SuggestCategoryInput): Promise<SuggestCategoryOutput> {
+  await initCategoryModel();
   const local = classifyCategory(input.description);
   if (local) {
     return { category: local };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next'
 import { headers } from 'next/headers'
 import { Inter } from "next/font/google"
 import './globals.css'
-import "@/ai/init"
 import { Toaster } from "@/components/ui/toaster"
 import { AuthProvider } from '@/components/auth/auth-provider'
 import { ThemeProvider } from 'next-themes'


### PR DESCRIPTION
## Summary
- lazily initialize category classifier inside server action
- drop unused `@/ai/init` import from root layout

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b247b700188331a80e33c9aeca5876