### PR TITLE
fix: resolve idb import path in service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-import { openDB } from "idb"
+import { openDB } from "https://cdn.jsdelivr.net/npm/idb@7/+esm"
 
 const DB_NAME = "offline-db"
 const STORE_NAME = "transactions"


### PR DESCRIPTION
## Summary
- load idb from CDN so service worker module resolves without bundling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ad00c45c833199b0ba28ff30f7dd