### PR TITLE
doc: add playwright deps guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ To get started, take a look at src/app/page.tsx.
 - On Cloud Workstations, run `PORT=6000 npm run dev` to match the reserved domain.
 - `npm run lint` – run ESLint for code quality.
 - `npm test` – run unit tests with Jest.
+- `npm run e2e` – run Playwright end-to-end tests. Run `npx playwright install-deps` first to install required system dependencies.
 - Run `npm install` to install Husky pre-commit hooks that run tests and reject commits containing standalone '...' lines.
 - `node scripts/update-cost-of-living.ts` – refresh cost of living dataset from BEA.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
+    "pree2e": "node scripts/check-playwright-deps.js",
+    "e2e": "npx playwright test",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/check-playwright-deps.js
+++ b/scripts/check-playwright-deps.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+
+const result = spawnSync('npx', ['playwright', 'install-deps', '--dry-run'], {
+  stdio: 'pipe',
+  encoding: 'utf-8',
+});
+
+if (result.status !== 0) {
+  console.warn('Playwright dependencies appear to be missing. Run `npx playwright install-deps` before running e2e tests.');
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- document Playwright dependency install step before running e2e tests
- add e2e npm script with pre-check for missing Playwright dependencies

## Testing
- `npm test`
- `npm run lint`
- `npm run e2e -- --help`


------
https://chatgpt.com/codex/tasks/task_e_68b2b6cb40688331b4753bdafcf3d813