### PR TITLE
refactor: narrow internet time error

### DIFF
--- a/src/lib/internet-time.ts
+++ b/src/lib/internet-time.ts
@@ -17,9 +17,9 @@ export async function fetchInternetTime(tz: string): Promise<Date> {
     res = await fetch(`https://worldtimeapi.org/api/timezone/${tz}`, {
       signal: controller.signal,
     });
-  } catch (err: any) {
+  } catch (err: unknown) {
     clearTimeout(timeout);
-    if (err?.name === "AbortError") {
+    if (err instanceof Error && err.name === "AbortError") {
       throw new Error(`Request to worldtimeapi.org timed out`);
     }
     throw err;


### PR DESCRIPTION
## Summary
- type internet time fetch errors as `unknown`
- handle `AbortError` with `instanceof Error`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28de9d23c8331a58642ebf5c8fe2b