### PR TITLE
Allow CDN script in CSP for service worker

### DIFF
--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -4,7 +4,7 @@ This project defines security headers in `next.config.ts` for all routes. Any ad
 
 ## Required Headers
 
-- **Content-Security-Policy**: `default-src 'self'; script-src 'self' 'nonce-<nonce>'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https: wss:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'`
+- **Content-Security-Policy**: `default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'nonce-<nonce>'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https: wss:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'`
 - **X-Frame-Options**: `DENY`
 - **X-Content-Type-Options**: `nosniff`
 - **Referrer-Policy**: `strict-origin-when-cross-origin`

--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -14,9 +14,9 @@ const onSnapshotMock = jest.fn();
 const deleteDocMock = jest.fn();
 
 jest.mock("firebase/firestore", () => ({
-  onSnapshot: (...args: any[]) => onSnapshotMock(...args),
+  onSnapshot: (...args: unknown[]) => onSnapshotMock(...args),
   setDoc: jest.fn(),
-  deleteDoc: (...args: any[]) => deleteDocMock(...args),
+  deleteDoc: (...args: unknown[]) => deleteDocMock(...args),
   updateDoc: jest.fn(),
   arrayUnion: jest.fn(),
   arrayRemove: jest.fn(),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,7 @@ export function middleware(request: NextRequest) {
 
   const csp = [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${cspNonce}'`,
+    `script-src 'self' https://cdn.jsdelivr.net 'nonce-${cspNonce}'`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
     "font-src 'self' https://fonts.gstatic.com",


### PR DESCRIPTION
## Summary
- allow jsdelivr CDN scripts in Content Security Policy for service worker import
- document new CSP directive
- replace `any` types with `unknown` in tests to satisfy lint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc37e8d48331b227c7251ca863aa