### PR TITLE
fix: rethrow debt operation errors

### DIFF
--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -61,7 +61,7 @@ describe("useDebts", () => {
     render(<TestComponent />);
 
     await act(async () => {
-      await result.deleteDebt("1");
+      await expect(result.deleteDebt("1")).rejects.toBe(err);
     });
 
     expect(result.error).toBe(err);

--- a/src/lib/debts/use-debts.ts
+++ b/src/lib/debts/use-debts.ts
@@ -32,6 +32,7 @@ export function useDebts() {
     } catch (err) {
       logger.error("Error adding/updating debt", err);
       setError(err as Error);
+      throw err;
     }
   };
 
@@ -42,6 +43,7 @@ export function useDebts() {
     } catch (err) {
       logger.error("Error deleting debt", err);
       setError(err as Error);
+      throw err;
     }
   };
 
@@ -52,6 +54,7 @@ export function useDebts() {
     } catch (err) {
       logger.error("Error marking debt paid", err);
       setError(err as Error);
+      throw err;
     }
   };
 
@@ -62,6 +65,7 @@ export function useDebts() {
     } catch (err) {
       logger.error("Error unmarking debt paid", err);
       setError(err as Error);
+      throw err;
     }
   };
 


### PR DESCRIPTION
## Summary
- rethrow debt helper errors so callers receive promise rejection
- test that failed operations reject and surface error state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bac4123c8331aad3610e80440f14