### PR TITLE
fix: log errors in production

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -5,8 +5,6 @@ export const logger = {
     }
   },
   error: (message: string, ...args: unknown[]) => {
-    if (process.env.NODE_ENV !== "production") {
-      console.error(message, ...args);
-    }
+    console.error(message, ...args);
   },
 };


### PR DESCRIPTION
## Summary
- ensure `logger.error` writes to console in all environments so housekeeping retries remain visible

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b28e628d8c8331a38b1fa917b1e07b