### PR TITLE
fix: generate base64 CSP nonce

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,20 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+function generateNonce(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16))
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64')
+  }
+  let binary = ''
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b)
+  })
+  return btoa(binary)
+}
+
 export function middleware(request: NextRequest) {
-  const cspNonce = crypto.randomUUID()
+  const cspNonce = generateNonce()
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-nonce', cspNonce)


### PR DESCRIPTION
## Summary
- generate a base64-encoded 16-byte nonce using Web Crypto

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2482dd9508331aaef27e9aeba2466