### PR TITLE
fix: preserve transaction ids and currency during sync

### DIFF
--- a/src/__tests__/transactions-sync.integration.test.ts
+++ b/src/__tests__/transactions-sync.integration.test.ts
@@ -59,7 +59,7 @@ const sample = {
   date: "2024-01-01",
   description: "test",
   amount: 100,
-  currency: "USD",
+  currency: "EUR",
   type: "Income" as const,
   category: "Misc",
   isRecurring: false,
@@ -71,7 +71,7 @@ describe("/api/transactions/sync persistence", () => {
     failCommit = false;
   });
 
-  it("persists transactions via importTransactions", async () => {
+  it("persists transactions via saveTransactions and preserves fields", async () => {
     const req = new Request("http://localhost", {
       method: "POST",
       headers: { Authorization: "Bearer test-token" },
@@ -81,11 +81,13 @@ describe("/api/transactions/sync persistence", () => {
     const res = await transactionsSync(req);
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ imported: 1 });
+    expect(body).toEqual({ saved: 1 });
     expect(store.size).toBe(1);
     const saved = Array.from(store.values())[0];
     expect(saved.description).toBe(sample.description);
     expect(saved.amount).toBe(sample.amount);
+    expect(saved.id).toBe(sample.id);
+    expect(saved.currency).toBe(sample.currency);
   });
 
   it("returns 500 when persistence fails", async () => {
@@ -99,6 +101,6 @@ describe("/api/transactions/sync persistence", () => {
     const res = await transactionsSync(req);
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error).toMatch(/Failed to import transactions/);
+    expect(body.error).toMatch(/Failed to save transactions/);
   });
 });

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
-import { TransactionPayloadSchema, importTransactions } from "@/lib/transactions"
+import { TransactionPayloadSchema, saveTransactions } from "@/lib/transactions"
 import { readBodyWithLimit } from "@/lib/http"
 
 /**
@@ -48,13 +48,11 @@ export async function POST(req: Request) {
   const { transactions } = parsed.data
 
   try {
-    await importTransactions(
-      transactions as Parameters<typeof importTransactions>[0],
-    )
-    return NextResponse.json({ imported: transactions.length })
+    await saveTransactions(transactions)
+    return NextResponse.json({ saved: transactions.length })
   } catch (err) {
     const message =
-      err instanceof Error ? err.message : "Failed to import transactions"
+      err instanceof Error ? err.message : "Failed to save transactions"
     return NextResponse.json({ error: message }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- persist transactions directly using `saveTransactions`
- ensure sync preserves provided IDs and currency
- update sync integration test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2981b87f88331a6e8da1fdbea2aa0