### PR TITLE
fix: resolve AI flow test conflicts

### DIFF
--- a/src/ai/flows/__tests__/no-output.test.ts
+++ b/src/ai/flows/__tests__/no-output.test.ts
@@ -17,7 +17,7 @@ describe('calculateCashflowFlow', () => {
         estimatedAnnualTaxes: 10000,
         totalMonthlyDeductions: 2000,
       })
-    ).rejects.toThrow('No output returned from calculateCashflowFlow');
+    ).rejects.toThrow(/No output returned/);
   });
 });
 
@@ -26,9 +26,18 @@ describe('suggestDebtStrategyFlow', () => {
     jest.resetModules();
     setupNoOutputMocks();
     const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
+    await expect(suggestDebtStrategy({ debts: [] })).rejects.toThrow(/No output returned/);
+  });
+});
+
+describe('suggestCategoryFlow', () => {
+  it('throws an error when prompt returns no output', async () => {
+    jest.resetModules();
+    setupNoOutputMocks();
+    const { suggestCategory } = await import('@/ai/flows/suggest-category');
     await expect(
-      suggestDebtStrategy({ debts: [] })
-    ).rejects.toThrow('No output returned from suggestDebtStrategyFlow');
+      suggestCategory({ description: 'Coffee shop latte' })
+    ).rejects.toThrow(/No output returned/);
   });
 });
 

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -94,3 +94,19 @@ describe('suggestDebtStrategy validation', () => {
     ).rejects.toThrow();
   });
 });
+
+describe('calculateCostOfLiving validation', () => {
+  it('rejects non-positive adult count', () => {
+    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
+    expect(() =>
+      calculateCostOfLiving({ region: 'California', adults: 0, children: 0 })
+    ).toThrow();
+  });
+
+  it('rejects unknown region', () => {
+    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
+    expect(() =>
+      calculateCostOfLiving({ region: 'Atlantis', adults: 1, children: 0 } as any)
+    ).toThrow('Unknown region');
+  });
+});


### PR DESCRIPTION
## Summary
- broaden AI flow no-output coverage and error assertions
- add validation tests for cost-of-living inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28fc00db48331bd6664702a75d6e1