### PR TITLE
refactor: allow console.info in logger

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,8 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "next/core-web-vitals"]
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "next/core-web-vitals"],
+  "rules": {
+    "no-console": ["error", { "allow": ["info", "warn", "error"] }]
+  }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,7 +1,7 @@
 export const logger = {
   info: (message: string, ...args: unknown[]) => {
     if (process.env.NODE_ENV !== "production") {
-      console.log(message, ...args);
+      console.info(message, ...args);
     }
   },
   error: (message: string, ...args: unknown[]) => {


### PR DESCRIPTION
## Summary
- use `console.info` in logger to avoid no-console
- allow `info`, `warn` and `error` in ESLint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28d2502f883319b050e030ef88488