### PR TITLE
fix: read nonce headers synchronously

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,13 +15,12 @@ export const metadata: Metadata = {
   description: 'Financial management for nursing professionals.',
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const nonceHeader = await headers();
-  const nonce = nonceHeader.get('x-nonce') || undefined
+  const nonce = headers().get('x-nonce') || undefined;
 
   return (
     <html lang="en" suppressHydrationWarning>


### PR DESCRIPTION
## Summary
- read nonce from headers without awaiting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b247fe48bc8331b714f3b3a3f1da33