### PR TITLE
feat: persist synced transactions

### DIFF
--- a/src/__tests__/transactions-sync-route.test.ts
+++ b/src/__tests__/transactions-sync-route.test.ts
@@ -71,7 +71,7 @@ describe("/api/transactions/sync persistence", () => {
     })
 
     const res = await POST(req)
-    expect(res.status).toBe(207)
+    expect(res.status).toBe(500)
     const data = await res.json()
     expect(mockSetDoc).toHaveBeenCalledTimes(transactions.length)
     expect(data.saved).toEqual(["1"])

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -71,7 +71,7 @@ export async function POST(req: Request) {
     })
 
     if (errors.length > 0) {
-      return NextResponse.json({ saved, errors }, { status: 207 })
+      return NextResponse.json({ saved, errors }, { status: 500 })
     }
 
     return NextResponse.json({ saved })


### PR DESCRIPTION
## Summary
- persist transactions in /api/transactions/sync using Firestore
- return saved IDs and any per-transaction errors
- add unit tests for successful and failing transaction writes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29075a718833193912d8d24be7f7e