### PR TITLE
Validate chunk size in chunkTransactions

### DIFF
--- a/src/__tests__/chunkTransactions.test.ts
+++ b/src/__tests__/chunkTransactions.test.ts
@@ -1,0 +1,9 @@
+import { chunkTransactions } from "../lib/transactions";
+
+describe("chunkTransactions", () => {
+  it.each([0, -1])("throws for non-positive chunkSize %i", (size) => {
+    expect(() => chunkTransactions([1, 2], size)).toThrow(
+      /chunkSize must be greater than 0/
+    );
+  });
+});

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -53,6 +53,9 @@ export function chunkTransactions<T>(
   transactions: T[],
   chunkSize = 500
 ): T[][] {
+  if (chunkSize <= 0) {
+    throw new Error("chunkSize must be greater than 0");
+  }
   const chunks: T[][] = [];
   for (let i = 0; i < transactions.length; i += chunkSize) {
     chunks.push(transactions.slice(i, i + chunkSize));


### PR DESCRIPTION
## Summary
- throw when chunkTransactions receives a non-positive chunk size
- add unit test confirming chunk size validation

## Testing
- `npm test src/__tests__/chunkTransactions.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2906e71d88331a7a02f66ef87544f