### PR TITLE
refactor tests to use ES module imports

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../components/auth/auth-provider';
+import { auth as authStub } from '@/lib/firebase';
 
 let mockPathname = '/';
 const pushMock = jest.fn();
@@ -18,7 +19,6 @@ jest.mock('@/lib/firebase', () => ({
     app: { options: { apiKey: 'test' }, name: '[DEFAULT]' },
   },
 }));
-const { auth: authStub } = require('@/lib/firebase');
 
 let mockUser: any = null;
 const onAuthStateChanged = jest.fn((_auth: unknown, cb: (u: any) => void) => {

--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -133,8 +133,13 @@ jest.mock('firebase/firestore', () => {
   };
 });
 
-const { archiveOldTransactions, cleanupDebts, backupData, runWithRetry } = require('../services/housekeeping');
-const firestore = require('firebase/firestore');
+import {
+  archiveOldTransactions,
+  cleanupDebts,
+  backupData,
+  runWithRetry,
+} from '../services/housekeeping';
+import * as firestore from 'firebase/firestore';
 const store = firestore.__dataStore as typeof dataStore;
 
 beforeEach(() => {

--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -2,8 +2,9 @@
  * @jest-environment node
  */
 
+import { EventEmitter } from "events"
+
 jest.mock("node:worker_threads", () => {
-  const { EventEmitter } = require("events")
   return {
     Worker: class MockWorker extends EventEmitter {
       postMessage(data: unknown) {


### PR DESCRIPTION
## Summary
- replace CommonJS requires with ES module imports in failing test files
- confirm TypeScript configuration supports ES module interop

## Testing
- `npm test src/__tests__/auth-provider.test.tsx src/__tests__/worker-pool.test.ts src/__tests__/housekeeping.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b24aec435c8331b9e5a4002beb3ff9