### PR TITLE
Validate internet time API response

### DIFF
--- a/src/__tests__/internet-time.test.ts
+++ b/src/__tests__/internet-time.test.ts
@@ -98,4 +98,15 @@ describe("internet time", () => {
       "500 Internal Error bad"
     );
   });
+
+  it("throws error for malformed JSON responses", async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    await expect(fetchInternetTime("Etc/UTC")).rejects.toThrow(
+      "Invalid response"
+    );
+  });
 });

--- a/src/lib/internet-time.ts
+++ b/src/lib/internet-time.ts
@@ -37,7 +37,17 @@ export async function fetchInternetTime(tz: string): Promise<Date> {
     );
   }
   const data = await res.json();
+  if (typeof data?.datetime !== "string") {
+    throw new Error(
+      `Invalid response from worldtimeapi.org for timezone ${tz}: missing datetime`
+    );
+  }
   const networkDate = new Date(data.datetime);
+  if (isNaN(networkDate.getTime())) {
+    throw new Error(
+      `Invalid datetime in response from worldtimeapi.org for timezone ${tz}: ${data.datetime}`
+    );
+  }
   const deviceDate = new Date();
   const offset = networkDate.getTime() - deviceDate.getTime();
   offsetCache.set(tz, { offset, ts: Date.now() });


### PR DESCRIPTION
## Summary
- Validate that worldtimeapi.org responses contain a parseable ISO datetime
- Add test covering malformed JSON responses

## Testing
- `npm test src/__tests__/internet-time.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b2bbc1a0d883318f38db05c57b095d