### PR TITLE
refactor cost-of-living validation tests

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -121,7 +121,8 @@ describe("Service worker registration", () => {
       type: "module",
     })
 
-    delete (navigator as any).serviceWorker
+    const nav = navigator as Navigator & { serviceWorker?: ServiceWorkerContainer }
+    delete nav.serviceWorker
     Object.defineProperty(navigator, "onLine", {
       value: true,
       configurable: true,

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,3 +1,5 @@
+import type { Region } from '@/data/costOfLiving2024';
+
 interface Schema<T = unknown> {
   parse: (value: unknown) => T;
 }
@@ -99,17 +101,21 @@ describe('suggestDebtStrategy validation', () => {
 });
 
 describe('calculateCostOfLiving validation', () => {
-  it('rejects non-positive adult count', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
+  it('rejects non-positive adult count', async () => {
+    const { calculateCostOfLiving } = await import('@/ai/flows/cost-of-living');
     expect(() =>
       calculateCostOfLiving({ region: 'California', adults: 0, children: 0 })
     ).toThrow();
   });
 
-  it('rejects unknown region', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
+  it('rejects unknown region', async () => {
+    const { calculateCostOfLiving } = await import('@/ai/flows/cost-of-living');
     expect(() =>
-      calculateCostOfLiving({ region: 'Atlantis', adults: 1, children: 0 } as any)
+      calculateCostOfLiving({
+        region: 'Atlantis' as unknown as Region,
+        adults: 1,
+        children: 0,
+      })
     ).toThrow('Unknown region');
   });
 });


### PR DESCRIPTION
## Summary
- replace require with async import for cost-of-living validation tests
- fix navigator typing in service worker tests to satisfy lint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2afacafec8331a42e1de3273c3740