### PR TITLE
chore: add husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+npm test
+if git diff --cached --name-only | xargs grep -nE '^\\.{3}$'; then
+  echo "Error: file contains standalone '...'" >&2
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ To get started, take a look at src/app/page.tsx.
 - On Cloud Workstations, run `PORT=6000 npm run dev` to match the reserved domain.
 - `npm run lint` – run ESLint for code quality.
 - `npm test` – run unit tests with Jest.
+- Run `npm install` to install Husky pre-commit hooks that run tests and reject commits containing standalone '...' lines.
 - `node scripts/update-cost-of-living.ts` – refresh cost of living dataset from BEA.
 
 ## Color input

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.5.2",
         "genkit-cli": "^1.14.1",
+        "husky": "^9.1.7",
         "jest": "^30.1.0",
         "jest-environment-jsdom": "^30.1.1",
         "postcss": "^8",
@@ -13109,6 +13110,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "husky"
   },
   "dependencies": {
     "@genkit-ai/next": "^1.14.1",
@@ -73,6 +74,7 @@
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.5.2",
     "genkit-cli": "^1.14.1",
+    "husky": "^9.1.7",
     "jest": "^30.1.0",
     "jest-environment-jsdom": "^30.1.1",
     "postcss": "^8",


### PR DESCRIPTION
## Summary
- add Husky pre-commit hook that runs tests and rejects standalone `...` lines
- document running `npm install` to enable hooks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a7fd1ed8833181f5a0317d1b4d87