### PR TITLE
Reject runs on destroyed worker pool

### DIFF
--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -78,4 +78,12 @@ describe("WorkerPool", () => {
 
     await destroyPromise
   })
+
+  it("rejects new tasks after destruction", async () => {
+    const pool = new WorkerPool<number, number>("fake", 1)
+
+    await pool.destroy()
+
+    await expect(pool.run(3)).rejects.toThrow("Worker pool destroyed")
+  })
 })

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -61,6 +61,10 @@ export class WorkerPool<T = unknown, R = unknown> {
    * emits an error or terminates with a non-zero exit code.
    */
   run(data: T): Promise<R> {
+    if (this.destroyed) {
+      return Promise.reject(new Error("Worker pool destroyed"))
+    }
+
     return new Promise((resolve, reject) => {
       this.queue.push({ data, resolve, reject })
       this.process()


### PR DESCRIPTION
## Summary
- prevent scheduling tasks after worker pool is destroyed
- add test covering run after destroy behavior

## Testing
- `npm test src/__tests__/worker-pool.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b29090a1188331a8b29da75a3fac0d