### PR TITLE
refactor: lazy firebase initialization

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -17,8 +17,19 @@ jest.mock('@/lib/firebase', () => ({
     currentUser: null,
     app: { options: { apiKey: 'test' }, name: '[DEFAULT]' },
   },
+  initFirebase: jest.fn(),
 }));
-import { auth as authStub } from '@/lib/firebase';
+import { auth as authStub, initFirebase } from '@/lib/firebase';
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'test';
+  process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'test';
+  process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'test';
+  process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'test';
+  process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'test';
+  process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'test';
+  initFirebase();
+});
 
 type User = { uid: string } | null;
 let mockUser: User = null;

--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -1,7 +1,22 @@
 import { addCategory, getCategories, removeCategory, clearCategories } from "@/lib/categoryService";
 import { setDoc, deleteDoc } from "firebase/firestore";
 
-jest.mock("@/lib/firebase", () => ({ db: {}, categoriesCollection: {} }));
+jest.mock("@/lib/firebase", () => ({
+  db: {},
+  categoriesCollection: {},
+  initFirebase: jest.fn(),
+}));
+import { initFirebase } from "@/lib/firebase";
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
+  initFirebase();
+});
 
 jest.mock("firebase/firestore", () => ({
   doc: jest.fn(() => ({})),

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -13,7 +13,18 @@ jest.mock("@/lib/internet-time", () => ({
   getCurrentTime: jest.fn(),
 }));
 
-jest.mock("@/lib/firebase", () => ({ db: {} }));
+jest.mock("@/lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
+import { initFirebase } from "@/lib/firebase";
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
+  initFirebase();
+});
 
 jest.mock("firebase/firestore", () => {
   const store: { lastRun?: number } = {};

--- a/src/__tests__/saveTransactions.integration.test.ts
+++ b/src/__tests__/saveTransactions.integration.test.ts
@@ -1,7 +1,18 @@
 import { saveTransactions } from "../lib/transactions";
 import type { Transaction } from "../lib/types";
 
-jest.mock("../lib/firebase", () => ({ db: {} }));
+jest.mock("../lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
+import { initFirebase } from "../lib/firebase";
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
+  initFirebase();
+});
 
 const store = new Map<string, Transaction>();
 

--- a/src/__tests__/saveTransactions.test.ts
+++ b/src/__tests__/saveTransactions.test.ts
@@ -1,6 +1,17 @@
 import { saveTransactions } from "../lib/transactions";
 
-jest.mock("../lib/firebase", () => ({ db: {} }));
+jest.mock("../lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
+import { initFirebase } from "../lib/firebase";
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
+  process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
+  initFirebase();
+});
 
 const mockSet = jest.fn();
 const mockCommit = jest.fn();

--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -8,7 +8,19 @@ jest.mock("../lib/offline", () => ({
 
 jest.mock("../lib/firebase", () => ({
   auth: { currentUser: { getIdToken: jest.fn().mockResolvedValue("token") } },
+  initFirebase: jest.fn(),
 }))
+import { initFirebase } from "../lib/firebase"
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test"
+  process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = "test"
+  process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = "test"
+  process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test"
+  process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test"
+  process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test"
+  initFirebase()
+})
 
 jest.mock("../hooks/use-toast", () => ({ toast: jest.fn() }))
 

--- a/src/ai/train/category-model.ts
+++ b/src/ai/train/category-model.ts
@@ -1,5 +1,7 @@
 import { collection, getDocs, onSnapshot } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+import { db, initFirebase } from "@/lib/firebase";
+
+initFirebase();
 
 interface FeedbackPair {
   description: string;

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 import { runHousekeeping } from "@/lib/housekeeping";
-import { db } from "@/lib/firebase";
+import { db, initFirebase } from "@/lib/firebase";
 import { getCurrentTime } from "@/lib/internet-time";
 import { doc, runTransaction, setDoc } from "firebase/firestore";
 
 const HEADER_NAME = "x-cron-secret";
 const WINDOW_MS = 60_000; // 1 minute
+initFirebase();
 const STATE_DOC = doc(db, "cron", "housekeeping");
 
 // Exposed for tests to reset the persisted rate limiter

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -5,7 +5,9 @@ import type { Goal } from "@/lib/types";
 import { GoalCard } from "@/components/goals/goal-card";
 import { AddGoalDialog } from "@/components/goals/add-goal-dialog";
 import { collection, addDoc, getDocs, updateDoc, deleteDoc, doc } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+import { db, initFirebase } from "@/lib/firebase";
+
+initFirebase();
 
 export default function GoalsPage() {
   const [goals, setGoals] = useState<Goal[]>([]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,9 @@ import {
   createUserWithEmailAndPassword,
   type AuthError,
 } from "firebase/auth"
-import { auth } from "@/lib/firebase"
+import { auth, initFirebase } from "@/lib/firebase"
+
+initFirebase()
 import { authErrorMessages, DEFAULT_AUTH_ERROR_MESSAGE } from "@/lib/auth-errors"
 
 import { Button } from "@/components/ui/button"

--- a/src/components/auth/auth-provider.tsx
+++ b/src/components/auth/auth-provider.tsx
@@ -8,9 +8,11 @@ import {
   startTransition,
 } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
-import { auth } from "@/lib/firebase";
+import { auth, initFirebase } from "@/lib/firebase";
 import { usePathname, useRouter } from "next/navigation";
 import { z } from "zod";
+
+initFirebase();
 
 interface AuthContextType {
   user: User | null;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { auth } from "@/lib/firebase"
+import { auth, initFirebase } from "@/lib/firebase"
 import { signOut } from "firebase/auth"
 import {
   CircleUser,
@@ -28,6 +28,8 @@ import {
 import { NurseFinAILogo } from "@/components/icons"
 import { useToast } from "@/hooks/use-toast"
 import { ThemeToggle } from "@/components/ThemeToggle"
+
+initFirebase()
 
 export default function AppHeader() {
   const router = useRouter()

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useRef } from "react"
 import { getQueuedTransactions, clearQueuedTransactions } from "@/lib/offline"
-import { auth } from "@/lib/firebase"
+import { auth, initFirebase } from "@/lib/firebase"
 import { toast } from "@/hooks/use-toast"
+
+initFirebase()
 
 export function ServiceWorker() {
   const debounceId = useRef<ReturnType<typeof setTimeout> | null>(null)

--- a/src/lib/category-feedback.ts
+++ b/src/lib/category-feedback.ts
@@ -1,6 +1,8 @@
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
-import { db } from "./firebase";
+import { db, initFirebase } from "./firebase";
 import { logger } from "./logger";
+
+initFirebase();
 
 /**
  * Persist a (description, category) feedback pair. This is used when a user

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -3,7 +3,9 @@
 // case-insensitive manner while preserving their original casing for display.
 
 import { doc, getDocs, setDoc, deleteDoc, writeBatch } from "firebase/firestore";
-import { db, categoriesCollection } from "./firebase";
+import { db, categoriesCollection, initFirebase } from "./firebase";
+
+initFirebase();
 
 const STORAGE_KEY = "categories";
 

--- a/src/lib/debts/index.ts
+++ b/src/lib/debts/index.ts
@@ -1,5 +1,5 @@
 import { collection, doc, QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
-import { db } from "../firebase";
+import { db, initFirebase } from "../firebase";
 import type { Debt } from "../types";
 
 // Firestore data converter for `Debt` documents.
@@ -14,5 +14,6 @@ const debtConverter = {
 };
 
 // `debts` collection reference using the converter.
+initFirebase();
 export const debtsCollection = collection(db, "debts").withConverter(debtConverter);
 export const debtDoc = (id: string) => doc(db, "debts", id).withConverter(debtConverter);

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -27,16 +27,10 @@ const envSchema = z.object({
   NEXT_PUBLIC_FIREBASE_APP_ID: nonPlaceholder,
 });
 
-const env = envSchema.parse(process.env);
-
-const firebaseConfig: FirebaseOptions = {
-  apiKey: env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: env.NEXT_PUBLIC_FIREBASE_APP_ID,
-};
+let app: ReturnType<typeof initializeApp>;
+let auth: ReturnType<typeof getAuth>;
+let db: ReturnType<typeof getFirestore>;
+let categoriesCollection: ReturnType<typeof collection>;
 
 // A function to check if all required environment variables are present.
 // This provides a clearer error message than the generic Firebase error.
@@ -58,16 +52,26 @@ function validateFirebaseConfig(config: FirebaseOptions): void {
   }
 }
 
-// Validate the config before initializing
-validateFirebaseConfig(firebaseConfig);
-
-// Initialize Firebase
-const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
-const auth = getAuth(app);
-const db = getFirestore(app);
-
-// Firestore collection reference for categories
-const categoriesCollection = collection(db, "categories");
+export function initFirebase() {
+  if (app) {
+    return { app, auth, db, categoriesCollection };
+  }
+  const env = envSchema.parse(process.env);
+  const firebaseConfig: FirebaseOptions = {
+    apiKey: env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    appId: env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  };
+  validateFirebaseConfig(firebaseConfig);
+  app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+  auth = getAuth(app);
+  db = getFirestore(app);
+  categoriesCollection = collection(db, "categories");
+  return { app, auth, db, categoriesCollection };
+}
 
 export { app, auth, db, categoriesCollection };
 

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 import { collection, doc, writeBatch, getDocs } from "firebase/firestore";
-import { db } from "./firebase";
+import { db, initFirebase } from "./firebase";
 import type { Transaction } from "./types";
+
+initFirebase();
 
 export const TransactionPayloadSchema = z.object({
   id: z.string(),

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -11,10 +11,12 @@ import {
   writeBatch,
   QueryDocumentSnapshot,
 } from "firebase/firestore";
-import { db } from "../lib/firebase";
+import { db, initFirebase } from "../lib/firebase";
 import type { Transaction, Debt, Goal } from "../lib/types";
 import { getCurrentTime } from "../lib/internet-time";
 import { logger } from "../lib/logger";
+
+initFirebase();
 
 /**
  * Moves transactions older than the provided cutoff date to an archive collection


### PR DESCRIPTION
## Summary
- refactor Firebase setup into lazily executed `initFirebase`
- ensure modules invoke `initFirebase` before using `auth`/`db`
- update tests to initialize Firebase with mocked env vars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b290924c5c83319b8ea859e7fe3258