### PR TITLE
refactor: type genkit flow mocks

### DIFF
--- a/src/ai/flows/__tests__/no-output.test.ts
+++ b/src/ai/flows/__tests__/no-output.test.ts
@@ -1,7 +1,24 @@
+import type { ZodType } from 'zod';
+
+interface FlowConfig<I, O> {
+  name: string;
+  inputSchema: ZodType<I>;
+  outputSchema: ZodType<O>;
+}
+
+type FlowHandler<I, O> = (input: I) => Promise<O>;
+
 function setupNoOutputMocks() {
-  const definePromptMock = jest.fn().mockReturnValue(async () => ({ output: undefined }));
-  const defineFlowMock = jest.fn((_config: any, handler: any) => handler);
-  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+  const definePromptMock = jest
+    .fn()
+    .mockReturnValue(async () => ({ output: undefined }));
+  const defineFlowMock = jest.fn(
+    <I, O>(_config: FlowConfig<I, O>, handler: FlowHandler<I, O>) => handler
+  );
+  jest.doMock('@/ai/genkit', () => ({
+    ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock },
+  }));
+  return { definePromptMock, defineFlowMock };
 }
 
 describe('calculateCashflowFlow', () => {


### PR DESCRIPTION
## Summary
- use typed FlowConfig and FlowHandler interfaces in no-output tests
- return typed mocks from `setupNoOutputMocks`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28d239500833196e73f7550e3459b