### PR TITLE
Enable linting for src directories

### DIFF
--- a/src/ai/flows/__tests__/no-output.test.ts
+++ b/src/ai/flows/__tests__/no-output.test.ts
@@ -1,9 +1,11 @@
 function setupNoOutputMocks() {
-  const definePromptMock = jest.fn().mockReturnValue(async () => ({ output: undefined }));
+  const definePromptMock = jest.fn(() => async () => ({ output: undefined }));
   const defineFlowMock = jest.fn(
     (_config: unknown, handler: (...args: unknown[]) => unknown) => handler
   );
-  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+  jest.doMock('@/ai/genkit', () => ({
+    ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock },
+  }));
 }
 
 describe('calculateCashflowFlow', () => {

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,5 +1,5 @@
 function setupSuccessMocks(output: unknown) {
-  const definePromptMock = jest.fn().mockReturnValue(async () => ({ output }));
+  const definePromptMock = jest.fn(() => async () => ({ output }));
   const defineFlowMock = jest.fn(
     (config: unknown, handler: (parsed: unknown) => unknown) => {
       return async (input: unknown) => {
@@ -13,7 +13,9 @@ function setupSuccessMocks(output: unknown) {
       };
     }
   );
-  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+  jest.doMock('@/ai/genkit', () => ({
+    ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock },
+  }));
 }
 
 describe('calculateCashflow validation', () => {

--- a/src/lib/internet-time.ts
+++ b/src/lib/internet-time.ts
@@ -18,12 +18,12 @@ export async function fetchInternetTime(tz: string): Promise<Date> {
       signal: controller.signal,
     });
   } catch (err: unknown) {
-      clearTimeout(timeout);
-      if ((err as { name?: string })?.name === "AbortError") {
-        throw new Error(`Request to worldtimeapi.org timed out`);
-      }
-      throw err;
+    clearTimeout(timeout);
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error(`Request to worldtimeapi.org timed out`);
     }
+    throw err;
+  }
   clearTimeout(timeout);
   if (!res.ok) {
     let body: string;


### PR DESCRIPTION
## Summary
- stop ignoring src directories in ESLint
- fix new lint errors across app, components, hooks, and libraries
- update flow tests to mock Genkit prompts as async functions
- improve internet time fetch error handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28fde1eb48331bf414382d3886e6f