### PR TITLE
Propagate currency conversion errors

### DIFF
--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -41,13 +41,13 @@ describe('currency code validation', () => {
     expect(converted).toBe(5);
   });
 
-  it('convertCurrency returns original amount for invalid codes', async () => {
+  it('convertCurrency throws for invalid codes', async () => {
     const mockFetch = jest.fn();
     (globalThis as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
 
-    const converted = await convertCurrency(10, 'u$', 'eur');
-
-    expect(converted).toBe(10);
+    await expect(convertCurrency(10, 'u$', 'eur')).rejects.toThrow(
+      'Invalid currency code',
+    );
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -52,13 +52,8 @@ export async function convertCurrency(
   from: string,
   to: string,
 ): Promise<number> {
-  try {
-    const rate = await getFxRate(from, to);
-    return amount * rate;
-  } catch (err) {
-    console.error('Currency conversion failed', err);
-    return amount;
-  }
+  const rate = await getFxRate(from, to);
+  return amount * rate;
 }
 
 export function formatCurrency(amount: number, currency: string, locale = 'en-US'): string {


### PR DESCRIPTION
## Summary
- stop swallowing failures in convertCurrency and let getFxRate errors propagate
- adjust currency tests to expect thrown errors for invalid codes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b290afe62883318cc9651cda72b907