### PR TITLE
refactor: use ES import in cost-of-living validation test

### DIFF
--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,3 +1,5 @@
+import { calculateCostOfLiving } from '@/ai/flows/cost-of-living';
+
 interface Schema<T = unknown> {
   parse: (value: unknown) => T;
 }
@@ -100,14 +102,12 @@ describe('suggestDebtStrategy validation', () => {
 
 describe('calculateCostOfLiving validation', () => {
   it('rejects non-positive adult count', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
     expect(() =>
       calculateCostOfLiving({ region: 'California', adults: 0, children: 0 })
     ).toThrow();
   });
 
   it('rejects unknown region', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
     expect(() =>
       calculateCostOfLiving({ region: 'Atlantis', adults: 1, children: 0 } as any)
     ).toThrow('Unknown region');


### PR DESCRIPTION
## Summary
- replace CommonJS require with ES module import in cost-of-living validation test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b56210388331abe8f2f705fb1225