### PR TITLE
chore: type cost-of-living script and allow console

### DIFF
--- a/.github/workflows/auto-label-automerge.yml
+++ b/.github/workflows/auto-label-automerge.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
+permissions:
+  pull-requests: write
+
 jobs:
   auto-label-automerge:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled, ready_for_review]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add RegionCost type and use it for cost-of-living regions map
- allow console usage in scripts via ESLint override
- grant required permissions to auto-label and PR automation workflows

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b29019a8f48331beb7037e274617ef