### PR TITLE
Prefix unused variables and guard while loops

### DIFF
--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -18,8 +18,9 @@ jest.mock("@/lib/firebase", () => ({ db: {} }));
 jest.mock("firebase/firestore", () => {
   const store: { lastRun?: number } = {};
   return {
-    doc: (_db: any, _col: string, _id: string) => ({}),
-    runTransaction: jest.fn(async (_db: any, updateFn: any) => {
+    doc: () => ({}),
+    runTransaction: jest.fn(async (_: any, updateFn: any) => {
+      // eslint-disable-next-line no-constant-condition
       while (true) {
         let write: any;
         const lastBefore = store.lastRun;

--- a/src/__tests__/saveTransactions.integration.test.ts
+++ b/src/__tests__/saveTransactions.integration.test.ts
@@ -5,7 +5,7 @@ jest.mock("../lib/firebase", () => ({ db: {} }));
 
 const store = new Map<string, Transaction>();
 
-function mockCollection(_db: unknown, name: string) {
+function mockCollection(_: unknown, name: string) {
   return { name } as const;
 }
 
@@ -13,7 +13,7 @@ function mockDoc(col: { name: string }, id: string) {
   return { col: col.name, id };
 }
 
-function mockWriteBatch(_db: unknown) {
+function mockWriteBatch() {
   const ops: { ref: { id: string }; data: Transaction }[] = [];
   return {
     set(ref: { id: string }, data: Transaction) {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -11,15 +11,16 @@ export async function readBodyWithLimit(req: Request, limit: number) {
   const decoder = new TextDecoder()
   let total = 0
   let result = ""
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    if (value) {
-      total += value.length
+  let done = false
+  while (!done) {
+    const chunk = await reader.read()
+    done = chunk.done ?? false
+    if (!done && chunk.value) {
+      total += chunk.value.length
       if (total > limit) {
         return null
       }
-      result += decoder.decode(value, { stream: true })
+      result += decoder.decode(chunk.value, { stream: true })
     }
   }
   result += decoder.decode()

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -25,6 +25,7 @@ export async function archiveOldTransactions(cutoffDate: string): Promise<void> 
   const pageSize = 100;
   let lastDoc: QueryDocumentSnapshot<unknown> | undefined;
 
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     const q = lastDoc
       ? query(
@@ -66,6 +67,7 @@ export async function cleanupDebts(): Promise<void> {
   const pageSize = 100;
   let lastDoc: QueryDocumentSnapshot<unknown> | undefined;
 
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     const q = lastDoc
       ? query(
@@ -145,6 +147,7 @@ export async function backupData(
     const items: T[] = [];
     let lastDoc: QueryDocumentSnapshot<unknown> | undefined;
 
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       const q = lastDoc
         ? query(col, orderBy(orderField), startAfter(lastDoc), limit(pageSize))


### PR DESCRIPTION
## Summary
- remove unused parameters from firestore mocks and silence intentional loops in housekeeping tests
- simplify saveTransactions Firestore mocks by dropping unused db argument
- replace constant `while(true)` in HTTP helper with done-based loop
- annotate constant-condition loops in housekeeping service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b24aed488c8331910381f1ebeb7fe3