### PR TITLE
refactor: remove any casts in tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -2,24 +2,34 @@ import '@testing-library/jest-dom'
 import { jest } from '@jest/globals'
 import { TextEncoder, TextDecoder } from 'node:util'
 
-Object.assign(globalThis as any, { TextEncoder, TextDecoder })
-
+Object.assign(
+  globalThis as unknown as { TextEncoder: typeof TextEncoder; TextDecoder: typeof TextDecoder },
+  { TextEncoder, TextDecoder }
+)
 
 // Provide a minimal fetch polyfill for tests that expect it
-;(global as any).fetch = jest.fn(() =>
+const globalMocks = globalThis as unknown as {
+  fetch: jest.Mock
+  Response?: typeof Response
+  Request?: typeof Request
+  Headers?: typeof Headers
+}
+
+globalMocks.fetch = jest.fn(() =>
   Promise.resolve({
     json: async () => ({}),
   })
 )
+
 // Stub out basic Response/Request/Headers constructors if missing
-if (typeof (global as any).Response === 'undefined') {
-  (global as any).Response = class {}
+if (typeof globalMocks.Response === 'undefined') {
+  globalMocks.Response = class {} as typeof Response
 }
-if (typeof (global as any).Request === 'undefined') {
-  (global as any).Request = class {}
+if (typeof globalMocks.Request === 'undefined') {
+  globalMocks.Request = class {} as typeof Request
 }
-if (typeof (global as any).Headers === 'undefined') {
-  (global as any).Headers = class {}
+if (typeof globalMocks.Headers === 'undefined') {
+  globalMocks.Headers = class {} as typeof Headers
 }
 
 // Stub Firebase environment variables expected by zod validation

--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -121,7 +121,7 @@ describe("Service worker registration", () => {
       type: "module",
     })
 
-    delete (navigator as any).serviceWorker
+    delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker
     Object.defineProperty(navigator, "onLine", {
       value: true,
       configurable: true,

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,3 +1,5 @@
+import { calculateCostOfLiving, type CalculateCostOfLivingInput } from '@/ai/flows/cost-of-living'
+
 interface Schema<T = unknown> {
   parse: (value: unknown) => T;
 }
@@ -100,16 +102,14 @@ describe('suggestDebtStrategy validation', () => {
 
 describe('calculateCostOfLiving validation', () => {
   it('rejects non-positive adult count', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
     expect(() =>
       calculateCostOfLiving({ region: 'California', adults: 0, children: 0 })
     ).toThrow();
   });
 
   it('rejects unknown region', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
     expect(() =>
-      calculateCostOfLiving({ region: 'Atlantis', adults: 1, children: 0 } as any)
+      calculateCostOfLiving({ region: 'Atlantis', adults: 1, children: 0 } as unknown as CalculateCostOfLivingInput)
     ).toThrow('Unknown region');
   });
 });


### PR DESCRIPTION
## Summary
- replace global any casts in Jest setup with typed mocks
- fix validation test to use proper type casting and static import
- remove remaining `any` cast in service-worker test

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2b562ce2883318b5cda54458e6d32