### PR TITLE
Omit undefined isRecurring fields in transaction validation

### DIFF
--- a/src/__tests__/transactions.test.ts
+++ b/src/__tests__/transactions.test.ts
@@ -54,6 +54,12 @@ describe("validateTransactions", () => {
     expect(tx.isRecurring).toBe(true);
   });
 
+  it("omits isRecurring when absent", () => {
+    const rows = [{ ...baseRow, amount: "10.00" }];
+    const [tx] = validateTransactions(rows, ["Misc"]);
+    expect(tx).not.toHaveProperty("isRecurring");
+  });
+
   it("parses isRecurring string values", () => {
     const rows = [
       { ...baseRow, amount: "10.00", isRecurring: "true" },

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -107,7 +107,7 @@ export function validateTransactions(
     }
     const parsedAmount = Number(amountString);
 
-    return {
+    const tx: Transaction = {
       id: crypto.randomUUID(),
       date: data.date,
       description: data.description,
@@ -116,13 +116,16 @@ export function validateTransactions(
       category: data.category,
       // Default to USD until currency is provided in import sources
       currency: "USD",
-      isRecurring:
-        data.isRecurring === undefined
-          ? undefined
-          : typeof data.isRecurring === "string"
-            ? data.isRecurring === "true"
-            : data.isRecurring,
     };
+
+    if (data.isRecurring !== undefined) {
+      tx.isRecurring =
+        typeof data.isRecurring === "string"
+          ? data.isRecurring === "true"
+          : data.isRecurring;
+    }
+
+    return tx;
   });
 }
 


### PR DESCRIPTION
## Summary
- avoid persisting `isRecurring` when the column is missing
- add tests verifying `isRecurring` is omitted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bb019058833187e3577e363cd843