### PR TITLE
Aggregate CSV parse errors

### DIFF
--- a/src/__tests__/csv.test.ts
+++ b/src/__tests__/csv.test.ts
@@ -1,0 +1,25 @@
+import { parseCsv } from '@/lib/csv';
+
+describe('parseCsv', () => {
+  it('parses valid CSV files', async () => {
+    const csv = 'a,b\n1,2\n3,4';
+    const file = new File([csv], 'test.csv', { type: 'text/csv' });
+
+    const result = await parseCsv<{ a: number; b: number }>(file);
+
+    expect(result).toEqual([
+      { a: 1, b: 2 },
+      { a: 3, b: 4 },
+    ]);
+  });
+
+  it('aggregates errors into a single message', async () => {
+    const csv = 'a,b\n1\n2,3,4';
+    const file = new File([csv], 'test.csv', { type: 'text/csv' });
+
+    await expect(parseCsv(file)).rejects.toThrow(
+      'Too few fields: expected 2 fields but parsed 1, Too many fields: expected 2 fields but parsed 3',
+    );
+  });
+});
+

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -8,7 +8,8 @@ export function parseCsv<T>(file: File): Promise<T[]> {
       dynamicTyping: true,
       complete: results => {
         if (results.errors.length) {
-          reject(results.errors);
+          const message = results.errors.map(e => e.message).join(", ");
+          reject(new Error(message));
         } else {
           resolve(results.data as T[]);
         }


### PR DESCRIPTION
## Summary
- Wrap Papaparse errors into a single `Error` with joined messages for clearer failures
- Add unit tests covering successful parsing and aggregated error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2b8a18ff48331948c44081adb60a3