### PR TITLE
Clear toast timers on removal

### DIFF
--- a/src/__tests__/use-toast.test.ts
+++ b/src/__tests__/use-toast.test.ts
@@ -1,0 +1,20 @@
+import { toast, reducer } from "../hooks/use-toast";
+
+describe("useToast reducer", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("clears timers when toast is removed manually", () => {
+    const { id, dismiss } = toast({ description: "test" });
+    dismiss();
+    expect(jest.getTimerCount()).toBe(1);
+    reducer({ toasts: [{ id }] }, { type: "REMOVE_TOAST", toastId: id });
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -105,10 +105,17 @@ export const reducer = (state: State, action: Action): State => {
     }
     case "REMOVE_TOAST":
       if (action.toastId === undefined) {
+        toastTimeouts.forEach((timeout) => clearTimeout(timeout))
+        toastTimeouts.clear()
         return {
           ...state,
           toasts: [],
         }
+      }
+      const timeout = toastTimeouts.get(action.toastId)
+      if (timeout) {
+        clearTimeout(timeout)
+        toastTimeouts.delete(action.toastId)
       }
       return {
         ...state,


### PR DESCRIPTION
## Summary
- clear timeouts when toasts are removed to avoid lingering timers
- add unit test verifying manual dismissal cleans up timers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bcfaacec8331af7f073648db1b65