### PR TITLE
Persist transactions in sync route

### DIFF
--- a/src/__tests__/transactions-sync.persistence.test.ts
+++ b/src/__tests__/transactions-sync.persistence.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/transactions", () => {
+  const actual = jest.requireActual("@/lib/transactions")
+  return { ...actual, saveTransactions: jest.fn() }
+})
+
+import { POST as transactionsSync } from "@/app/api/transactions/sync/route"
+import { saveTransactions } from "@/lib/transactions"
+
+const baseTx = {
+  id: "1",
+  date: "2024-01-01",
+  description: "Test",
+  amount: 1,
+  currency: "USD",
+  type: "Income" as const,
+  category: "Misc",
+}
+
+describe("/api/transactions/sync persistence", () => {
+  beforeEach(() => {
+    (saveTransactions as jest.Mock).mockReset()
+  })
+
+  it("persists transactions and returns saved count", async () => {
+    (saveTransactions as jest.Mock).mockResolvedValue(undefined)
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ transactions: [baseTx] }),
+    })
+
+    const res = await transactionsSync(req)
+    expect(saveTransactions).toHaveBeenCalledWith([baseTx])
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ saved: 1 })
+  })
+
+  it("returns 500 when persistence fails", async () => {
+    (saveTransactions as jest.Mock).mockRejectedValue(new Error("boom"))
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ transactions: [baseTx] }),
+    })
+
+    const res = await transactionsSync(req)
+    expect(saveTransactions).toHaveBeenCalled()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: "boom" })
+  })
+})

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
-import { TransactionPayloadSchema } from "@/lib/transactions"
+import { TransactionPayloadSchema, saveTransactions } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
 
 /**
@@ -53,12 +53,11 @@ export async function POST(req: Request) {
   const { transactions } = parsed.data
 
   try {
-    // TODO: Persist transactions to the database.
-    return NextResponse.json({ received: transactions.length })
-  } catch {
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    )
+    await saveTransactions(transactions)
+    return NextResponse.json({ saved: transactions.length })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to save transactions"
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- persist validated transactions to Firestore in the `/api/transactions/sync` endpoint
- handle errors during persistence and return saved count
- add tests for successful and failing persistence paths

## Testing
- `npm run lint -- --file src/app/api/transactions/sync/route.ts --file src/__tests__/transactions-sync.persistence.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bcf6663083318ddd0847bb2fc2da