### PR TITLE
refactor: cache lowercase query in debt occurrences hook

### DIFF
--- a/src/__tests__/use-debt-occurrences.test.ts
+++ b/src/__tests__/use-debt-occurrences.test.ts
@@ -134,4 +134,38 @@ describe("useDebtOccurrences", () => {
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
+
+  it("filters grouped map by query without altering occurrences", () => {
+    const debts: Debt[] = [
+      {
+        ...baseDebt,
+        id: "r1",
+        name: "Rent",
+        notes: "Monthly payment",
+        dueDate: "2024-01-05",
+        recurrence: "none",
+      },
+      {
+        ...baseDebt,
+        id: "c1",
+        name: "Car Loan",
+        notes: "Auto",
+        dueDate: "2024-01-10",
+        recurrence: "none",
+      },
+    ];
+    const { occurrences, grouped } = renderUseDebtOccurrences(
+      debts,
+      new Date("2024-01-01"),
+      new Date("2024-01-31"),
+      "rent"
+    );
+    // All occurrences are returned
+    expect(occurrences.map((o) => o.date)).toEqual([
+      "2024-01-05",
+      "2024-01-10",
+    ]);
+    // Grouped map filtered by query (case-insensitive)
+    expect([...grouped.keys()]).toEqual(["2024-01-05"]);
+  });
 });

--- a/src/hooks/use-debt-occurrences.ts
+++ b/src/hooks/use-debt-occurrences.ts
@@ -164,12 +164,11 @@ export function useDebtOccurrences(
 
   const filtered = useMemo(() => {
     if (!query) return grouped;
+    const q = query.toLowerCase();
     const map = new Map<string, Occurrence[]>();
     grouped.forEach((arr, date) => {
       const filteredArr = arr.filter((oc) =>
-        `${oc.debt.name} ${oc.debt.notes ?? ""}`
-          .toLowerCase()
-          .includes(query.toLowerCase())
+        `${oc.debt.name} ${oc.debt.notes ?? ""}`.toLowerCase().includes(q)
       );
       if (filteredArr.length) map.set(date, filteredArr);
     });


### PR DESCRIPTION
## Summary
- optimize `useDebtOccurrences` filtered map by lowercasing query once
- test grouped map filtering leaves occurrences unchanged

## Testing
- `npm test src/__tests__/use-debt-occurrences.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b29094051483318bc27572201b6347