### PR TITLE
Use UUIDs for toast IDs

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -18,11 +18,8 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-let count = 0
-
 function genId() {
-  count = (count + 1) % Number.MAX_SAFE_INTEGER
-  return count.toString()
+  return crypto.randomUUID()
 }
 
 type Action =


### PR DESCRIPTION
## Summary
- use crypto.randomUUID for toast IDs
- remove numeric count state

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2995b1fbc8331af99f4e28fc27b45