### PR TITLE
refactor: call server action for category suggestion

### DIFF
--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -27,6 +27,7 @@ import { useToast } from "@/hooks/use-toast";
 import { addCategory, getCategories } from "@/lib/categoryService";
 import { recordCategoryFeedback } from "@/lib/category-feedback";
 import { logger } from "@/lib/logger";
+import { suggestCategoryAction } from "@/app/actions";
 
 interface AddTransactionDialogProps {
   onSave: (transaction: Omit<Transaction, "id" | "date">) => void;
@@ -67,14 +68,13 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
     let active = true;
     const fetchSuggestion = async () => {
       try {
-        const { suggestCategory } = await import("@/ai/flows/suggest-category");
-        const res = await suggestCategory({ description });
+        const category = await suggestCategoryAction(description);
         if (active) {
-          setSuggestedCategory(res.category);
+          setSuggestedCategory(category);
           if (!userModifiedCategory.current) {
-            setCategory(res.category);
+            setCategory(category);
           }
-          setCategories(addCategory(res.category));
+          setCategories(addCategory(category));
         }
       } catch (error) {
         logger.error("Failed to suggest category", error);


### PR DESCRIPTION
## Summary
- avoid client-side import of server-only flow
- fetch category suggestions via server action

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b28a23ffc08331814f0e8d4e4f3962