### PR TITLE
chore: remove any from tests

### DIFF
--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
 import React from 'react';
+import type { ComponentProps, PropsWithChildren } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { AddTransactionDialog } from '@/components/transactions/add-transaction-dialog';
 import { clearCategories } from '@/lib/categoryService';
@@ -12,25 +13,30 @@ jest.mock('@/hooks/use-toast', () => ({
 }));
 jest.mock('lucide-react', () => ({ PlusCircle: () => null }));
 jest.mock('@/components/ui/dialog', () => ({
-  Dialog: ({ children }: any) => <div>{children}</div>,
-  DialogTrigger: ({ children }: any) => <div>{children}</div>,
-  DialogContent: ({ children }: any) => <div>{children}</div>,
-  DialogDescription: ({ children }: any) => <div>{children}</div>,
-  DialogFooter: ({ children }: any) => <div>{children}</div>,
-  DialogHeader: ({ children }: any) => <div>{children}</div>,
-  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  Dialog: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogTrigger: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogDescription: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogFooter: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogHeader: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogTitle: ({ children }: PropsWithChildren) => <div>{children}</div>,
 }));
 jest.mock('@/components/ui/select', () => ({
-  Select: ({ children }: any) => <div>{children}</div>,
-  SelectContent: ({ children }: any) => <div>{children}</div>,
-  SelectItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-  SelectTrigger: ({ children }: any) => <div>{children}</div>,
-  SelectValue: ({ children }: any) => <div>{children}</div>,
+  Select: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectItem: ({ children, ...props }: ComponentProps<'div'>) => (
+    <div {...props}>{children}</div>
+  ),
+  SelectTrigger: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectValue: ({ children }: PropsWithChildren) => <div>{children}</div>,
 }));
 jest.mock('@/components/ui/switch', () => ({
-  Switch: ({ onCheckedChange, ...props }: any) => (
-    <input type="checkbox" onChange={onCheckedChange} {...props} />
-  ),
+  Switch: (
+    {
+      onCheckedChange,
+      ...props
+    }: { onCheckedChange: (checked: boolean) => void } & ComponentProps<'input'>
+  ) => <input type="checkbox" onChange={onCheckedChange} {...props} />,
 }));
 
 beforeEach(() => {

--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../components/auth/auth-provider';
+import type { User } from 'firebase/auth';
 
 let mockPathname = '/';
 const pushMock = jest.fn();
@@ -20,14 +21,18 @@ jest.mock('@/lib/firebase', () => ({
 }));
 const { auth: authStub } = require('@/lib/firebase');
 
-let mockUser: any = null;
-const onAuthStateChanged = jest.fn((_auth: unknown, cb: (u: any) => void) => {
-  cb(mockUser);
-  return () => {};
-});
+let mockUser: User | null = null;
+const onAuthStateChanged = jest.fn(
+  (_auth: unknown, cb: (u: User | null) => void) => {
+    cb(mockUser);
+    return () => {};
+  }
+);
 
 jest.mock('firebase/auth', () => ({
-  onAuthStateChanged: (...args: any[]) => (onAuthStateChanged as any)(...args),
+  onAuthStateChanged: (
+    ...args: Parameters<typeof onAuthStateChanged>
+  ) => onAuthStateChanged(...args),
 }));
 
 function DisplayUser() {
@@ -45,7 +50,7 @@ beforeEach(() => {
 
 test('redirects to dashboard when authenticated on "/" and updates context', async () => {
   mockPathname = '/';
-  mockUser = { uid: 'abc' } as any;
+  mockUser = { uid: 'abc' } as unknown as User;
 
   render(
     <AuthProvider>

--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -10,7 +10,7 @@ describe('currency code validation', () => {
       ok: true,
       json: async () => ({ rates: { EUR: 0.85 } }),
     });
-    (global as any).fetch = mockFetch;
+    (globalThis as unknown as { fetch: jest.Mock }).fetch = mockFetch;
 
     const rate = await getFxRate('usd', 'eur');
 
@@ -23,7 +23,7 @@ describe('currency code validation', () => {
 
   it('getFxRate throws on invalid code', async () => {
     const mockFetch = jest.fn();
-    (global as any).fetch = mockFetch;
+    (globalThis as unknown as { fetch: jest.Mock }).fetch = mockFetch;
 
     await expect(getFxRate('US', 'EUR')).rejects.toThrow('Invalid currency code');
     expect(mockFetch).not.toHaveBeenCalled();
@@ -34,7 +34,7 @@ describe('currency code validation', () => {
       ok: true,
       json: async () => ({ rates: { EUR: 0.5 } }),
     });
-    (global as any).fetch = mockFetch;
+    (globalThis as unknown as { fetch: jest.Mock }).fetch = mockFetch;
 
     const converted = await convertCurrency(10, 'usd', 'eur');
 
@@ -43,7 +43,7 @@ describe('currency code validation', () => {
 
   it('convertCurrency returns original amount for invalid codes', async () => {
     const mockFetch = jest.fn();
-    (global as any).fetch = mockFetch;
+    (globalThis as unknown as { fetch: jest.Mock }).fetch = mockFetch;
 
     const converted = await convertCurrency(10, 'u$', 'eur');
 

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -18,33 +18,44 @@ jest.mock("@/lib/firebase", () => ({ db: {} }));
 jest.mock("firebase/firestore", () => {
   const store: { lastRun?: number } = {};
   return {
-    doc: (_db: any, _col: string, _id: string) => ({}),
-    runTransaction: jest.fn(async (_db: any, updateFn: any) => {
-      while (true) {
-        let write: any;
-        const lastBefore = store.lastRun;
-        const tx = {
-          get: async () => ({
-            exists: () => store.lastRun !== undefined,
-            data: () => ({ lastRun: store.lastRun }),
-          }),
-          set: (_ref: any, data: any) => {
-            write = data;
-          },
-        };
-        const result = await updateFn(tx);
-        if (write && lastBefore !== store.lastRun) {
-          // retry due to concurrent modification
-          continue;
+    doc: (_db: unknown, _col: string, _id: string) => ({}),
+    runTransaction: jest.fn(
+      async (
+        _db: unknown,
+        updateFn: (tx: {
+          get: () => Promise<{
+            exists: () => boolean
+            data: () => { lastRun?: number }
+          }>
+          set: (_ref: unknown, data: { lastRun: number }) => void
+        }) => unknown
+      ) => {
+        while (true) {
+          let write: { lastRun: number } | undefined
+          const lastBefore = store.lastRun
+          const tx = {
+            get: async () => ({
+              exists: () => store.lastRun !== undefined,
+              data: () => ({ lastRun: store.lastRun }),
+            }),
+            set: (_ref: unknown, data: { lastRun: number }) => {
+              write = data
+            },
+          }
+          const result = await updateFn(tx)
+          if (write && lastBefore !== store.lastRun) {
+            // retry due to concurrent modification
+            continue
+          }
+          if (write) {
+            store.lastRun = write.lastRun
+          }
+          return result
         }
-        if (write) {
-          store.lastRun = write.lastRun;
-        }
-        return result;
       }
-    }),
-    setDoc: jest.fn(async (_ref: any, data: any) => {
-      store.lastRun = data.lastRun;
+    ),
+    setDoc: jest.fn(async (_ref: unknown, data: { lastRun: number }) => {
+      store.lastRun = data.lastRun
     }),
     __store: store,
   };

--- a/src/__tests__/internet-time.test.ts
+++ b/src/__tests__/internet-time.test.ts
@@ -8,7 +8,7 @@ describe("internet time", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     __resetInternetTimeOffset();
-    (global as any).fetch = jest.fn();
+    (globalThis as unknown as { fetch: jest.Mock }).fetch = jest.fn();
     delete process.env.DEFAULT_TZ;
   });
 
@@ -76,7 +76,7 @@ describe("internet time", () => {
         new Promise((_resolve, reject) => {
           opts.signal.addEventListener("abort", () => {
             const err = new Error("aborted");
-            (err as any).name = "AbortError";
+            err.name = "AbortError";
             reject(err);
           });
         })

--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -39,11 +39,11 @@ import * as offline from "../lib/offline"
 import React from "react"
 
 beforeAll(() => {
-  ;(global as any).indexedDB = {}
+  (globalThis as unknown as { indexedDB: unknown }).indexedDB = {}
 })
 
 afterAll(() => {
-  delete (global as any).indexedDB
+  delete (globalThis as unknown as { indexedDB?: unknown }).indexedDB
 })
 
 describe("offline fallbacks", () => {
@@ -79,7 +79,7 @@ describe("ServiceWorker", () => {
       .mockResolvedValueOnce(null)
 
     const fetchMock = jest.fn()
-    ;(global as any).fetch = fetchMock
+    ;(globalThis as unknown as { fetch: jest.Mock }).fetch = fetchMock
 
     render(React.createElement(ServiceWorker))
 
@@ -91,6 +91,6 @@ describe("ServiceWorker", () => {
     expect(fetchMock).not.toHaveBeenCalled()
 
     jest.useRealTimers()
-    delete (global as any).fetch
+    delete (globalThis as unknown as { fetch?: unknown }).fetch
   })
 })

--- a/src/__tests__/payload-size-limit.test.ts
+++ b/src/__tests__/payload-size-limit.test.ts
@@ -16,7 +16,7 @@ function createOversizedRequest() {
       this.push(null)
     },
   })
-  const req = new Request("http://localhost", {
+  const init: RequestInit & { duplex: "half" } = {
     method: "POST",
     headers: {
       Authorization: "Bearer test-token",
@@ -24,8 +24,9 @@ function createOversizedRequest() {
     },
     body: stream,
     // Node's Request type requires duplex when using a stream body
-    duplex: "half" as any,
-  })
+    duplex: "half",
+  }
+  const req = new Request("http://localhost", init)
   return { req, read: () => read }
 }
 

--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -24,10 +24,12 @@ describe("ServiceWorker aborts in-flight sync", () => {
 
   it("aborts fetch on unmount", async () => {
     let signal: AbortSignal | undefined
-    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
-      signal = options.signal
-      return new Promise(() => {})
-    })
+    ;(fetch as jest.Mock).mockImplementation(
+      (_url: string, options: RequestInit) => {
+        signal = options.signal as AbortSignal
+        return new Promise(() => {})
+      }
+    )
 
     Object.defineProperty(navigator, "onLine", {
       value: true,
@@ -49,10 +51,12 @@ describe("ServiceWorker aborts in-flight sync", () => {
 
   it("aborts previous fetch when new sync starts", async () => {
     const signals: AbortSignal[] = []
-    ;(fetch as jest.Mock).mockImplementation((_url, options: any) => {
-      signals.push(options.signal)
-      return new Promise(() => {})
-    })
+    ;(fetch as jest.Mock).mockImplementation(
+      (_url: string, options: RequestInit) => {
+        signals.push(options.signal as AbortSignal)
+        return new Promise(() => {})
+      }
+    )
 
     Object.defineProperty(navigator, "onLine", {
       value: true,

--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -28,7 +28,7 @@ describe("WorkerPool", () => {
   it("continues processing after a worker crash", async () => {
     const pool = new WorkerPool<number | string, number>("fake", 1)
 
-    const fail = pool.run("crash" as any)
+    const fail = pool.run("crash")
     const success = pool.run(5)
 
     await expect(fail).rejects.toThrow("boom")
@@ -40,7 +40,7 @@ describe("WorkerPool", () => {
   it("does not reject when a worker exits normally", async () => {
     const pool = new WorkerPool<number | string, number>("fake", 1)
 
-    const promise = pool.run("exit" as any)
+    const promise = pool.run("exit")
     const timeout = new Promise(resolve => setTimeout(resolve, 10))
 
     await expect(Promise.race([promise, timeout])).resolves.toBeUndefined()
@@ -53,7 +53,11 @@ describe("WorkerPool", () => {
 
     for (let i = 0; i < 50; i++) {
       await pool.run(i)
-      const worker = (pool as any).workers[0]
+      const worker = (
+        pool as unknown as {
+          workers: Array<{ listenerCount: (event: string) => number }>
+        }
+      ).workers[0]
       expect(worker.listenerCount("exit")).toBe(1)
     }
 


### PR DESCRIPTION
## Summary
- replace `any` test mocks with explicit types
- use typed globals for fetch and indexedDB in tests
- clean up worker pool and request mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b24ad3e7448331ba81c35feb3921a3