### PR TITLE
Clear toast timeouts on removal

### DIFF
--- a/src/__tests__/use-toast.test.ts
+++ b/src/__tests__/use-toast.test.ts
@@ -1,0 +1,58 @@
+import type { reducer as ReducerType, toast as ToastFn } from "../hooks/use-toast"
+
+describe("toast timer management", () => {
+  let toast: typeof ToastFn
+  let reducer: typeof ReducerType
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.resetModules()
+    ;({ toast, reducer } = require("../hooks/use-toast"))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("clears pending timeout when toast is removed", () => {
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout")
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout")
+
+    const { id, dismiss } = toast({ title: "test" })
+    dismiss()
+
+    const timeoutId = (setTimeoutSpy.mock.results[0] as { value: any }).value
+
+    reducer({ toasts: [{ id } as any] }, { type: "REMOVE_TOAST", toastId: id })
+
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(timeoutId)
+    expect(jest.getTimerCount()).toBe(0)
+
+    setTimeoutSpy.mockRestore()
+    clearTimeoutSpy.mockRestore()
+  })
+
+  it("clears all timeouts when removing all toasts", () => {
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout")
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout")
+
+    const first = toast({ title: "first" })
+    const second = toast({ title: "second" })
+
+    first.dismiss()
+    second.dismiss()
+
+    expect(jest.getTimerCount()).toBe(2)
+
+    reducer(
+      { toasts: [{ id: first.id } as any, { id: second.id } as any] },
+      { type: "REMOVE_TOAST" }
+    )
+
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(2)
+    expect(jest.getTimerCount()).toBe(0)
+
+    setTimeoutSpy.mockRestore()
+    clearTimeoutSpy.mockRestore()
+  })
+})

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -103,17 +103,27 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
     }
-    case "REMOVE_TOAST":
+    case "REMOVE_TOAST": {
       if (action.toastId === undefined) {
+        toastTimeouts.forEach((timeout) => clearTimeout(timeout))
+        toastTimeouts.clear()
         return {
           ...state,
           toasts: [],
         }
       }
+
+      const timeout = toastTimeouts.get(action.toastId)
+      if (timeout) {
+        clearTimeout(timeout)
+        toastTimeouts.delete(action.toastId)
+      }
+
       return {
         ...state,
         toasts: state.toasts.filter((t) => t.id !== action.toastId),
       }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- clear toast dismissal timers when removing individual or all toasts
- add tests ensuring toast timers are cleared on removal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2bbc4034883318123f0914971b5e4