### PR TITLE
Validate offline transaction queue size

### DIFF
--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -77,6 +77,15 @@ describe("offline fallbacks", () => {
 
     await clearQueuedTransactions()
   })
+
+  it("rejects negative maxQueueSize", async () => {
+    await clearQueuedTransactions()
+    const result = await queueTransaction({ id: 1 }, -1)
+    expect(result.ok).toBe(false)
+    const queued = await getQueuedTransactions()
+    expect(queued.ok).toBe(true)
+    expect(queued.value).toEqual([])
+  })
 })
 
 describe("ServiceWorker", () => {

--- a/src/lib/offline.ts
+++ b/src/lib/offline.ts
@@ -39,6 +39,12 @@ export async function queueTransaction(
   tx: unknown,
   maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
 ): Promise<Result<void, Error>> {
+  if (maxQueueSize < 0) {
+    return {
+      ok: false,
+      error: new Error("maxQueueSize must be non-negative"),
+    }
+  }
   try {
     const db = await getDb()
     if (!db) {


### PR DESCRIPTION
## Summary
- reject negative max queue size in queueTransaction
- test negative maxQueueSize handling

## Testing
- `npm test src/__tests__/offline.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b2995c95fc83318ff48536bc310f8f