### PR TITLE
fix: remove duplicate authStub import

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -19,7 +19,6 @@ jest.mock('@/lib/firebase', () => ({
     app: { options: { apiKey: 'test' }, name: '[DEFAULT]' },
   },
 }));
-import { auth as authStub } from '@/lib/firebase';
 
 interface MockUser {
   uid: string;


### PR DESCRIPTION
## Summary
- remove duplicate authStub import in auth-provider test to avoid redeclaration error

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28a46f5d88331bec3eb29c52f88b5