### PR TITLE
fix: resolve merge conflicts in AI flow tests

### DIFF
--- a/src/ai/flows/__tests__/no-output.test.ts
+++ b/src/ai/flows/__tests__/no-output.test.ts
@@ -1,9 +1,24 @@
+import type { ZodType } from 'zod';
+
+interface FlowConfig<I, O> {
+  name: string;
+  inputSchema: ZodType<I>;
+  outputSchema: ZodType<O>;
+}
+
+type FlowHandler<I, O> = (input: I) => Promise<O>;
+
 function setupNoOutputMocks() {
-  const definePromptMock = jest.fn().mockReturnValue(async () => ({ output: undefined }));
+  const definePromptMock = jest
+    .fn()
+    .mockReturnValue(async () => ({ output: undefined }));
   const defineFlowMock = jest.fn(
-    (_config: unknown, handler: unknown) => handler as unknown
+    <I, O>(_config: FlowConfig<I, O>, handler: FlowHandler<I, O>) => handler
   );
-  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+  jest.doMock('@/ai/genkit', () => ({
+    ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock },
+  }));
+  return { definePromptMock, defineFlowMock };
 }
 
 describe('calculateCashflowFlow', () => {
@@ -25,8 +40,12 @@ describe('suggestDebtStrategyFlow', () => {
   it('throws an error when prompt returns no output', async () => {
     jest.resetModules();
     setupNoOutputMocks();
-    const { suggestDebtStrategy } = await import('@/ai/flows/suggest-debt-strategy');
-    await expect(suggestDebtStrategy({ debts: [] })).rejects.toThrow(/No output returned/);
+    const { suggestDebtStrategy } = await import(
+      '@/ai/flows/suggest-debt-strategy'
+    );
+    await expect(
+      suggestDebtStrategy({ debts: [] })
+    ).rejects.toThrow(/No output returned/);
   });
 });
 


### PR DESCRIPTION
## Summary
- restore typed flow mock helpers and use regex-based "No output returned" assertions with new `suggestCategory` coverage
- reintroduce generic schema mocks and add cost-of-living validation tests for invalid adults and unknown regions

## Testing
- `npm test --silent 2>&1 | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68b291ee46e883319f1f616456b8b5fd