### PR TITLE
Add Vary header for allowed CORS origins

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,6 +44,7 @@ export function middleware(request: NextRequest) {
     )
   ) {
     response.headers.set('Access-Control-Allow-Origin', origin)
+    response.headers.append('Vary', 'Origin')
   }
 
   return response


### PR DESCRIPTION
## Summary
- append `Vary: Origin` when setting `Access-Control-Allow-Origin`
- test that middleware varies responses by request origin

## Testing
- `npm test src/__tests__/allowed-origins.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2bbbf474883318091aaede59d3f39