### PR TITLE
feat: validate numeric strings strictly

### DIFF
--- a/src/__tests__/transactions.test.ts
+++ b/src/__tests__/transactions.test.ts
@@ -15,6 +15,16 @@ describe("validateTransactions", () => {
     );
   });
 
+  it.each(["123abc", "12.34.56"])(
+    "throws for malformed numeric string '%s'",
+    (amount) => {
+      const rows = [{ ...baseRow, amount }];
+      expect(() => validateTransactions(rows, ["Misc"])).toThrow(
+        /Invalid amount in row 1/
+      );
+    }
+  );
+
   it("accepts valid ISO date", () => {
     const rows = [{ ...baseRow, amount: "10.00", date: "2024-12-31" }];
     expect(() => validateTransactions(rows, ["Misc"])).not.toThrow();

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -97,12 +97,12 @@ export function validateTransactions(
     }
     const data = parsed.data;
     const amountString = data.amount.trim();
-    const parsedAmount = parseFloat(amountString);
-    if (isNaN(parsedAmount)) {
+    if (!/^[+-]?\d+(\.\d+)?$/.test(amountString)) {
       throw new Error(
-        `Invalid amount in row ${index + 1}: "${data.amount}" cannot be parsed as a number`
+        `Invalid amount in row ${index + 1}: "${data.amount}" is not a valid number`
       );
     }
+    const parsedAmount = Number(amountString);
 
     return {
       id: crypto.randomUUID(),


### PR DESCRIPTION
## Summary
- ensure transaction amount parsing rejects malformed numeric strings
- add tests for invalid numeric strings in transaction validation

## Testing
- `npm test src/__tests__/transactions.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2b89a6a148331800e86289d1913f7