### PR TITLE
Refactor AI flows with shared prompt helper

### DIFF
--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -9,8 +9,8 @@
  * - AnalyzeReceiptOutput - The return type for the analyzeReceipt function.
  */
 
-import {ai} from '@/ai/genkit';
 import {DATA_URI_REGEX} from '@/lib/data-uri';
+import {definePromptFlow} from './utils';
 import {z} from 'genkit';
 
 export const AnalyzeReceiptInputSchema = z.object({
@@ -30,30 +30,14 @@ const AnalyzeReceiptOutputSchema = z.object({
 });
 export type AnalyzeReceiptOutput = z.infer<typeof AnalyzeReceiptOutputSchema>;
 
-export async function analyzeReceipt(input: AnalyzeReceiptInput): Promise<AnalyzeReceiptOutput> {
-  return analyzeReceiptFlow(input);
-}
-
-const prompt = ai.definePrompt({
-  name: 'analyzeReceiptPrompt',
-  input: {schema: AnalyzeReceiptInputSchema},
-  output: {schema: AnalyzeReceiptOutputSchema},
+export const analyzeReceipt = definePromptFlow<
+  AnalyzeReceiptInput,
+  AnalyzeReceiptOutput
+>({
+  name: 'analyzeReceipt',
+  inputSchema: AnalyzeReceiptInputSchema,
+  outputSchema: AnalyzeReceiptOutputSchema,
   prompt: `You are an expert receipt scanner. Analyze the provided receipt image and extract the vendor name (for the description), the total amount, and suggest a relevant category for a nursing professional (e.g., Food, Uniforms, Supplies, Transport, Certifications, Other). The transaction type is always 'Expense'.
 
 Receipt Image: {{media url=receiptImage}}`,
 });
-
-const analyzeReceiptFlow = ai.defineFlow(
-  {
-    name: 'analyzeReceiptFlow',
-    inputSchema: AnalyzeReceiptInputSchema,
-    outputSchema: AnalyzeReceiptOutputSchema,
-  },
-  async input => {
-    const {output} = await prompt(input);
-    if (!output) {
-      throw new Error('No output returned from analyzeReceiptPrompt');
-    }
-    return output;
-  }
-);

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -11,8 +11,8 @@
  * - AnalyzeSpendingHabitsOutput - The return type for the analyzeSpendingHabits function.
  */
 
-import {ai} from '@/ai/genkit';
 import {DATA_URI_REGEX} from '@/lib/data-uri';
+import {definePromptFlow} from './utils';
 import {z} from 'genkit';
 
 const GoalSchema = z.object({
@@ -49,14 +49,13 @@ const AnalyzeSpendingHabitsOutputSchema = z.object({
 });
 export type AnalyzeSpendingHabitsOutput = z.infer<typeof AnalyzeSpendingHabitsOutputSchema>;
 
-export async function analyzeSpendingHabits(input: AnalyzeSpendingHabitsInput): Promise<AnalyzeSpendingHabitsOutput> {
-  return analyzeSpendingHabitsFlow(input);
-}
-
-const prompt = ai.definePrompt({
-  name: 'analyzeSpendingHabitsPrompt',
-  input: {schema: AnalyzeSpendingHabitsInputSchema},
-  output: {schema: AnalyzeSpendingHabitsOutputSchema},
+export const analyzeSpendingHabits = definePromptFlow<
+  AnalyzeSpendingHabitsInput,
+  AnalyzeSpendingHabitsOutput
+>({
+  name: 'analyzeSpendingHabits',
+  inputSchema: AnalyzeSpendingHabitsInputSchema,
+  outputSchema: AnalyzeSpendingHabitsOutputSchema,
   prompt: `You are a personal finance advisor for nursing professionals. Analyze the user's spending habits based on the provided financial documents, their personal description, and their stated financial goals.
 
 Crucially, you must consider the 'importance' ranking of each goal. Recommendations should prioritize achieving the goals the user has marked as most important.
@@ -82,18 +81,3 @@ Based on all this information, provide:
 2.  **savingsOpportunities**: Areas where the user could potentially save money.
 3.  **recommendations**: Personalized, actionable recommendations that help the user achieve their *most important* goals faster.`,
 });
-
-const analyzeSpendingHabitsFlow = ai.defineFlow(
-  {
-    name: 'analyzeSpendingHabitsFlow',
-    inputSchema: AnalyzeSpendingHabitsInputSchema,
-    outputSchema: AnalyzeSpendingHabitsOutputSchema,
-  },
-  async input => {
-    const {output} = await prompt(input);
-    if (!output) {
-      throw new Error('No output returned from analyzeSpendingHabitsPrompt');
-    }
-    return output;
-  }
-);

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -9,7 +9,7 @@
  * - CalculateCashflowOutput - The return type for the calculateCashflow function.
  */
 
-import {ai} from '@/ai/genkit';
+import {definePromptFlow} from './utils';
 import {z} from 'genkit';
 
 const CalculateCashflowInputSchema = z.object({
@@ -43,14 +43,13 @@ const CalculateCashflowOutputSchema = z.object({
 });
 export type CalculateCashflowOutput = z.infer<typeof CalculateCashflowOutputSchema>;
 
-export async function calculateCashflow(input: CalculateCashflowInput): Promise<CalculateCashflowOutput> {
-  return calculateCashflowFlow(input);
-}
-
-const prompt = ai.definePrompt({
-  name: 'calculateCashflowPrompt',
-  input: {schema: CalculateCashflowInputSchema},
-  output: {schema: CalculateCashflowOutputSchema},
+export const calculateCashflow = definePromptFlow<
+  CalculateCashflowInput,
+  CalculateCashflowOutput
+>({
+  name: 'calculateCashflow',
+  inputSchema: CalculateCashflowInputSchema,
+  outputSchema: CalculateCashflowOutputSchema,
   prompt: `You are a financial analyst. Based on the user's provided income, taxes, and deductions, calculate their gross and net monthly cashflow.
 
 Annual Income: {{{annualIncome}}}
@@ -63,18 +62,3 @@ Total Monthly Deductions: {{{totalMonthlyDeductions}}}
 
 Return the results in the specified output format.`,
 });
-
-const calculateCashflowFlow = ai.defineFlow(
-  {
-    name: 'calculateCashflowFlow',
-    inputSchema: CalculateCashflowInputSchema,
-    outputSchema: CalculateCashflowOutputSchema,
-  },
-  async input => {
-    const {output} = await prompt(input);
-    if (!output) {
-      throw new Error('No output returned from calculateCashflowFlow');
-    }
-    return output;
-  }
-);

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -9,7 +9,7 @@
  * - SpendingForecastOutput - The return type for the predictSpending function.
  */
 
-import {ai} from '@/ai/genkit';
+import {definePromptFlow} from './utils';
 import {z} from 'genkit';
 
 const TransactionSchema = z.object({
@@ -41,14 +41,13 @@ export const SpendingForecastOutputSchema = z.object({
 });
 export type SpendingForecastOutput = z.infer<typeof SpendingForecastOutputSchema>;
 
-export async function predictSpending(input: SpendingForecastInput): Promise<SpendingForecastOutput> {
-  return spendingForecastFlow(input);
-}
-
-const prompt = ai.definePrompt({
-  name: 'spendingForecastPrompt',
-  input: {schema: SpendingForecastInputSchema},
-  output: {schema: SpendingForecastOutputSchema},
+export const predictSpending = definePromptFlow<
+  SpendingForecastInput,
+  SpendingForecastOutput
+>({
+  name: 'spendingForecast',
+  inputSchema: SpendingForecastInputSchema,
+  outputSchema: SpendingForecastOutputSchema,
   prompt: `You are a financial analyst. Review the user's past transactions and predict the total spending for the next three months.
 
 Transactions:
@@ -60,18 +59,3 @@ Return:
 1. forecast: an array with three objects, each having 'month' and 'amount'.
 2. analysis: a short summary of the predicted spending trend.`,
 });
-
-const spendingForecastFlow = ai.defineFlow(
-  {
-    name: 'spendingForecastFlow',
-    inputSchema: SpendingForecastInputSchema,
-    outputSchema: SpendingForecastOutputSchema,
-  },
-  async input => {
-    const {output} = await prompt(input);
-    if (!output) {
-      throw new Error('No output returned from spendingForecastPrompt');
-    }
-    return output;
-  }
-);

--- a/src/ai/flows/suggest-category.ts
+++ b/src/ai/flows/suggest-category.ts
@@ -1,10 +1,10 @@
 // This file uses server-side code.
 'use server';
 
-import { ai } from '@/ai/genkit';
 import { z } from 'genkit';
 
 import { classifyCategory } from '../train/category-model';
+import { definePromptFlow } from './utils';
 
 const SuggestCategoryInputSchema = z.object({
   description: z.string().describe('Description of the transaction'),
@@ -16,29 +16,17 @@ const SuggestCategoryOutputSchema = z.object({
 });
 export type SuggestCategoryOutput = z.infer<typeof SuggestCategoryOutputSchema>;
 
-const prompt = ai.definePrompt({
-  name: 'suggestCategoryPrompt',
-  input: { schema: SuggestCategoryInputSchema },
-  output: { schema: SuggestCategoryOutputSchema },
+const suggestCategoryFlow = definePromptFlow<
+  SuggestCategoryInput,
+  SuggestCategoryOutput
+>({
+  name: 'suggestCategory',
+  inputSchema: SuggestCategoryInputSchema,
+  outputSchema: SuggestCategoryOutputSchema,
   prompt: `You are a financial assistant. Suggest a spending category for the following transaction description suitable for personal budgeting (e.g., Food, Transport, Utilities, Salary, Other).
 
 Description: {{description}}`,
 });
-
-const suggestCategoryFlow = ai.defineFlow(
-  {
-    name: 'suggestCategoryFlow',
-    inputSchema: SuggestCategoryInputSchema,
-    outputSchema: SuggestCategoryOutputSchema,
-  },
-  async (input) => {
-    const { output } = await prompt(input);
-    if (!output) {
-      throw new Error('No output returned from suggestCategoryFlow');
-    }
-    return output;
-  }
-);
 
 /**
  * Suggest a category for a transaction description. Attempts to use the local

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -9,9 +9,9 @@
  * - SuggestDebtStrategyOutput - The return type for the suggestDebtStrategy function.
  */
 
-import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 import { RecurrenceValues } from '@/lib/types';
+import {definePromptFlow} from './utils';
 
 const DebtSchema = z.object({
     id: z.string(),
@@ -40,14 +40,13 @@ const SuggestDebtStrategyOutputSchema = z.object({
 });
 export type SuggestDebtStrategyOutput = z.infer<typeof SuggestDebtStrategyOutputSchema>;
 
-export async function suggestDebtStrategy(input: SuggestDebtStrategyInput): Promise<SuggestDebtStrategyOutput> {
-  return suggestDebtStrategyFlow(input);
-}
-
-const prompt = ai.definePrompt({
-  name: 'suggestDebtStrategyPrompt',
-  input: {schema: SuggestDebtStrategyInputSchema},
-  output: {schema: SuggestDebtStrategyOutputSchema},
+export const suggestDebtStrategy = definePromptFlow<
+  SuggestDebtStrategyInput,
+  SuggestDebtStrategyOutput
+>({
+  name: 'suggestDebtStrategy',
+  inputSchema: SuggestDebtStrategyInputSchema,
+  outputSchema: SuggestDebtStrategyOutputSchema,
   prompt: `You are an expert financial advisor specializing in debt management for healthcare professionals like nurses. Analyze the following list of debts and recommend the best payoff strategy.
 
 Your primary goal is to help the user save the most money on interest, so you should lean towards the 'avalanche' method (highest interest rate first) unless there is a very small debt that could be paid off quickly for a psychological win (the 'snowball' method).
@@ -63,18 +62,3 @@ Based on this, please provide:
 3.  **payoffOrder**: A list of the debts in the order they should be prioritized.
 4.  **summary**: A brief, encouraging summary of the plan to motivate the user.`,
 });
-
-const suggestDebtStrategyFlow = ai.defineFlow(
-  {
-    name: 'suggestDebtStrategyFlow',
-    inputSchema: SuggestDebtStrategyInputSchema,
-    outputSchema: SuggestDebtStrategyOutputSchema,
-  },
-  async input => {
-    const {output} = await prompt(input);
-    if (!output) {
-      throw new Error('No output returned from suggestDebtStrategyFlow');
-    }
-    return output;
-  }
-);

--- a/src/ai/flows/utils.ts
+++ b/src/ai/flows/utils.ts
@@ -1,0 +1,45 @@
+import { ai } from '@/ai/genkit';
+import type { ZodType } from 'zod';
+
+interface PromptFlowConfig<I, O> {
+  name: string;
+  prompt: string;
+  inputSchema: ZodType<I>;
+  outputSchema: ZodType<O>;
+}
+
+/**
+ * Helper to compose a prompt and flow.
+ *
+ * Given a base name, schemas, and prompt text, this defines the Genkit prompt and
+ * wraps it in a flow that validates input and output. The resulting flow function
+ * can be called directly with the input type to produce the output type.
+ */
+export function definePromptFlow<I, O>({
+  name,
+  prompt,
+  inputSchema,
+  outputSchema,
+}: PromptFlowConfig<I, O>) {
+  const promptDef = ai.definePrompt({
+    name: `${name}Prompt`,
+    input: { schema: inputSchema },
+    output: { schema: outputSchema },
+    prompt,
+  });
+
+  return ai.defineFlow(
+    {
+      name: `${name}Flow`,
+      inputSchema,
+      outputSchema,
+    },
+    async (input: I) => {
+      const { output } = await promptDef(input);
+      if (!output) {
+        throw new Error(`No output returned from ${name}Prompt`);
+      }
+      return output;
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `definePromptFlow` utility to combine prompt and flow setup
- refactor all AI flow modules to use the helper for cleaner definitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bcfbad748331844393b67128fd01