### PR TITLE
chore: enable linting for src

### DIFF
--- a/src/ai/flows/__tests__/no-output.test.ts
+++ b/src/ai/flows/__tests__/no-output.test.ts
@@ -32,3 +32,25 @@ describe('suggestDebtStrategyFlow', () => {
   });
 });
 
+describe('analyzeSpendingHabitsFlow', () => {
+  it('throws an error when prompt returns no output', async () => {
+    jest.resetModules();
+    setupNoOutputMocks();
+    const { analyzeSpendingHabits } = await import('@/ai/flows/analyze-spending-habits');
+    await expect(
+      analyzeSpendingHabits({ financialDocuments: [], userDescription: '', goals: [] })
+    ).rejects.toThrow('No output returned from analyzeSpendingHabitsPrompt');
+  });
+});
+
+describe('spendingForecastFlow', () => {
+  it('throws an error when prompt returns no output', async () => {
+    jest.resetModules();
+    setupNoOutputMocks();
+    const { predictSpending } = await import('@/ai/flows/spendingForecast');
+    await expect(
+      predictSpending({ transactions: [] })
+    ).rejects.toThrow('No output returned from spendingForecastPrompt');
+  });
+});
+

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -94,3 +94,37 @@ describe('suggestDebtStrategy validation', () => {
     ).rejects.toThrow();
   });
 });
+
+describe('analyzeSpendingHabits validation', () => {
+  it('rejects invalid financial document format', async () => {
+    jest.resetModules();
+    setupSuccessMocks({
+      spendingAnalysis: '',
+      savingsOpportunities: '',
+      recommendations: '',
+    });
+    const { analyzeSpendingHabits } = await import('@/ai/flows/analyze-spending-habits');
+    await expect(
+      analyzeSpendingHabits({
+        financialDocuments: ['invalid-data'],
+        userDescription: '',
+        goals: [],
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe('spendingForecast validation', () => {
+  it('rejects invalid transaction data', async () => {
+    jest.resetModules();
+    setupSuccessMocks({ forecast: [], analysis: '' });
+    const { predictSpending } = await import('@/ai/flows/spendingForecast');
+    await expect(
+      predictSpending({
+        transactions: [
+          { date: 'not-a-date', amount: -10, category: 'food' },
+        ],
+      })
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- stop ignoring source directories in ESLint
- clean up lint issues across app, components, hooks and lib
- cover additional AI flow tests to resolve merge conflicts

## Testing
- `npm run lint`
- `npm test src/ai/flows/__tests__/no-output.test.ts src/ai/flows/__tests__/validation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b28fed941483319a751ac3588ea7c1