### PR TITLE
fix: resolve merge conflicts and address review feedback

### DIFF
--- a/src/ai/flows/suggest-category.ts
+++ b/src/ai/flows/suggest-category.ts
@@ -4,7 +4,17 @@
 import { ai } from '@/ai/genkit';
 import { z } from 'genkit';
 
-import { classifyCategory } from '../train/category-model';
+import {
+  classifyCategory,
+  initCategoryModel,
+  teardownCategoryModel,
+} from '../train/category-model';
+
+// Initialize the local category model on startup and clean up on exit.
+void initCategoryModel().catch(console.error);
+if (typeof process !== 'undefined') {
+  process.on('exit', teardownCategoryModel);
+}
 
 const SuggestCategoryInputSchema = z.object({
   description: z.string().describe('Description of the transaction'),


### PR DESCRIPTION
## Summary
- remove duplicate cost-of-living exports
- guard category model behind initializer with teardown
- sync layout nonce headers and update payroll/category service tests
- initialize category model at startup to enable local classification

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b24865a434833187ccdb0ea702145e