### PR TITLE
Switch toast IDs to UUID

### DIFF
--- a/src/__tests__/use-toast.test.tsx
+++ b/src/__tests__/use-toast.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { render, act } from "@testing-library/react";
+
+describe("useToast with UUID ids", () => {
+  let captured: any;
+  let originalCrypto: any;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalCrypto = global.crypto;
+    Object.defineProperty(global, "crypto", {
+      value: { randomUUID: () => "test-uuid" },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    Object.defineProperty(global, "crypto", {
+      value: originalCrypto,
+      configurable: true,
+    });
+  });
+
+  it("adds, updates, and dismisses toasts using string ids", () => {
+    const { toast, useToast } = require("../hooks/use-toast");
+
+    const TestComponent = () => {
+      const state = useToast();
+      React.useEffect(() => {
+        captured = state;
+      }, [state]);
+      return null;
+    };
+
+    render(<TestComponent />);
+
+    let controller: any;
+    act(() => {
+      controller = toast({ title: "Hello" });
+    });
+
+    expect(captured.toasts).toHaveLength(1);
+    expect(captured.toasts[0].id).toBe("test-uuid");
+
+    act(() => {
+      controller.update({ title: "Updated" });
+    });
+    expect(captured.toasts[0].title).toBe("Updated");
+
+    act(() => {
+      controller.dismiss();
+    });
+    expect(captured.toasts[0].open).toBe(false);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(captured.toasts).toHaveLength(0);
+  });
+});

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -25,11 +25,8 @@ const actionTypes = {
   REMOVE_TOAST: "REMOVE_TOAST",
 } as const
 
-let count = 0
-
 function genId() {
-  count = (count + 1) % Number.MAX_SAFE_INTEGER
-  return count.toString()
+  return crypto.randomUUID()
 }
 
 type ActionType = typeof actionTypes


### PR DESCRIPTION
## Summary
- generate toast IDs with `crypto.randomUUID`
- verify toast add/update/dismiss works with string IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2906a333c8331b74b487c3c7a2189