### PR TITLE
feat: surface debt operation errors

### DIFF
--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, act } from "@testing-library/react";
+import { useDebts } from "@/lib/debts/use-debts";
+
+// Mock logger to silence output
+jest.mock("@/lib/logger", () => ({ logger: { error: jest.fn() } }));
+// Mock debts index module
+jest.mock("@/lib/debts", () => ({
+  debtsCollection: {},
+  debtDoc: (id: string) => ({ id })
+}));
+
+const onSnapshotMock = jest.fn();
+const deleteDocMock = jest.fn();
+
+jest.mock("firebase/firestore", () => ({
+  onSnapshot: (...args: any[]) => onSnapshotMock(...args),
+  setDoc: jest.fn(),
+  deleteDoc: (...args: any[]) => deleteDocMock(...args),
+  updateDoc: jest.fn(),
+  arrayUnion: jest.fn(),
+  arrayRemove: jest.fn(),
+}));
+
+describe("useDebts", () => {
+  beforeEach(() => {
+    onSnapshotMock.mockReset();
+    deleteDocMock.mockReset();
+  });
+
+  it("exposes subscription errors", () => {
+    const err = new Error("subscribe failed");
+    onSnapshotMock.mockImplementation((_col, _onNext, onError) => {
+      onError(err);
+      return () => {};
+    });
+
+    let result: ReturnType<typeof useDebts>;
+    function TestComponent() {
+      result = useDebts();
+      return null;
+    }
+    render(<TestComponent />);
+    expect(result.error).toBe(err);
+  });
+
+  it("captures errors from operations", async () => {
+    // Successful subscription
+    onSnapshotMock.mockImplementation((_col, onNext) => {
+      onNext({ docs: [] });
+      return () => {};
+    });
+    const err = new Error("delete failed");
+    deleteDocMock.mockRejectedValue(err);
+
+    let result: ReturnType<typeof useDebts>;
+    function TestComponent() {
+      result = useDebts();
+      return null;
+    }
+    render(<TestComponent />);
+
+    await act(async () => {
+      await result.deleteDebt("1");
+    });
+
+    expect(result.error).toBe(err);
+  });
+});


### PR DESCRIPTION
## Summary
- expose actual Error instances from the `useDebts` hook instead of a boolean
- catch CRUD operation failures and record them in hook state
- test that subscription and mutation errors are surfaced

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b8a2a30c8331998581e687577202