### PR TITLE
Ensure maxQueueSize is a non-negative integer

### DIFF
--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -82,6 +82,21 @@ describe("offline fallbacks", () => {
     await clearQueuedTransactions()
     const result = await queueTransaction({ id: 1 }, -1)
     expect(result.ok).toBe(false)
+    expect(result.error.message).toBe(
+      "maxQueueSize must be a non-negative integer",
+    )
+    const queued = await getQueuedTransactions()
+    expect(queued.ok).toBe(true)
+    expect(queued.value).toEqual([])
+  })
+
+  it("rejects non-integer maxQueueSize", async () => {
+    await clearQueuedTransactions()
+    const result = await queueTransaction({ id: 1 }, 1.5)
+    expect(result.ok).toBe(false)
+    expect(result.error.message).toBe(
+      "maxQueueSize must be a non-negative integer",
+    )
     const queued = await getQueuedTransactions()
     expect(queued.ok).toBe(true)
     expect(queued.value).toEqual([])

--- a/src/lib/offline.ts
+++ b/src/lib/offline.ts
@@ -39,10 +39,10 @@ export async function queueTransaction(
   tx: unknown,
   maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
 ): Promise<Result<void, Error>> {
-  if (maxQueueSize < 0) {
+  if (!Number.isInteger(maxQueueSize) || maxQueueSize < 0) {
     return {
       ok: false,
-      error: new Error("maxQueueSize must be non-negative"),
+      error: new Error("maxQueueSize must be a non-negative integer"),
     }
   }
   try {


### PR DESCRIPTION
## Summary
- Validate offline queue size with `Number.isInteger` and non-negative check
- Improve error messages for invalid `maxQueueSize`
- Test negative and fractional queue size handling

## Testing
- `npm test src/__tests__/offline.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2b8a08c988331bcc35217a5332835