### PR TITLE
feat: allow debt occurrence truncation flag

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -4,6 +4,11 @@ export const logger = {
       console.info(message, ...args);
     }
   },
+  warn: (message: string, ...args: unknown[]) => {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(message, ...args);
+    }
+  },
   error: (message: string, ...args: unknown[]) => {
     if (process.env.NODE_ENV !== "production") {
       console.error(message, ...args);


### PR DESCRIPTION
## Summary
- add warn method to logger and log debt occurrence truncation warnings
- add optional truncation flag to useDebtOccurrences hook
- test new logger-based warning and truncation option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b290ae47248331bd5855f5d00747b5