### PR TITLE
refactor: use logger instead of console

### DIFF
--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -1,5 +1,6 @@
 import { addCategory, getCategories, removeCategory, clearCategories } from "@/lib/categoryService";
 import { setDoc, deleteDoc } from "firebase/firestore";
+import { logger } from "@/lib/logger";
 
 jest.mock("@/lib/firebase", () => ({
   db: {},
@@ -33,16 +34,22 @@ describe("categoryService", () => {
   });
 
   it("rejects categories with illegal Firestore characters", () => {
+    const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
     addCategory("Food/Drink");
     expect(getCategories()).toEqual([]);
     expect(setDoc).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith("Invalid category name");
+    errorSpy.mockRestore();
   });
 
   it("ignores removal of invalid category names", () => {
+    const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
     addCategory("Groceries");
     removeCategory("Bad[Cat]");
     expect(getCategories()).toEqual(["Groceries"]);
     expect(deleteDoc).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith("Invalid category name");
+    errorSpy.mockRestore();
   });
 
   it("does not write to Firestore when category already exists", () => {

--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -37,6 +37,7 @@ import { render, act } from "@testing-library/react"
 import { ServiceWorker } from "../components/service-worker"
 import * as offline from "../lib/offline"
 import React from "react"
+import { logger } from "../lib/logger"
 
 const globalAny = globalThis as {
   indexedDB?: unknown
@@ -95,6 +96,8 @@ describe("ServiceWorker", () => {
       .spyOn(offline, "getQueuedTransactions")
       .mockResolvedValueOnce({ ok: false, error: new Error("failed") })
 
+    const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {})
+
     const fetchMock = jest.fn()
     globalAny.fetch = fetchMock as unknown as typeof fetch
 
@@ -109,5 +112,6 @@ describe("ServiceWorker", () => {
 
     jest.useRealTimers()
     delete globalAny.fetch
+    errorSpy.mockRestore()
   })
 })

--- a/src/ai/init.ts
+++ b/src/ai/init.ts
@@ -1,7 +1,8 @@
 import { initCategoryModel, teardownCategoryModel } from "./train/category-model";
+import { logger } from "@/lib/logger";
 
 initCategoryModel().catch((err) => {
-  console.error("Failed to initialize category model", err);
+  logger.error("Failed to initialize category model", err);
 });
 
 if (typeof process !== "undefined") {

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -3,6 +3,7 @@ import { runHousekeeping } from "@/lib/housekeeping";
 import { db, initFirebase } from "@/lib/firebase";
 import { getCurrentTime } from "@/lib/internet-time";
 import { doc, runTransaction, setDoc } from "firebase/firestore";
+import { logger } from "@/lib/logger";
 
 const HEADER_NAME = "x-cron-secret";
 const WINDOW_MS = 60_000; // 1 minute
@@ -40,7 +41,7 @@ export async function GET(req: Request) {
     await runHousekeeping();
     return NextResponse.json({ status: "ok" });
   } catch (err) {
-    console.error(err);
+    logger.error("Housekeeping run failed", err);
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }

--- a/src/app/cashflow/page.tsx
+++ b/src/app/cashflow/page.tsx
@@ -17,6 +17,7 @@ import {
   getShiftsInPayPeriod,
   type Shift,
 } from "@/lib/payroll"
+import { logger } from "@/lib/logger"
 
 type ShiftDetails = Omit<Shift, 'date'>;
 
@@ -131,7 +132,7 @@ export default function CashflowPage() {
       })
       setCashflowResult(result)
     } catch (error) {
-      console.error("Error calculating cashflow:", error)
+      logger.error("Error calculating cashflow:", error)
       toast({
         title: "Calculation Failed",
         description: "There was an error calculating your cashflow. Please try again.",

--- a/src/app/debts/page.tsx
+++ b/src/app/debts/page.tsx
@@ -12,6 +12,7 @@ import { suggestDebtStrategy, type SuggestDebtStrategyOutput } from "@/ai/flows"
 import { useToast } from "@/hooks/use-toast";
 import type { Debt } from "@/lib/types";
 import { deleteDebt } from "@/lib/debts/use-debts";
+import { logger } from "@/lib/logger";
 
 export default function DebtsPage() {
   const [debts, setDebts] = useState<Debt[]>([]);
@@ -36,7 +37,7 @@ export default function DebtsPage() {
       setStrategy(result);
 
     } catch (error) {
-      console.error("Error suggesting debt strategy:", error);
+      logger.error("Error suggesting debt strategy:", error);
       toast({
         title: "Strategy Failed",
         description: "There was an error generating your debt strategy. Please try again.",

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input"
 import { Loader2, Lightbulb, TrendingUp, Sparkles } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from "recharts"
+import { logger } from "@/lib/logger"
 
 export default function InsightsPage() {
   const [userDescription, setUserDescription] = useState("I'm a staff nurse looking to save for a down payment on a house and pay off my student loans within 5 years.")
@@ -30,7 +31,7 @@ export default function InsightsPage() {
         const result = await predictSpending({ transactions: mockTransactions });
         setForecastData(result.forecast);
       } catch (error) {
-        console.error("Error predicting spending:", error);
+        logger.error("Error predicting spending:", error);
       }
     };
     loadForecast();
@@ -74,7 +75,7 @@ export default function InsightsPage() {
       });
       setAnalysisResult(result);
     } catch (error) {
-      console.error("Error analyzing spending habits:", error);
+      logger.error("Error analyzing spending habits:", error);
       toast({
         title: "Analysis Failed",
         description: "There was an error generating your financial insights. Please try again.",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,7 @@ import { Label } from "@/components/ui/label"
 import { NurseFinAILogo } from "@/components/icons"
 import { useToast } from "@/hooks/use-toast"
 import { Loader2 } from "lucide-react"
+import { logger } from "@/lib/logger"
 
 export default function LoginPage() {
   const router = useRouter()
@@ -48,7 +49,7 @@ export default function LoginPage() {
       // If we don't have a user-friendly message for this error, log it for debugging
       // while showing a generic message to the user to avoid exposing raw error codes.
       if (!authErrorMessages[authError.code]) {
-        console.error(authError.code, authError.message)
+        logger.error(authError.code, authError.message)
       }
       toast({
         title: isLoginView ? "Sign In Failed" : "Sign Up Failed",

--- a/src/app/taxes/page.tsx
+++ b/src/app/taxes/page.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label"
 import { Loader2, Calculator, Percent, FileText } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { logger } from "@/lib/logger"
 
 type FilingStatus = 'single' | 'married_jointly' | 'married_separately' | 'head_of_household';
 
@@ -44,7 +45,7 @@ export default function TaxEstimatorPage() {
       })
       setTaxResult(result)
     } catch (error) {
-      console.error("Error estimating tax:", error)
+      logger.error("Error estimating tax:", error)
       toast({
         title: "Estimation Failed",
         description: "There was an error estimating your taxes. Please try again.",

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -20,6 +20,7 @@ import { parseCsv, downloadCsv } from "@/lib/csv";
 import { validateTransactions, TransactionRowType } from "@/lib/transactions";
 import { addCategory, getCategories } from "@/lib/categoryService";
 import { Upload, Download, ScanLine, Loader2 } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 export default function TransactionsPage() {
   const [transactions, setTransactions] = useState<Transaction[]>(mockTransactions);
@@ -72,7 +73,7 @@ export default function TransactionsPage() {
       parsed.forEach((t) => addCategory(t.category));
       setTransactions((prev) => [...parsed, ...prev]);
     } catch (err) {
-      console.error(err);
+      logger.error("Failed to import transactions", err);
     } finally {
       e.target.value = "";
     }

--- a/src/app/transactions/scan/page.tsx
+++ b/src/app/transactions/scan/page.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Loader2, Camera, Sparkles, Wand2 } from "lucide-react"
 import Image from "next/image"
+import { logger } from "@/lib/logger"
 
 export default function ScanReceiptPage() {
   const router = useRouter()
@@ -53,7 +54,7 @@ export default function ScanReceiptPage() {
           videoRef.current.srcObject = stream;
         }
       } catch (error) {
-        console.error("Error accessing camera:", error);
+        logger.error("Error accessing camera:", error);
         setHasCameraPermission(false);
         toast({
           variant: "destructive",
@@ -112,7 +113,7 @@ export default function ScanReceiptPage() {
       setAnalysisResult(result);
       setSuggestedCategory(result.category);
     } catch (error) {
-      console.error("Error analyzing receipt:", error);
+      logger.error("Error analyzing receipt:", error);
       toast({ title: "Analysis Failed", description: "Could not analyze the receipt. Please try again.", variant: "destructive" });
     } finally {
       setIsLoading(false);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -28,6 +28,7 @@ import {
 import { NurseFinAILogo } from "@/components/icons"
 import { useToast } from "@/hooks/use-toast"
 import { ThemeToggle } from "@/components/ThemeToggle"
+import { logger } from "@/lib/logger"
 
 initFirebase()
 
@@ -44,7 +45,7 @@ export default function AppHeader() {
         description: "You have been successfully logged out.",
       })
     } catch (error) {
-      console.error("Logout failed:", error)
+      logger.error("Logout failed:", error)
        toast({
         title: "Logout Failed",
         description: "Could not log you out. Please try again.",


### PR DESCRIPTION
## Summary
- replace direct console.* calls with centralized logger
- update tests to mock logger usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2b89ec19883319b927cdb5184b75b