### PR TITLE
Allow WebSocket connections in CSP

### DIFF
--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -4,7 +4,7 @@ This project defines security headers in `next.config.ts` for all routes. Any ad
 
 ## Required Headers
 
-- **Content-Security-Policy**: `default-src 'self'; script-src 'self' 'nonce-<nonce>'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'`
+- **Content-Security-Policy**: `default-src 'self'; script-src 'self' 'nonce-<nonce>'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https: wss:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'`
 - **X-Frame-Options**: `DENY`
 - **X-Content-Type-Options**: `nosniff`
 - **Referrer-Policy**: `strict-origin-when-cross-origin`

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,15 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import { middleware } from '@/middleware'
+
+describe('middleware', () => {
+  it('includes wss scheme in connect-src CSP directive', () => {
+    const request = new NextRequest('http://localhost')
+    const response = middleware(request)
+    const csp = response.headers.get('Content-Security-Policy') ?? ''
+    expect(csp).toContain("connect-src 'self' https: wss:")
+  })
+})
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,7 +20,7 @@ export function middleware(request: NextRequest) {
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
     "font-src 'self' https://fonts.gstatic.com",
-    "connect-src 'self' https:",
+    "connect-src 'self' https: wss:",
     "base-uri 'self'",
     "form-action 'self'",
     "frame-ancestors 'none'",


### PR DESCRIPTION
## Summary
- allow `wss:` in Content-Security-Policy connect-src directive
- document WebSocket scheme in security headers guide
- add middleware unit test for `wss:` scheme

## Testing
- `npm test`
- `npm test src/__tests__/middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2b89fab708331b599405d10f28774