### PR TITLE
fix: ensure firebase mocks applied before imports

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -2,8 +2,6 @@
 /** @jest-environment jsdom */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '../components/auth/auth-provider';
-import { auth as authStub } from '@/lib/firebase';
 
 let mockPathname = '/';
 const pushMock = jest.fn();
@@ -34,6 +32,11 @@ jest.mock('firebase/auth', () => ({
     ...args: Parameters<typeof onAuthStateChanged>
   ) => onAuthStateChanged(...args),
 }));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { AuthProvider, useAuth } = require('../components/auth/auth-provider');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { auth: authStub } = require('@/lib/firebase');
 
 function DisplayUser() {
   const { user } = useAuth();

--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
 process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'test';
 process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'test';
 process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'test';
@@ -152,14 +154,13 @@ jest.mock('firebase/firestore', () => {
   };
 });
 
-import {
+const {
   archiveOldTransactions,
   cleanupDebts,
   backupData,
   runWithRetry,
-} from '../services/housekeeping';
-import * as firestoreRaw from 'firebase/firestore';
-const firestore = firestoreRaw as unknown as {
+} = require('../services/housekeeping');
+const firestore = require('firebase/firestore') as unknown as {
   __dataStore: typeof dataStore;
   writeBatch: jest.Mock;
   getDocs: jest.Mock;


### PR DESCRIPTION
## Summary
- require firestore service and auth modules after jest mocks in tests to apply stubs
- disable no-require-imports for affected tests

## Testing
- `npx eslint src/__tests__/auth-provider.test.tsx src/__tests__/housekeeping.test.ts`
- `npm test -- src/__tests__/housekeeping.test.ts src/__tests__/auth-provider.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b24820d0288331b16415862e42caee