### PR TITLE
feat: enforce body size limits

### DIFF
--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
 import { TransactionPayloadSchema } from "@/lib/transactions"
-import { readBodyWithLimit } from "@/lib/http"
+import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
 
 /**
  * Generic transaction syncing endpoint.
@@ -25,9 +25,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: message }, { status: 401 })
   }
 
-  const text = await readBodyWithLimit(req, MAX_BODY_SIZE)
-  if (text === null) {
-    return NextResponse.json({ error: "Payload too large" }, { status: 413 })
+  let text: string
+  try {
+    text = await readBodyWithLimit(req, MAX_BODY_SIZE)
+  } catch (err) {
+    if (err instanceof PayloadTooLargeError) {
+      return NextResponse.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
 
   let json: unknown

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,7 +1,23 @@
+export class PayloadTooLargeError extends Error {
+  status = 413
+  constructor(message = "Payload too large") {
+    super(message)
+    this.name = "PayloadTooLargeError"
+  }
+}
+
+/**
+ * Reads the request body up to a specified limit.
+ *
+ * If the incoming payload exceeds the limit, the request stream is cancelled,
+ * any remaining data is drained, and the function rejects with a
+ * {@link PayloadTooLargeError}. Callers can catch this error and return a 413
+ * response immediately.
+ */
 export async function readBodyWithLimit(req: Request, limit: number) {
   const contentLength = req.headers.get("content-length")
   if (contentLength && Number(contentLength) > limit) {
-    return null
+    throw new PayloadTooLargeError()
   }
 
   const reader = req.body?.getReader()
@@ -17,7 +33,15 @@ export async function readBodyWithLimit(req: Request, limit: number) {
     if (value) {
       total += value.length
       if (total > limit) {
-        return null
+        await reader.cancel()
+        try {
+          while (!(await reader.read()).done) {
+            // drain remaining data
+          }
+        } catch {
+          // ignore errors during draining
+        }
+        throw new PayloadTooLargeError()
       }
       result += decoder.decode(value, { stream: true })
     }


### PR DESCRIPTION
## Summary
- add `PayloadTooLargeError` and enhance `readBodyWithLimit` to cancel and drain oversized requests
- bubble structured error to callers so API routes can send a 413 immediately
- document rejection behavior for `readBodyWithLimit`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b290acc18c833197b998c35fee0f9f