### PR TITLE
Handle getDocs errors during transaction import

### DIFF
--- a/src/__tests__/importTransactions.test.ts
+++ b/src/__tests__/importTransactions.test.ts
@@ -1,0 +1,19 @@
+import { importTransactions } from "../lib/transactions";
+import { getDocs } from "firebase/firestore";
+
+jest.mock("firebase/firestore", () => {
+  const actual = jest.requireActual("firebase/firestore");
+  return {
+    ...actual,
+    getDocs: jest.fn(),
+  };
+});
+
+describe("importTransactions", () => {
+  it("throws a descriptive error when fetching categories fails", async () => {
+    (getDocs as jest.Mock).mockRejectedValue(new Error("network failure"));
+    await expect(importTransactions([])).rejects.toThrow(
+      /Failed to fetch categories: network failure/
+    );
+  });
+});

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -159,8 +159,16 @@ export async function saveTransactions(transactions: Transaction[]): Promise<voi
  * @remarks Generates UUIDs during validation and writes data to Firestore.
  */
 async function fetchCategories(): Promise<string[]> {
-  const snapshot = await getDocs(collection(db, "categories"));
-  return snapshot.docs.map((doc) => doc.id);
+  try {
+    const snapshot = await getDocs(collection(db, "categories"));
+    return snapshot.docs.map((doc) => doc.id);
+  } catch (err) {
+    throw new Error(
+      `Failed to fetch categories: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
 }
 
 export async function importTransactions(rows: TransactionRowType[]): Promise<void> {


### PR DESCRIPTION
## Summary
- Guard Firestore `getDocs` calls in transaction import with descriptive errors
- Test import failure path when category retrieval fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b89d81a083318ad01f9819c877b0