### PR TITLE
Handle category feedback errors in AddTransactionDialog

### DIFF
--- a/src/components/transactions/add-transaction-dialog.tsx
+++ b/src/components/transactions/add-transaction-dialog.tsx
@@ -77,7 +77,7 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
         return () => { active = false }
     }, [description])
 
-    const handleSave = () => {
+    const handleSave = async () => {
         const numericAmount = Number(amount)
 
         if (!description || !amount || !type || !category || !Number.isFinite(numericAmount)) {
@@ -94,7 +94,19 @@ export function AddTransactionDialog({ onSave }: AddTransactionDialogProps) {
             isRecurring
         })
         if(suggestedCategory && category !== suggestedCategory){
-            recordCategoryFeedback(description, category)
+            try {
+                const success = await recordCategoryFeedback(description, category)
+                if (!success) {
+                    throw new Error("Failed to record category feedback")
+                }
+            } catch (error) {
+                logger.error("Failed to record category feedback", error)
+                toast({
+                    title: "Failed to record category feedback",
+                    description: "Could not record category feedback.",
+                    variant: "destructive",
+                })
+            }
         }
         setOpen(false)
         // Reset form


### PR DESCRIPTION
## Summary
- await category feedback recording and handle errors in AddTransactionDialog
- add tests for category feedback success and failure

## Testing
- `npm test src/__tests__/add-transaction-dialog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b290783b048331a08b3fd511bae51b