### PR TITLE
Improve error typing in internet-time module

### DIFF
--- a/src/lib/internet-time.ts
+++ b/src/lib/internet-time.ts
@@ -17,9 +17,9 @@ export async function fetchInternetTime(tz: string): Promise<Date> {
     res = await fetch(`https://worldtimeapi.org/api/timezone/${tz}`, {
       signal: controller.signal,
     });
-  } catch (err: any) {
+  } catch (err: unknown) {
     clearTimeout(timeout);
-    if (err?.name === "AbortError") {
+    if (err instanceof Error && err.name === "AbortError") {
       throw new Error(`Request to worldtimeapi.org timed out`);
     }
     throw err;


### PR DESCRIPTION
## Summary
- treat caught errors as unknown in `fetchInternetTime`
- narrow errors with `instanceof` before accessing properties

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28d22c7588331a215a50f1575741f