### PR TITLE
refactor: use ESM import in validation tests

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -121,7 +121,7 @@ describe("Service worker registration", () => {
       type: "module",
     })
 
-    delete (navigator as any).serviceWorker
+    delete (navigator as unknown as Record<string, unknown>).serviceWorker
     Object.defineProperty(navigator, "onLine", {
       value: true,
       configurable: true,

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -99,17 +99,20 @@ describe('suggestDebtStrategy validation', () => {
 });
 
 describe('calculateCostOfLiving validation', () => {
-  it('rejects non-positive adult count', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
+  it('rejects non-positive adult count', async () => {
+    const { calculateCostOfLiving } = await import('@/ai/flows/cost-of-living');
     expect(() =>
       calculateCostOfLiving({ region: 'California', adults: 0, children: 0 })
     ).toThrow();
   });
 
-  it('rejects unknown region', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
-    expect(() =>
-      calculateCostOfLiving({ region: 'Atlantis', adults: 1, children: 0 } as any)
-    ).toThrow('Unknown region');
+  it('rejects unknown region', async () => {
+    const { calculateCostOfLiving } = await import('@/ai/flows/cost-of-living');
+    const invalidInput = {
+      region: 'Atlantis',
+      adults: 1,
+      children: 0,
+    } as unknown as Parameters<typeof calculateCostOfLiving>[0];
+    expect(() => calculateCostOfLiving(invalidInput)).toThrow('Unknown region');
   });
 });


### PR DESCRIPTION
## Summary
- use dynamic ESM imports for cost-of-living validation tests
- remove `any` usage in tests to satisfy lint rules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b53eae488331a47f3d6c20368199