### PR TITLE
Refactor offline queue to return Result with error handling

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -2,8 +2,12 @@ import { render, act } from "@testing-library/react"
 import { ServiceWorker } from "../components/service-worker"
 
 jest.mock("../lib/offline", () => ({
-  getQueuedTransactions: jest.fn().mockResolvedValue([{ id: 1 }]),
-  clearQueuedTransactions: jest.fn().mockResolvedValue(undefined),
+  getQueuedTransactions: jest
+    .fn()
+    .mockResolvedValue({ ok: true, value: [{ id: 1 }] }),
+  clearQueuedTransactions: jest
+    .fn()
+    .mockResolvedValue({ ok: true, value: undefined }),
 }))
 
 jest.mock("../lib/firebase", () => ({


### PR DESCRIPTION
## Summary
- return structured Result objects from offline queue helpers instead of booleans
- surface errors in ServiceWorker and log through logger
- update unit tests to expect Result-based responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b29095d10c8331b4d068685c0028b6