### PR TITLE
refactor: use imports in validation tests

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -121,7 +121,7 @@ describe("Service worker registration", () => {
       type: "module",
     })
 
-    delete (navigator as any).serviceWorker
+    delete (navigator as { serviceWorker?: unknown }).serviceWorker
     Object.defineProperty(navigator, "onLine", {
       value: true,
       configurable: true,

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,3 +1,5 @@
+import { calculateCostOfLiving } from '@/ai/flows/cost-of-living';
+
 interface Schema<T = unknown> {
   parse: (value: unknown) => T;
 }
@@ -100,16 +102,15 @@ describe('suggestDebtStrategy validation', () => {
 
 describe('calculateCostOfLiving validation', () => {
   it('rejects non-positive adult count', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
     expect(() =>
       calculateCostOfLiving({ region: 'California', adults: 0, children: 0 })
     ).toThrow();
   });
 
   it('rejects unknown region', () => {
-    const { calculateCostOfLiving } = require('@/ai/flows/cost-of-living');
+    // @ts-expect-error - invalid region for testing
     expect(() =>
-      calculateCostOfLiving({ region: 'Atlantis', adults: 1, children: 0 } as any)
+      calculateCostOfLiving({ region: 'Atlantis', adults: 1, children: 0 })
     ).toThrow('Unknown region');
   });
 });


### PR DESCRIPTION
## Summary
- replace CommonJS `require` with `import` in validation tests
- adjust cost-of-living tests and remove `as any` usage
- clean up service-worker test typing to satisfy lint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b538c9588331bf94cc40c745ca56