### PR TITLE
chore: remove explicit any from tests

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../components/auth/auth-provider';
-import { auth as authStub } from '@/lib/firebase';
 
 let mockPathname = '/';
 const pushMock = jest.fn();


### PR DESCRIPTION
## Summary
- remove duplicate Firebase auth import in auth-provider test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28a53fac8833199e314d22cc074d3