### PR TITLE
test: ensure firebase mocks applied in tests

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -3,8 +3,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../components/auth/auth-provider';
-import { auth as authStub } from '@/lib/firebase';
-
 let mockPathname = '/';
 const pushMock = jest.fn();
 
@@ -34,6 +32,14 @@ jest.mock('firebase/auth', () => ({
     ...args: Parameters<typeof onAuthStateChanged>
   ) => onAuthStateChanged(...args),
 }));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { auth: authStub } = require('@/lib/firebase') as {
+  auth: {
+    currentUser: null;
+    app: { options: { apiKey: string }; name: string };
+  };
+};
 
 function DisplayUser() {
   const { user } = useAuth();

--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -152,13 +152,10 @@ jest.mock('firebase/firestore', () => {
   };
 });
 
-import {
-  archiveOldTransactions,
-  cleanupDebts,
-  backupData,
-  runWithRetry,
-} from '../services/housekeeping';
-import * as firestoreRaw from 'firebase/firestore';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { archiveOldTransactions, cleanupDebts, backupData, runWithRetry } = require('../services/housekeeping');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const firestoreRaw = require('firebase/firestore');
 const firestore = firestoreRaw as unknown as {
   __dataStore: typeof dataStore;
   writeBatch: jest.Mock;


### PR DESCRIPTION
## Summary
- require firebase auth after jest mocks in AuthProvider tests
- load housekeeping modules with require so firestore mocks apply

## Testing
- `npx eslint src/__tests__`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2481f70848331ab0390078cff174a