### PR TITLE
fix: avoid 207 response for partial transaction sync

### DIFF
--- a/src/__tests__/transactions-sync-route.test.ts
+++ b/src/__tests__/transactions-sync-route.test.ts
@@ -71,7 +71,7 @@ describe("/api/transactions/sync persistence", () => {
     })
 
     const res = await POST(req)
-    expect(res.status).toBe(207)
+    expect(res.status).toBe(500)
     const data = await res.json()
     expect(mockSetDoc).toHaveBeenCalledTimes(transactions.length)
     expect(data.saved).toEqual(["1"])

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -71,7 +71,7 @@ export async function POST(req: Request) {
     })
 
     if (errors.length > 0) {
-      return NextResponse.json({ saved, errors }, { status: 207 })
+      return NextResponse.json({ saved, errors }, { status: 500 })
     }
 
     return NextResponse.json({ saved })


### PR DESCRIPTION
## Summary
- return 500 when any transaction write fails so offline queue isn't cleared
- adjust transaction sync route tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b298824574833199976f06dd28e719