### PR TITLE
Validate transaction date and currency inputs

### DIFF
--- a/src/__tests__/api-validation.test.ts
+++ b/src/__tests__/api-validation.test.ts
@@ -4,6 +4,16 @@
 import { POST as bankImport } from "@/app/api/bank/import/route"
 import { POST as transactionsSync } from "@/app/api/transactions/sync/route"
 
+const baseTx = {
+  id: "1",
+  date: "2024-01-01",
+  description: "Test",
+  amount: 1,
+  currency: "USD",
+  type: "Income" as const,
+  category: "Misc",
+}
+
 describe("/api/bank/import", () => {
   it("returns 401 when auth is missing", async () => {
     const req = new Request("http://localhost", { method: "POST" })
@@ -54,6 +64,30 @@ describe("/api/transactions/sync", () => {
       method: "POST",
       headers: { Authorization: "Bearer test-token" },
       body: JSON.stringify({ transactions: "not-array" }),
+    })
+    const res = await transactionsSync(req)
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for invalid date format", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({
+        transactions: [{ ...baseTx, date: "2024/01/01" }],
+      }),
+    })
+    const res = await transactionsSync(req)
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for invalid currency code", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({
+        transactions: [{ ...baseTx, currency: "US" }],
+      }),
     })
     const res = await transactionsSync(req)
     expect(res.status).toBe(400)

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -4,7 +4,7 @@ const fxRateCache = new Map<string, { rate: number; ts: number }>();
 const fxRateRequests = new Map<string, Promise<number>>();
 const FX_RATE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
-const currencyCodeSchema = z.string().regex(/^[A-Z]{3}$/);
+export const currencyCodeSchema = z.string().regex(/^[A-Z]{3}$/);
 
 function parseCurrencyCode(code: string): string {
   const parsed = currencyCodeSchema.safeParse(code.trim().toUpperCase());

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -2,15 +2,16 @@ import { z } from "zod";
 import { collection, doc, writeBatch, getDocs } from "firebase/firestore";
 import { db, initFirebase } from "./firebase";
 import type { Transaction } from "./types";
+import { currencyCodeSchema } from "./currency";
 
 initFirebase();
 
 export const TransactionPayloadSchema = z.object({
   id: z.string(),
-  date: z.string(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   description: z.string(),
   amount: z.number(),
-  currency: z.string(),
+  currency: currencyCodeSchema,
   type: z.enum(["Income", "Expense"]),
   category: z.string(),
   isRecurring: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- enforce YYYY-MM-DD format and ISO currency codes in `TransactionPayloadSchema`
- export `currencyCodeSchema` for reuse
- reject invalid dates and currencies in `/api/transactions/sync` tests

## Testing
- `npm test src/__tests__/transactions.test.ts src/__tests__/api-validation.test.ts`
- `npm test src/__tests__/currency.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b29d4fa7d48331a11812f327a9f669