### PR TITLE
chore: enforce npm usage

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,0 +1,15 @@
+name: Verify lockfile
+
+on:
+  pull_request:
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - name: Check package-lock.json
+        run: |
+          git status --porcelain package-lock.json
+          test -z "$(git status --porcelain package-lock.json)"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ To get started, take a look at src/app/page.tsx.
 - `npm test` – run unit tests with Jest.
 - `node scripts/update-cost-of-living.ts` – refresh cost of living dataset from BEA.
 
+## Package manager
+
+This project uses **npm** exclusively. Install dependencies with `npm ci` and
+commit changes to `package-lock.json`. Yarn and pnpm are not supported—the
+`preinstall` hook fails if another package manager is detected. The repository's
+`.npmrc` enables `engine-strict=true` to enforce the Node version specified in
+`package.json`.
+
 ## Color input
 When supplying colors to chart configuration, only the following formats are allowed:
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "preinstall": "node scripts/ensure-npm.js",
     "dev": "next dev -p ${PORT:-3000}",
     "build": "next build",
     "start": "next start",

--- a/scripts/ensure-npm.js
+++ b/scripts/ensure-npm.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const agent = process.env.npm_config_user_agent || '';
+if (agent.includes('yarn') || agent.includes('pnpm')) {
+  console.error('Use npm instead of yarn or pnpm to install dependencies.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- guard installs against yarn or pnpm with an `ensure-npm` preinstall script
- add GitHub Action to verify `npm ci` does not modify `package-lock.json`
- document npm-only policy and enable `engine-strict`

## Testing
- `npm test`
- `node scripts/ensure-npm.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2a8026c888331b0af61c3817e9cda