### PR TITLE
feat: make CORS origins configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Create a `.env.local` file by copying `.env.example` and populate it with the re
 | `RETENTION_DAYS` | Number of days to retain files before deletion (default: 30). |
 | `CRON_SECRET` | Shared secret expected in the `X-CRON-SECRET` header for housekeeping runs. |
 | `DEFAULT_TZ` | Optional IANA timezone used when synchronizing time with the network. Defaults to the system timezone. |
+| `ALLOWED_ORIGINS` | Comma-separated list of allowed request origins for CORS. Regex patterns may be wrapped in `/`. |
 
 Adjust the retention threshold by setting `RETENTION_DAYS` before running the service or updating the scheduled job configuration.
 

--- a/src/__tests__/allowed-origins.test.ts
+++ b/src/__tests__/allowed-origins.test.ts
@@ -1,0 +1,16 @@
+import { getAllowedOrigins } from '@/lib/allowed-origins';
+
+describe('getAllowedOrigins', () => {
+  it('parses strings and regex and ignores malformed entries', () => {
+    const input = [
+      'http://localhost:6006',
+      String.raw`/^https:\/\/.*\.example\.com$/`,
+      'not-a-url',
+      '/foo(',
+    ].join(',');
+    const origins = getAllowedOrigins(input);
+    expect(origins).toHaveLength(2);
+    expect(origins[0]).toBe('http://localhost:6006');
+    expect(origins[1]).toBeInstanceOf(RegExp);
+  });
+});

--- a/src/lib/allowed-origins.ts
+++ b/src/lib/allowed-origins.ts
@@ -1,0 +1,31 @@
+export type AllowedOrigin = string | RegExp;
+
+function parseItem(item: string): AllowedOrigin | null {
+  const trimmed = item.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('/') && trimmed.endsWith('/')) {
+    const pattern = trimmed.slice(1, -1);
+    try {
+      return new RegExp(pattern);
+    } catch {
+      return null;
+    }
+  }
+  try {
+    // Validate URL
+    new URL(trimmed);
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
+
+export function getAllowedOrigins(env: string | undefined = process.env.ALLOWED_ORIGINS): AllowedOrigin[] {
+  if (!env) return [];
+  return env
+    .split(',')
+    .map(parseItem)
+    .filter((item): item is AllowedOrigin => item !== null);
+}
+
+export const allowedOrigins: AllowedOrigin[] = getAllowedOrigins();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { allowedOrigins } from '@/lib/allowed-origins'
 
 export function middleware(request: NextRequest) {
   const cspNonce = crypto.randomUUID()
@@ -35,10 +36,6 @@ export function middleware(request: NextRequest) {
   )
 
   const origin = request.headers.get('origin')
-  const allowedOrigins = [
-    /^https:\/\/.*-firebase-studio-.*\.cloudworkstations\.dev$/,
-    'http://localhost:6006',
-  ]
 
   if (
     origin &&


### PR DESCRIPTION
## Summary
- parse ALLOWED_ORIGINS env var into vetted string/regex list
- use parsed origins in middleware CORS check
- document ALLOWED_ORIGINS and test parsing logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b290ab51608331917661efe021803e