### PR TITLE
refactor: remove any from tests

### DIFF
--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -11,25 +11,40 @@ jest.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: toastMock }),
 }));
 jest.mock('lucide-react', () => ({ PlusCircle: () => null }));
+type PropsWithChildren = React.PropsWithChildren;
+
 jest.mock('@/components/ui/dialog', () => ({
-  Dialog: ({ children }: any) => <div>{children}</div>,
-  DialogTrigger: ({ children }: any) => <div>{children}</div>,
-  DialogContent: ({ children }: any) => <div>{children}</div>,
-  DialogDescription: ({ children }: any) => <div>{children}</div>,
-  DialogFooter: ({ children }: any) => <div>{children}</div>,
-  DialogHeader: ({ children }: any) => <div>{children}</div>,
-  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  Dialog: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogTrigger: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogDescription: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogFooter: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogHeader: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogTitle: ({ children }: PropsWithChildren) => <div>{children}</div>,
 }));
 jest.mock('@/components/ui/select', () => ({
-  Select: ({ children }: any) => <div>{children}</div>,
-  SelectContent: ({ children }: any) => <div>{children}</div>,
-  SelectItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-  SelectTrigger: ({ children }: any) => <div>{children}</div>,
-  SelectValue: ({ children }: any) => <div>{children}</div>,
+  Select: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectItem: (
+    { children, ...props }: PropsWithChildren & Record<string, unknown>
+  ) => <div {...props}>{children}</div>,
+  SelectTrigger: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectValue: ({ children }: PropsWithChildren) => <div>{children}</div>,
 }));
 jest.mock('@/components/ui/switch', () => ({
-  Switch: ({ onCheckedChange, ...props }: any) => (
-    <input type="checkbox" onChange={onCheckedChange} {...props} />
+  Switch: (
+    {
+      onCheckedChange,
+      ...props
+    }: {
+      onCheckedChange?: (checked: boolean) => void
+    } & React.InputHTMLAttributes<HTMLInputElement>
+  ) => (
+    <input
+      type="checkbox"
+      onChange={e => onCheckedChange?.(e.target.checked)}
+      {...props}
+    />
   ),
 }));
 

--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -20,14 +20,22 @@ jest.mock('@/lib/firebase', () => ({
 }));
 const { auth: authStub } = require('@/lib/firebase');
 
-let mockUser: any = null;
-const onAuthStateChanged = jest.fn((_auth: unknown, cb: (u: any) => void) => {
-  cb(mockUser);
-  return () => {};
-});
+interface MockUser {
+  uid: string;
+}
+
+let mockUser: MockUser | null = null;
+const onAuthStateChanged = jest.fn(
+  (_auth: unknown, cb: (u: MockUser | null) => void) => {
+    cb(mockUser);
+    return () => {};
+  }
+);
 
 jest.mock('firebase/auth', () => ({
-  onAuthStateChanged: (...args: any[]) => (onAuthStateChanged as any)(...args),
+  onAuthStateChanged: (
+    ...args: Parameters<typeof onAuthStateChanged>
+  ) => onAuthStateChanged(...args),
 }));
 
 function DisplayUser() {
@@ -45,7 +53,7 @@ beforeEach(() => {
 
 test('redirects to dashboard when authenticated on "/" and updates context', async () => {
   mockPathname = '/';
-  mockUser = { uid: 'abc' } as any;
+  mockUser = { uid: 'abc' };
 
   render(
     <AuthProvider>

--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -1,7 +1,11 @@
 import { getFxRate, convertCurrency } from '@/lib/currency';
 
 describe('currency code validation', () => {
+  const g = global as unknown as { fetch: typeof fetch };
+  const originalFetch = g.fetch;
+
   afterEach(() => {
+    g.fetch = originalFetch;
     jest.resetAllMocks();
   });
 
@@ -9,8 +13,8 @@ describe('currency code validation', () => {
     const mockFetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ rates: { EUR: 0.85 } }),
-    });
-    (global as any).fetch = mockFetch;
+    }) as jest.MockedFunction<typeof fetch>;
+    g.fetch = mockFetch;
 
     const rate = await getFxRate('usd', 'eur');
 
@@ -22,8 +26,8 @@ describe('currency code validation', () => {
   });
 
   it('getFxRate throws on invalid code', async () => {
-    const mockFetch = jest.fn();
-    (global as any).fetch = mockFetch;
+    const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+    g.fetch = mockFetch;
 
     await expect(getFxRate('US', 'EUR')).rejects.toThrow('Invalid currency code');
     expect(mockFetch).not.toHaveBeenCalled();
@@ -33,8 +37,8 @@ describe('currency code validation', () => {
     const mockFetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ rates: { EUR: 0.5 } }),
-    });
-    (global as any).fetch = mockFetch;
+    }) as jest.MockedFunction<typeof fetch>;
+    g.fetch = mockFetch;
 
     const converted = await convertCurrency(10, 'usd', 'eur');
 
@@ -42,8 +46,8 @@ describe('currency code validation', () => {
   });
 
   it('convertCurrency returns original amount for invalid codes', async () => {
-    const mockFetch = jest.fn();
-    (global as any).fetch = mockFetch;
+    const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+    g.fetch = mockFetch;
 
     const converted = await convertCurrency(10, 'u$', 'eur');
 

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -18,32 +18,43 @@ jest.mock("@/lib/firebase", () => ({ db: {} }));
 jest.mock("firebase/firestore", () => {
   const store: { lastRun?: number } = {};
   return {
-    doc: (_db: any, _col: string, _id: string) => ({}),
-    runTransaction: jest.fn(async (_db: any, updateFn: any) => {
-      while (true) {
-        let write: any;
-        const lastBefore = store.lastRun;
-        const tx = {
-          get: async () => ({
-            exists: () => store.lastRun !== undefined,
-            data: () => ({ lastRun: store.lastRun }),
-          }),
-          set: (_ref: any, data: any) => {
-            write = data;
-          },
-        };
-        const result = await updateFn(tx);
-        if (write && lastBefore !== store.lastRun) {
-          // retry due to concurrent modification
-          continue;
+    doc: (_db: unknown, _col: string, _id: string) => ({}),
+    runTransaction: jest.fn(
+      async (
+        _db: unknown,
+        updateFn: (tx: {
+          get: () => Promise<{
+            exists: () => boolean;
+            data: () => { lastRun: number | undefined };
+          }>;
+          set: (_ref: unknown, data: { lastRun: number }) => void;
+        }) => Promise<unknown>
+      ) => {
+        while (true) {
+          let write: { lastRun: number } | undefined;
+          const lastBefore = store.lastRun;
+          const tx = {
+            get: async () => ({
+              exists: () => store.lastRun !== undefined,
+              data: () => ({ lastRun: store.lastRun }),
+            }),
+            set: (_ref: unknown, data: { lastRun: number }) => {
+              write = data;
+            },
+          };
+          const result = await updateFn(tx);
+          if (write && lastBefore !== store.lastRun) {
+            // retry due to concurrent modification
+            continue;
+          }
+          if (write) {
+            store.lastRun = write.lastRun;
+          }
+          return result;
         }
-        if (write) {
-          store.lastRun = write.lastRun;
-        }
-        return result;
       }
-    }),
-    setDoc: jest.fn(async (_ref: any, data: any) => {
+    ),
+    setDoc: jest.fn(async (_ref: unknown, data: { lastRun: number }) => {
       store.lastRun = data.lastRun;
     }),
     __store: store,

--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -5,7 +5,7 @@ process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'test';
 process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'test';
 process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'test';
 
-const dataStore: Record<string, Map<string, any>> = {
+const dataStore: Record<string, Map<string, unknown>> = {
   transactions: new Map(),
   transactions_archive: new Map(),
   debts: new Map(),
@@ -28,73 +28,107 @@ jest.mock('../lib/internet-time', () => ({
 }));
 
 jest.mock('firebase/firestore', () => {
-  const where = (field: string, op: string, value: any) => ({
+  type Constraint =
+    | { type: 'where'; field: string; op: string; value: unknown }
+    | { type: 'orderBy'; field: string }
+    | { type: 'limit'; n: number }
+    | { type: 'startAfter'; doc: { data: () => Record<string, unknown> } };
+
+  const where = (field: string, op: string, value: unknown): Constraint => ({
     type: 'where',
     field,
     op,
     value,
   });
-  const orderBy = (field: string) => ({ type: 'orderBy', field });
-  const limit = (n: number) => ({ type: 'limit', n });
-  const startAfter = (doc: any) => ({ type: 'startAfter', doc });
-  const query = (colRef: any, ...constraints: any[]) => ({ ...colRef, constraints });
+  const orderBy = (field: string): Constraint => ({ type: 'orderBy', field });
+  const limit = (n: number): Constraint => ({ type: 'limit', n });
+  const startAfter = (doc: { data: () => Record<string, unknown> }): Constraint => ({
+    type: 'startAfter',
+    doc,
+  });
+  const query = (
+    colRef: { name: keyof typeof dataStore },
+    ...constraints: Constraint[]
+  ) => ({ ...colRef, constraints });
 
-  const getDocs = jest.fn(async (q: any) => {
-    const colName = q.name;
-    let docs = Array.from(dataStore[colName].entries()).map(([id, data]) => ({
-      id,
-      data: () => data,
-    }));
+  const getDocs = jest.fn(
+    async (q: { name: keyof typeof dataStore; constraints?: Constraint[] }) => {
+      const colName = q.name;
+      let docs = Array.from(dataStore[colName].entries()).map(([id, data]) => ({
+        id,
+        data: () => data,
+      }));
 
-    const constraints = q.constraints || [];
-    for (const c of constraints) {
-      if (c.type === 'where') {
-        docs = docs.filter((d) => {
-          const val = d.data()[c.field];
-          switch (c.op) {
-            case '<':
-              return val < c.value;
-            case '<=':
-              return val <= c.value;
-            default:
-              return true;
-          }
+      const constraints = q.constraints || [];
+      for (const c of constraints) {
+        if (c.type === 'where') {
+          docs = docs.filter(d => {
+            const val = (d.data() as Record<string, unknown>)[c.field] as number;
+            switch (c.op) {
+              case '<':
+                return val < (c.value as number);
+              case '<=':
+                return val <= (c.value as number);
+              default:
+                return true;
+            }
+          });
+        }
+      }
+
+      const order = constraints.find(
+        c => c.type === 'orderBy'
+      ) as Extract<Constraint, { type: 'orderBy' }> | undefined;
+      if (order) {
+        docs.sort((a, b) => {
+          const av = (a.data() as Record<string, unknown>)[order.field] as number;
+          const bv = (b.data() as Record<string, unknown>)[order.field] as number;
+          if (av > bv) return 1;
+          if (av < bv) return -1;
+          return 0;
         });
       }
-    }
 
-    const order = constraints.find((c: any) => c.type === 'orderBy');
-    if (order) {
-      docs.sort((a, b) => {
-        const av = a.data()[order.field];
-        const bv = b.data()[order.field];
-        if (av > bv) return 1;
-        if (av < bv) return -1;
-        return 0;
-      });
-    }
+      const start = constraints.find(
+        c => c.type === 'startAfter'
+      ) as Extract<Constraint, { type: 'startAfter' }> | undefined;
+      if (start && order) {
+        const startVal = (start.doc.data() as Record<string, unknown>)[
+          order.field
+        ] as number;
+        docs = docs.filter(
+          d => (d.data() as Record<string, unknown>)[order.field] > startVal
+        );
+      }
 
-    const start = constraints.find((c: any) => c.type === 'startAfter');
-    if (start && order) {
-      const startVal = start.doc.data()[order.field];
-      docs = docs.filter((d) => d.data()[order.field] > startVal);
-    }
+      const lim = constraints.find(
+        c => c.type === 'limit'
+      ) as Extract<Constraint, { type: 'limit' }> | undefined;
+      if (lim) {
+        docs = docs.slice(0, lim.n);
+      }
 
-    const lim = constraints.find((c: any) => c.type === 'limit');
-    if (lim) {
-      docs = docs.slice(0, lim.n);
+      return { docs, size: docs.length, empty: docs.length === 0 };
     }
-
-    return { docs, size: docs.length, empty: docs.length === 0 };
-  });
+  );
 
   const writeBatch = jest.fn(() => {
-    const ops: any[] = [];
+    const ops: Array<
+      | {
+          type: 'set';
+          docRef: { name: keyof typeof dataStore; id: string };
+          data: unknown;
+        }
+      | { type: 'delete'; docRef: { name: keyof typeof dataStore; id: string } }
+    > = [];
     const batch = {
-      set: (docRef: any, data: any) => {
+      set: (
+        docRef: { name: keyof typeof dataStore; id: string },
+        data: unknown
+      ) => {
         ops.push({ type: 'set', docRef, data });
       },
-      delete: (docRef: any) => {
+      delete: (docRef: { name: keyof typeof dataStore; id: string }) => {
         ops.push({ type: 'delete', docRef });
       },
       commit: jest.fn(async () => {
@@ -111,16 +145,18 @@ jest.mock('firebase/firestore', () => {
     return batch;
   });
 
-  const addDoc = jest.fn(async (colRef: any, data: any) => {
-    const id = Math.random().toString(36).slice(2);
-    dataStore[colRef.name].set(id, data);
-    return { id };
-  });
+  const addDoc = jest.fn(
+    async (colRef: { name: keyof typeof dataStore }, data: unknown) => {
+      const id = Math.random().toString(36).slice(2);
+      dataStore[colRef.name].set(id, data);
+      return { id };
+    }
+  );
 
   return {
     getFirestore: jest.fn(() => ({})),
-    collection: (_db: any, name: string) => ({ name }),
-    doc: (_db: any, name: string, id: string) => ({ name, id }),
+    collection: (_db: unknown, name: keyof typeof dataStore) => ({ name }),
+    doc: (_db: unknown, name: keyof typeof dataStore, id: string) => ({ name, id }),
     getDocs,
     addDoc,
     query,

--- a/src/__tests__/internet-time.test.ts
+++ b/src/__tests__/internet-time.test.ts
@@ -5,15 +5,18 @@ import {
 } from "@/lib/internet-time";
 
 describe("internet time", () => {
+  const g = global as unknown as { fetch: jest.MockedFunction<typeof fetch> };
+  const originalFetch = global.fetch;
   beforeEach(() => {
     jest.useFakeTimers();
     __resetInternetTimeOffset();
-    (global as any).fetch = jest.fn();
+    g.fetch = jest.fn() as jest.MockedFunction<typeof fetch>;
     delete process.env.DEFAULT_TZ;
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    g.fetch = originalFetch as typeof fetch;
     jest.restoreAllMocks();
   });
 
@@ -76,7 +79,7 @@ describe("internet time", () => {
         new Promise((_resolve, reject) => {
           opts.signal.addEventListener("abort", () => {
             const err = new Error("aborted");
-            (err as any).name = "AbortError";
+            err.name = "AbortError";
             reject(err);
           });
         })

--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -38,12 +38,18 @@ import { ServiceWorker } from "../components/service-worker"
 import * as offline from "../lib/offline"
 import React from "react"
 
+interface TestGlobal {
+  indexedDB?: unknown
+  fetch?: jest.MockedFunction<typeof fetch>
+}
+const g = global as unknown as TestGlobal
+
 beforeAll(() => {
-  ;(global as any).indexedDB = {}
+  g.indexedDB = {}
 })
 
 afterAll(() => {
-  delete (global as any).indexedDB
+  delete g.indexedDB
 })
 
 describe("offline fallbacks", () => {
@@ -78,8 +84,8 @@ describe("ServiceWorker", () => {
       .spyOn(offline, "getQueuedTransactions")
       .mockResolvedValueOnce(null)
 
-    const fetchMock = jest.fn()
-    ;(global as any).fetch = fetchMock
+    const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>
+    g.fetch = fetchMock
 
     render(React.createElement(ServiceWorker))
 
@@ -91,6 +97,6 @@ describe("ServiceWorker", () => {
     expect(fetchMock).not.toHaveBeenCalled()
 
     jest.useRealTimers()
-    delete (global as any).fetch
+    delete g.fetch
   })
 })

--- a/src/__tests__/payload-size-limit.test.ts
+++ b/src/__tests__/payload-size-limit.test.ts
@@ -16,7 +16,7 @@ function createOversizedRequest() {
       this.push(null)
     },
   })
-  const req = new Request("http://localhost", {
+  const init: RequestInit & { duplex: "half" } = {
     method: "POST",
     headers: {
       Authorization: "Bearer test-token",
@@ -24,8 +24,9 @@ function createOversizedRequest() {
     },
     body: stream,
     // Node's Request type requires duplex when using a stream body
-    duplex: "half" as any,
-  })
+    duplex: "half",
+  }
+  const req = new Request("http://localhost", init)
   return { req, read: () => read }
 }
 

--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -24,10 +24,12 @@ describe("ServiceWorker aborts in-flight sync", () => {
 
   it("aborts fetch on unmount", async () => {
     let signal: AbortSignal | undefined
-    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
-      signal = options.signal
-      return new Promise(() => {})
-    })
+    ;(fetch as jest.Mock).mockImplementation(
+      (_url: string, options: { signal: AbortSignal }) => {
+        signal = options.signal
+        return new Promise(() => {})
+      }
+    )
 
     Object.defineProperty(navigator, "onLine", {
       value: true,
@@ -49,10 +51,12 @@ describe("ServiceWorker aborts in-flight sync", () => {
 
   it("aborts previous fetch when new sync starts", async () => {
     const signals: AbortSignal[] = []
-    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
-      signals.push(options.signal)
-      return new Promise(() => {})
-    })
+    ;(fetch as jest.Mock).mockImplementation(
+      (_url: string, options: { signal: AbortSignal }) => {
+        signals.push(options.signal)
+        return new Promise(() => {})
+      }
+    )
 
     Object.defineProperty(navigator, "onLine", {
       value: true,

--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -23,12 +23,13 @@ jest.mock("node:worker_threads", () => {
 })
 
 import { WorkerPool } from "../lib/worker-pool"
+import { EventEmitter } from "events"
 
 describe("WorkerPool", () => {
   it("continues processing after a worker crash", async () => {
     const pool = new WorkerPool<number | string, number>("fake", 1)
 
-    const fail = pool.run("crash" as any)
+    const fail = pool.run("crash")
     const success = pool.run(5)
 
     await expect(fail).rejects.toThrow("boom")
@@ -40,7 +41,7 @@ describe("WorkerPool", () => {
   it("does not reject when a worker exits normally", async () => {
     const pool = new WorkerPool<number | string, number>("fake", 1)
 
-    const promise = pool.run("exit" as any)
+    const promise = pool.run("exit")
     const timeout = new Promise(resolve => setTimeout(resolve, 10))
 
     await expect(Promise.race([promise, timeout])).resolves.toBeUndefined()
@@ -53,7 +54,7 @@ describe("WorkerPool", () => {
 
     for (let i = 0; i < 50; i++) {
       await pool.run(i)
-      const worker = (pool as any).workers[0]
+      const worker = (pool as unknown as { workers: EventEmitter[] }).workers[0]
       expect(worker.listenerCount("exit")).toBe(1)
     }
 


### PR DESCRIPTION
## Summary
- remove `any` casts in tests and replace with `unknown` or specific interfaces
- add explicit mock types for globals and Request duplex option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b24b5925a08331a96538da9ced9f95