### PR TITLE
test: resolve conflicts in AI flow tests

### DIFF
--- a/src/ai/flows/__tests__/no-output.test.ts
+++ b/src/ai/flows/__tests__/no-output.test.ts
@@ -1,9 +1,22 @@
+import type { ZodType } from 'zod';
+
+interface FlowConfig<I, O> {
+  name: string;
+  inputSchema: ZodType<I>;
+  outputSchema: ZodType<O>;
+}
+
+type FlowHandler<I, O> = (input: I) => Promise<O>;
+
 function setupNoOutputMocks() {
   const definePromptMock = jest.fn().mockReturnValue(async () => ({ output: undefined }));
   const defineFlowMock = jest.fn(
-    (_config: unknown, handler: unknown) => handler as unknown
+    <I, O>(_config: FlowConfig<I, O>, handler: FlowHandler<I, O>) => handler
   );
-  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+  jest.doMock('@/ai/genkit', () => ({
+    ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock },
+  }));
+  return { definePromptMock, defineFlowMock };
 }
 
 describe('calculateCashflowFlow', () => {


### PR DESCRIPTION
## Summary
- adopt generic mock helpers for no-output tests and retain regex-based assertions
- use typed success-mock helpers and keep cost-of-living validation cases

## Testing
- `npm test --silent 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b2916896cc833188353c5d006429bb