### PR TITLE
refactor: use logger for housekeeping errors

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -5,8 +5,6 @@ export const logger = {
     }
   },
   error: (message: string, ...args: unknown[]) => {
-    if (process.env.NODE_ENV !== "production") {
-      console.error(message, ...args);
-    }
+    console.error(message, ...args);
   },
 };


### PR DESCRIPTION
## Summary
- replace console.error with logger.error in housekeeping runWithRetry
- ensure logger.error logs in production

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b28e7b638883319f3011d254053f57