### PR TITLE
feat: validate category names

### DIFF
--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -33,12 +33,24 @@ describe("categoryService", () => {
     jest.clearAllMocks();
   });
 
-  it("rejects categories with illegal Firestore characters", () => {
+  it.each(["/", "*", "[", "]"])(
+    "rejects categories containing %s",
+    (char) => {
+      const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
+      addCategory(`Bad${char}Cat`);
+      expect(getCategories()).toEqual([]);
+      expect(setDoc).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith("Invalid category name");
+      errorSpy.mockRestore();
+    },
+  );
+
+  it("accepts valid category names", () => {
     const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
-    addCategory("Food/Drink");
-    expect(getCategories()).toEqual([]);
-    expect(setDoc).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith("Invalid category name");
+    addCategory("Groceries");
+    expect(getCategories()).toEqual(["Groceries"]);
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
     errorSpy.mockRestore();
   });
 

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -18,8 +18,9 @@ const hasLocalStorage = () =>
   typeof window !== "undefined" && !!window.localStorage;
 
 const normalize = (value: string) => value.trim().toLowerCase();
+const INVALID_KEY = /[\/\*\[\]]/;
 
-const isValidKey = (key: string) => key.length > 0 && !/[/*[\]]/.test(key);
+const isValidKey = (key: string) => key.length > 0 && !INVALID_KEY.test(key);
 
 function load(): string[] {
   if (hasLocalStorage()) {


### PR DESCRIPTION
## Summary
- ensure category keys reject `/`, `*`, `[` and `]`
- test category key validation for invalid characters and valid names

## Testing
- `npm test src/__tests__/categoryService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2bbbbf0c88331ab07e830ab997bf2