### PR TITLE
Expose category sync promise

### DIFF
--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -14,9 +14,9 @@ const onSnapshotMock = jest.fn();
 const deleteDocMock = jest.fn();
 
 jest.mock("firebase/firestore", () => ({
-  onSnapshot: (...args: any[]) => onSnapshotMock(...args),
+  onSnapshot: (...args: unknown[]) => onSnapshotMock(...args),
   setDoc: jest.fn(),
-  deleteDoc: (...args: any[]) => deleteDocMock(...args),
+  deleteDoc: (...args: unknown[]) => deleteDocMock(...args),
   updateDoc: jest.fn(),
   arrayUnion: jest.fn(),
   arrayRemove: jest.fn(),


### PR DESCRIPTION
## Summary
- expose `syncCategories` and `waitForCategorySync` so consumers can await category sync
- run category sync with retry/backoff and surface errors via logger
- fix lint error in use-debts test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2bcd41d848331bd2c1ed5225ef719