### PR TITLE
Validate WorkerPool size input

### DIFF
--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -28,6 +28,15 @@ jest.mock("node:worker_threads", () => {
 import { WorkerPool } from "../lib/worker-pool"
 
 describe("WorkerPool", () => {
+  it.each([0, -1, 1.5])(
+    "throws an error when size is %p",
+    size => {
+      expect(() => new WorkerPool("fake", size)).toThrow(
+        "Worker pool size must be a positive integer"
+      )
+    }
+  )
+
   it("continues processing after a worker crash", async () => {
     const pool = new WorkerPool<number | string, number>("fake", 1)
 
@@ -68,8 +77,10 @@ describe("WorkerPool", () => {
   })
 
   it("rejects queued tasks when destroyed", async () => {
-    const pool = new WorkerPool<number, number>("fake", 0)
+    const pool = new WorkerPool<number | string, number>("fake", 1)
 
+    // Occupy the single worker so subsequent tasks remain queued
+    pool.run("hang").catch(() => {})
     const first = pool.run(1)
     const second = pool.run(2)
 

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -23,6 +23,9 @@ export class WorkerPool<T = unknown, R = unknown> {
   private destroyed = false
 
   constructor(private readonly file: string, size: number) {
+    if (!Number.isInteger(size) || size <= 0) {
+      throw new Error("Worker pool size must be a positive integer")
+    }
     for (let i = 0; i < size; i++) {
       this.spawn()
     }


### PR DESCRIPTION
## Summary
- validate WorkerPool constructor size ensuring a positive integer
- test invalid worker-pool sizes and queued task rejection

## Testing
- `npm test src/__tests__/worker-pool.test.ts`
- `npm run lint src/lib/worker-pool.ts src/__tests__/worker-pool.test.ts` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b2995be3408331b86c4c6be1bc8b55