### PR TITLE
fix: enforce strict numeric parsing for transactions

### DIFF
--- a/src/__tests__/transactions.test.ts
+++ b/src/__tests__/transactions.test.ts
@@ -8,10 +8,15 @@ const baseRow = {
 };
 
 describe("validateTransactions", () => {
+  const escapeRegex = (str: string) =>
+    str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
   it.each(["abc", "", "NaN"])("throws for invalid amount '%s'", (amount) => {
     const rows = [{ ...baseRow, amount }];
     expect(() => validateTransactions(rows, ["Misc"])).toThrow(
-      /Invalid amount in row 1/
+      new RegExp(
+        `Invalid amount in row 1: "${escapeRegex(amount)}" is not a valid number`
+      )
     );
   });
 
@@ -20,7 +25,9 @@ describe("validateTransactions", () => {
     (amount) => {
       const rows = [{ ...baseRow, amount }];
       expect(() => validateTransactions(rows, ["Misc"])).toThrow(
-        /Invalid amount in row 1/
+        new RegExp(
+          `Invalid amount in row 1: "${escapeRegex(amount)}" is not a valid number`
+        )
       );
     }
   );

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -100,12 +100,12 @@ export function validateTransactions(
     }
     const data = parsed.data;
     const amountString = data.amount.trim();
-    if (!/^[+-]?\d+(\.\d+)?$/.test(amountString)) {
+    const parsedAmount = Number(amountString);
+    if (Number.isNaN(parsedAmount) || !/^\-?\d+(\.\d+)?$/.test(amountString)) {
       throw new Error(
         `Invalid amount in row ${index + 1}: "${data.amount}" is not a valid number`
       );
     }
-    const parsedAmount = Number(amountString);
 
     const tx: Transaction = {
       id: crypto.randomUUID(),


### PR DESCRIPTION
## Summary
- ensure validateTransactions rejects amounts with extraneous characters
- assert full error message for invalid amounts in tests

## Testing
- `npm test src/__tests__/transactions.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2bcf9d8788331b67c07f6fced9a2d