### PR TITLE
Fix service worker idb import

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-import { openDB } from "idb"
+import { openDB } from "https://cdn.jsdelivr.net/npm/idb@7/+esm"
 
 const DB_NAME = "offline-db"
 const STORE_NAME = "transactions"


### PR DESCRIPTION
## Summary
- load idb dependency from CDN in service worker

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ba90afe083319a5c2b8bc2e95b2a