### PR TITLE
Validate cutoff date in housekeeping archive function

### DIFF
--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -199,6 +199,17 @@ describe('housekeeping services', () => {
     expect(store.transactions_archive.has('t1')).toBe(true);
   });
 
+  test('archiveOldTransactions accepts valid date input', async () => {
+    await expect(archiveOldTransactions('2021-01-01')).resolves.toBeUndefined();
+  });
+
+  test('archiveOldTransactions throws on invalid date input', async () => {
+    await expect(archiveOldTransactions('not-a-date')).rejects.toThrow(
+      'Invalid cutoff date'
+    );
+    expect(firestore.getDocs).not.toHaveBeenCalled();
+  });
+
   test('cleanupDebts removes settled debts', async () => {
     store.debts.set('d1', {
       id: 'd1',

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -21,7 +21,11 @@ import { logger } from "../lib/logger";
  * and removes them from the main transactions collection.
  */
 export async function archiveOldTransactions(cutoffDate: string): Promise<void> {
-  const cutoff = new Date(cutoffDate).toISOString();
+  const timestamp = Date.parse(cutoffDate);
+  if (Number.isNaN(timestamp)) {
+    throw new Error("Invalid cutoff date");
+  }
+  const cutoff = new Date(timestamp).toISOString();
   const transCol = collection(db, "transactions");
   const pageSize = 100;
   let lastDoc: QueryDocumentSnapshot<unknown> | undefined;


### PR DESCRIPTION
## Summary
- validate cutoff date using `Date.parse` before querying Firestore
- add tests for valid and invalid cutoff date inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b290ac0d5c8331959a8f9778298d76