### PR TITLE
Guard worker removal in worker pool

### DIFF
--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -34,9 +34,10 @@ export class WorkerPool<T = unknown, R = unknown> {
   private spawn() {
     const worker = new Worker(this.file)
     worker.once("exit", code => {
-      this.workers.splice(this.workers.indexOf(worker), 1)
-      const idleIndex = this.idle.indexOf(worker)
-      if (idleIndex !== -1) this.idle.splice(idleIndex, 1)
+      const idx = this.workers.indexOf(worker)
+      if (idx >= 0) this.workers.splice(idx, 1)
+      const idleIdx = this.idle.indexOf(worker)
+      if (idleIdx >= 0) this.idle.splice(idleIdx, 1)
 
       const task = this.tasks.get(worker)
       this.tasks.delete(worker)


### PR DESCRIPTION
## Summary
- prevent splicing worker arrays when missing
- test missing worker exit does not remove others

## Testing
- `npm test src/__tests__/worker-pool.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2bbc2c2388331904042b88492264f