### PR TITLE
refactor validation test types

### DIFF
--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,7 +1,18 @@
-function setupSuccessMocks(output: any) {
+interface Schema<T = unknown> {
+  parse: (value: unknown) => T;
+}
+
+interface FlowConfig<I = unknown, O = unknown> {
+  inputSchema: Schema<I>;
+  outputSchema: Schema<O>;
+}
+
+type FlowHandler<I = unknown, O = unknown> = (input: I) => O | Promise<O>;
+
+function setupSuccessMocks<O>(output: O) {
   const definePromptMock = jest.fn().mockReturnValue(async () => ({ output }));
-  const defineFlowMock = jest.fn((config: any, handler: any) => {
-    return async (input: any) => {
+  const defineFlowMock = jest.fn(<I>(config: FlowConfig<I, O>, handler: FlowHandler<I, O>) => {
+    return async (input: unknown): Promise<O> => {
       const parsedInput = config.inputSchema.parse(input);
       const result = await handler(parsedInput);
       return config.outputSchema.parse(result);


### PR DESCRIPTION
## Summary
- remove any types in validation.test.ts by introducing Schema, FlowConfig, and FlowHandler interfaces
- mock flow utilities with type-safe generics

## Testing
- `npm test -- src/ai/flows/__tests__/validation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b28d244c348331a5e1d6ae10aed881