### PR TITLE
Validate isRecurring strings in transactions

### DIFF
--- a/src/__tests__/transactions.test.ts
+++ b/src/__tests__/transactions.test.ts
@@ -37,4 +37,25 @@ describe("validateTransactions", () => {
     const rows = [{ ...baseRow, amount: "10.00" }];
     expect(() => validateTransactions(rows, ["Misc"])).not.toThrow();
   });
+
+  it("accepts boolean isRecurring", () => {
+    const rows = [{ ...baseRow, amount: "10.00", isRecurring: true }];
+    const [tx] = validateTransactions(rows, ["Misc"]);
+    expect(tx.isRecurring).toBe(true);
+  });
+
+  it("parses isRecurring string values", () => {
+    const rows = [
+      { ...baseRow, amount: "10.00", isRecurring: "true" },
+      { ...baseRow, amount: "10.00", isRecurring: "false" },
+    ];
+    const [first, second] = validateTransactions(rows, ["Misc"]);
+    expect(first.isRecurring).toBe(true);
+    expect(second.isRecurring).toBe(false);
+  });
+
+  it("throws for invalid isRecurring string", () => {
+    const rows = [{ ...baseRow, amount: "10.00", isRecurring: "yes" }];
+    expect(() => validateTransactions(rows, ["Misc"])).toThrow(/Invalid row 1/);
+  });
 });

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -28,7 +28,10 @@ const BaseTransactionRow = z.object({
   ),
   type: z.enum(["Income", "Expense"]),
   category: z.string(),
-  isRecurring: z.union([z.boolean(), z.string()]).optional(),
+  // Accepts boolean or string values "true"/"false" only
+  isRecurring: z
+    .union([z.boolean(), z.enum(["true", "false"])])
+    .optional(),
 });
 
 export type TransactionRowType = z.infer<typeof BaseTransactionRow>;
@@ -114,9 +117,11 @@ export function validateTransactions(
       // Default to USD until currency is provided in import sources
       currency: "USD",
       isRecurring:
-        typeof data.isRecurring === "boolean"
-          ? data.isRecurring
-          : data.isRecurring === "true",
+        data.isRecurring === undefined
+          ? undefined
+          : typeof data.isRecurring === "string"
+            ? data.isRecurring === "true"
+            : data.isRecurring,
     };
   });
 }


### PR DESCRIPTION
## Summary
- limit `isRecurring` to booleans or "true"/"false" strings
- normalize optional `isRecurring` values during transaction validation
- cover `isRecurring` parsing with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2b89c4e0483318108b0544d700c6d