### PR TITLE
chore: remove broad eslint ignores and fix lint warnings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,1 @@
-src/ai
-src/app
-src/components
-src/hooks
-src/lib
-tailwind.config.ts
+# All directories are linted; add ignore patterns below as needed.

--- a/src/ai/flows/__tests__/no-output.test.ts
+++ b/src/ai/flows/__tests__/no-output.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 function setupNoOutputMocks() {
   const definePromptMock = jest.fn().mockReturnValue(async () => ({ output: undefined }));
   const defineFlowMock = jest.fn((_config: any, handler: any) => handler);

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 function setupSuccessMocks(output: any) {
   const definePromptMock = jest.fn().mockReturnValue(async () => ({ output }));
   const defineFlowMock = jest.fn((config: any, handler: any) => {

--- a/src/app/cashflow/page.tsx
+++ b/src/app/cashflow/page.tsx
@@ -81,8 +81,8 @@ export default function CashflowPage() {
             weeklyPremiumPay += shift.premiumPay || 0;
         });
 
-        let regularHours = Math.min(weeklyHours, 40);
-        let overtimeHours = Math.max(0, weeklyHours - 40);
+        const regularHours = Math.min(weeklyHours, 40);
+        const overtimeHours = Math.max(0, weeklyHours - 40);
         totalMonthlyHours += weeklyHours;
         totalMonthlyOvertimeHours += overtimeHours;
         
@@ -171,7 +171,8 @@ export default function CashflowPage() {
           setShifts([...shifts, newShift]);
       }
       
-      const { date, ...shiftDetails } = newShift;
+      const { date: unusedDate, ...shiftDetails } = newShift;
+      void unusedDate;
       setLastEnteredShift(shiftDetails);
   }
   

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -37,7 +37,7 @@ export default async function DashboardPage() {
     <div className="space-y-6">
       <div className="space-y-1">
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-        <p className="text-muted-foreground">Here's a high-level overview of your finances.</p>
+          <p className="text-muted-foreground">Here&apos;s a high-level overview of your finances.</p>
       </div>
       <div className="grid gap-6 sm:grid-cols-2">
         <TimeCard />

--- a/src/app/debts/page.tsx
+++ b/src/app/debts/page.tsx
@@ -107,7 +107,7 @@ export default function DebtsPage() {
                 ))}
             </div>
           ) : (
-             <p className="text-muted-foreground">You haven't added any debts yet. Add one in the calendar to get started.</p>
+               <p className="text-muted-foreground">You haven&apos;t added any debts yet. Add one in the calendar to get started.</p>
           )}
       </div>
     </div>

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -80,7 +80,10 @@ export default function TransactionsPage() {
 
   const handleDownload = () => {
     downloadCsv(
-      transactions.map(({ id, ...rest }) => rest),
+        transactions.map(({ id, ...rest }) => {
+          void id;
+          return rest;
+        }),
       "transactions.csv"
     );
   };

--- a/src/app/transactions/scan/page.tsx
+++ b/src/app/transactions/scan/page.tsx
@@ -9,8 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
-import { Loader2, Camera, Upload, Sparkles, Wand2 } from "lucide-react"
+import { Loader2, Camera, Sparkles, Wand2 } from "lucide-react"
 import Image from "next/image"
 
 export default function ScanReceiptPage() {
@@ -24,15 +23,16 @@ export default function ScanReceiptPage() {
   const videoRef = useRef<HTMLVideoElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
-  useEffect(() => {
-    return () => {
-      // Stop camera stream when component unmounts
-      if (videoRef.current && videoRef.current.srcObject) {
-        const stream = videoRef.current.srcObject as MediaStream;
-        stream.getTracks().forEach(track => track.stop());
-      }
-    };
-  }, []);
+    useEffect(() => {
+      const videoElement = videoRef.current;
+      return () => {
+        // Stop camera stream when component unmounts
+        if (videoElement && videoElement.srcObject) {
+          const stream = videoElement.srcObject as MediaStream;
+          stream.getTracks().forEach(track => track.stop());
+        }
+      };
+    }, []);
 
   const requestCamera = async () => {
       if (hasCameraPermission) {

--- a/src/components/debts/DebtCalendar.tsx
+++ b/src/components/debts/DebtCalendar.tsx
@@ -35,7 +35,7 @@ export default function DebtCalendar({ onChange, startOn = 0 }: DebtCalendarProp
   const { debts, addOrUpdateDebt, deleteDebt, markPaid, unmarkPaid } = useDebts();
   useEffect(() => { onChange?.(debts); }, [debts, onChange]);
 
-  const today = new Date();
+    const today = useMemo(() => new Date(), []);
   const [cursor, setCursor] = useState<Date>(new Date(today.getFullYear(), today.getMonth(), 1));
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [activeDebt, setActiveDebt] = useState<Debt | null>(null);

--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -75,7 +75,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
         }
         fetchSuggestion()
         return () => { active = false }
-    }, [description])
+      }, [description, toast])
 
     const handleSave = () => {
         const numericAmount = Number(amount)
@@ -120,7 +120,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
         <DialogHeader>
           <DialogTitle>Add New Transaction</DialogTitle>
           <DialogDescription>
-            Enter the details of your transaction below. Click save when you're done.
+              Enter the details of your transaction below. Click save when you&apos;re done.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -54,10 +54,10 @@ function Calendar({
         day_hidden: "invisible",
         ...classNames,
       }}
-      components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
-      }}
+        components={{
+          IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+          IconRight: () => <ChevronRight className="h-4 w-4" />,
+        }}
       {...props}
     />
   )

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -18,12 +18,12 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
-} as const
+enum ActionType {
+  ADD_TOAST = "ADD_TOAST",
+  UPDATE_TOAST = "UPDATE_TOAST",
+  DISMISS_TOAST = "DISMISS_TOAST",
+  REMOVE_TOAST = "REMOVE_TOAST",
+}
 
 let count = 0
 
@@ -32,23 +32,21 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
-
 type Action =
   | {
-      type: ActionType["ADD_TOAST"]
+      type: ActionType.ADD_TOAST
       toast: ToasterToast
     }
   | {
-      type: ActionType["UPDATE_TOAST"]
+      type: ActionType.UPDATE_TOAST
       toast: Partial<ToasterToast>
     }
   | {
-      type: ActionType["DISMISS_TOAST"]
+      type: ActionType.DISMISS_TOAST
       toastId?: ToasterToast["id"]
     }
   | {
-      type: ActionType["REMOVE_TOAST"]
+      type: ActionType.REMOVE_TOAST
       toastId?: ToasterToast["id"]
     }
 
@@ -66,7 +64,7 @@ const addToRemoveQueue = (toastId: string) => {
   const timeout = setTimeout(() => {
     toastTimeouts.delete(toastId)
     dispatch({
-      type: "REMOVE_TOAST",
+      type: ActionType.REMOVE_TOAST,
       toastId: toastId,
     })
   }, TOAST_REMOVE_DELAY)
@@ -76,13 +74,13 @@ const addToRemoveQueue = (toastId: string) => {
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case "ADD_TOAST":
+    case ActionType.ADD_TOAST:
       return {
         ...state,
         toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
       }
 
-    case "UPDATE_TOAST":
+    case ActionType.UPDATE_TOAST:
       return {
         ...state,
         toasts: state.toasts.map((t) =>
@@ -90,7 +88,7 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
 
-    case "DISMISS_TOAST": {
+    case ActionType.DISMISS_TOAST: {
       const { toastId } = action
 
       // ! Side effects ! - This could be extracted into a dismissToast() action,
@@ -115,7 +113,7 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
     }
-    case "REMOVE_TOAST":
+    case ActionType.REMOVE_TOAST:
       if (action.toastId === undefined) {
         return {
           ...state,
@@ -149,15 +147,15 @@ function toast({ ...props }: Toast) {
   const id = genId()
 
   const update = (props: ToasterToast) =>
-    dispatch({
-      type: "UPDATE_TOAST",
-      toast: { ...props, id },
-    })
-  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+      dispatch({
+        type: ActionType.UPDATE_TOAST,
+        toast: { ...props, id },
+      })
+    const dismiss = () => dispatch({ type: ActionType.DISMISS_TOAST, toastId: id })
 
-  dispatch({
-    type: "ADD_TOAST",
-    toast: {
+    dispatch({
+      type: ActionType.ADD_TOAST,
+      toast: {
       ...props,
       id,
       open: true,
@@ -187,7 +185,7 @@ function useToast() {
   return {
     ...state,
     toast,
-    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+    dismiss: (toastId?: string) => dispatch({ type: ActionType.DISMISS_TOAST, toastId }),
   }
 }
 

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -16,7 +16,7 @@ const hasLocalStorage = () =>
 
 const normalize = (value: string) => value.trim().toLowerCase();
 
-const isValidKey = (key: string) => key.length > 0 && !/[\/\*\[\]]/.test(key);
+const isValidKey = (key: string) => key.length > 0 && !/[/*[\]]/.test(key);
 
 function load(): string[] {
   if (hasLocalStorage()) {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -11,9 +11,9 @@ export async function readBodyWithLimit(req: Request, limit: number) {
   const decoder = new TextDecoder()
   let total = 0
   let result = ""
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
+  for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
     if (value) {
       total += value.length
       if (total > limit) {

--- a/src/lib/internet-time.ts
+++ b/src/lib/internet-time.ts
@@ -17,13 +17,13 @@ export async function fetchInternetTime(tz: string): Promise<Date> {
     res = await fetch(`https://worldtimeapi.org/api/timezone/${tz}`, {
       signal: controller.signal,
     });
-  } catch (err: any) {
-    clearTimeout(timeout);
-    if (err?.name === "AbortError") {
-      throw new Error(`Request to worldtimeapi.org timed out`);
+    } catch (err: unknown) {
+      clearTimeout(timeout);
+      if ((err as { name?: string })?.name === "AbortError") {
+        throw new Error(`Request to worldtimeapi.org timed out`);
+      }
+      throw err;
     }
-    throw err;
-  }
   clearTimeout(timeout);
   if (!res.ok) {
     let body: string;


### PR DESCRIPTION
## Summary
- remove broad `.eslintignore` entries so src files are linted
- fix lint errors across app, hooks, components, and libs
- replace toast action string constants with an enum

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b28de493a0833193a2ae5b81260095