### PR TITLE
refactor: use logger instead of console

### DIFF
--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -40,7 +40,11 @@ export async function GET(req: Request) {
     await runHousekeeping();
     return NextResponse.json({ status: "ok" });
   } catch (err) {
-    logger.error("Housekeeping failed", err);
+    if (process.env.NODE_ENV === "production") {
+      console.error("Housekeeping failed", err);
+    } else {
+      logger.error("Housekeeping failed", err);
+    }
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }


### PR DESCRIPTION
## Summary
- replace console logging with centralized logger in offline storage and category services
- use logger across login, debts, insights, transactions, taxes, cashflow, receipt scan pages and housekeeping API route
- update housekeeping retry tests to mock logger
- ensure housekeeping cron errors are still surfaced in production logs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2983abf7883318319d5dde31b4677