### PR TITLE
refactor: centralize firebase init

### DIFF
--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -14,9 +14,9 @@ const onSnapshotMock = jest.fn();
 const deleteDocMock = jest.fn();
 
 jest.mock("firebase/firestore", () => ({
-  onSnapshot: (...args: any[]) => onSnapshotMock(...args),
+  onSnapshot: (...args: unknown[]) => onSnapshotMock(...args),
   setDoc: jest.fn(),
-  deleteDoc: (...args: any[]) => deleteDocMock(...args),
+  deleteDoc: (...args: unknown[]) => deleteDocMock(...args),
   updateDoc: jest.fn(),
   arrayUnion: jest.fn(),
   arrayRemove: jest.fn(),

--- a/src/ai/train/category-model.ts
+++ b/src/ai/train/category-model.ts
@@ -1,7 +1,6 @@
 import { collection, getDocs, onSnapshot } from "firebase/firestore";
-import { db, initFirebase } from "@/lib/firebase";
+import { db } from "@/lib/firebase";
 
-initFirebase();
 
 interface FeedbackPair {
   description: string;

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from "next/server";
 import { runHousekeeping } from "@/lib/housekeeping";
-import { db, initFirebase } from "@/lib/firebase";
+import { db } from "@/lib/firebase";
 import { getCurrentTime } from "@/lib/internet-time";
 import { doc, runTransaction, setDoc } from "firebase/firestore";
 import { logger } from "@/lib/logger";
 
 const HEADER_NAME = "x-cron-secret";
 const WINDOW_MS = 60_000; // 1 minute
-initFirebase();
 const STATE_DOC = doc(db, "cron", "housekeeping");
 
 // Exposed for tests to reset the persisted rate limiter

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -5,9 +5,8 @@ import type { Goal } from "@/lib/types";
 import { GoalCard } from "@/components/goals/goal-card";
 import { AddGoalDialog } from "@/components/goals/add-goal-dialog";
 import { collection, addDoc, getDocs, updateDoc, deleteDoc, doc } from "firebase/firestore";
-import { db, initFirebase } from "@/lib/firebase";
+import { db } from "@/lib/firebase";
 
-initFirebase();
 
 export default function GoalsPage() {
   const [goals, setGoals] = useState<Goal[]>([]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,8 @@ import {
   createUserWithEmailAndPassword,
   type AuthError,
 } from "firebase/auth"
-import { auth, initFirebase } from "@/lib/firebase"
+import { auth } from "@/lib/firebase"
 
-initFirebase()
 import { authErrorMessages, DEFAULT_AUTH_ERROR_MESSAGE } from "@/lib/auth-errors"
 
 import { Button } from "@/components/ui/button"

--- a/src/components/auth/auth-provider.tsx
+++ b/src/components/auth/auth-provider.tsx
@@ -8,11 +8,10 @@ import {
   startTransition,
 } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
-import { auth, initFirebase } from "@/lib/firebase";
+import { auth } from "@/lib/firebase";
 import { usePathname, useRouter } from "next/navigation";
 import { z } from "zod";
 
-initFirebase();
 
 interface AuthContextType {
   user: User | null;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { auth, initFirebase } from "@/lib/firebase"
+import { auth } from "@/lib/firebase"
 import { signOut } from "firebase/auth"
 import {
   CircleUser,
@@ -30,7 +30,6 @@ import { useToast } from "@/hooks/use-toast"
 import { ThemeToggle } from "@/components/ThemeToggle"
 import { logger } from "@/lib/logger"
 
-initFirebase()
 
 export default function AppHeader() {
   const router = useRouter()

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -2,11 +2,10 @@
 
 import { useEffect, useRef } from "react"
 import { getQueuedTransactions, clearQueuedTransactions } from "@/lib/offline"
-import { auth, initFirebase } from "@/lib/firebase"
+import { auth } from "@/lib/firebase"
 import { toast } from "@/hooks/use-toast"
 import { logger } from "@/lib/logger"
 
-initFirebase()
 
 export function ServiceWorker() {
   const debounceId = useRef<ReturnType<typeof setTimeout> | null>(null)

--- a/src/lib/category-feedback.ts
+++ b/src/lib/category-feedback.ts
@@ -1,8 +1,7 @@
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
-import { db, initFirebase } from "./firebase";
+import { db } from "./firebase";
 import { logger } from "./logger";
 
-initFirebase();
 
 /**
  * Persist a (description, category) feedback pair. This is used when a user

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -3,10 +3,9 @@
 // case-insensitive manner while preserving their original casing for display.
 
 import { doc, getDocs, setDoc, deleteDoc, writeBatch } from "firebase/firestore";
-import { db, categoriesCollection, initFirebase } from "./firebase";
+import { db, categoriesCollection } from "./firebase";
 import { logger } from "./logger";
 
-initFirebase();
 
 const STORAGE_KEY = "categories";
 

--- a/src/lib/debts/index.ts
+++ b/src/lib/debts/index.ts
@@ -1,5 +1,5 @@
 import { collection, doc, QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
-import { db, initFirebase } from "../firebase";
+import { db } from "../firebase";
 import type { Debt } from "../types";
 
 // Firestore data converter for `Debt` documents.
@@ -14,6 +14,5 @@ const debtConverter = {
 };
 
 // `debts` collection reference using the converter.
-initFirebase();
 export const debtsCollection = collection(db, "debts").withConverter(debtConverter);
 export const debtDoc = (id: string) => doc(db, "debts", id).withConverter(debtConverter);

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -73,5 +73,8 @@ export function initFirebase() {
   return { app, auth, db, categoriesCollection };
 }
 
+// Initialize Firebase at module load to avoid repeated calls across components.
+initFirebase();
+
 export { app, auth, db, categoriesCollection };
 

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
 import { collection, doc, writeBatch, getDocs } from "firebase/firestore";
-import { db, initFirebase } from "./firebase";
+import { db } from "./firebase";
 import type { Transaction } from "./types";
 import { currencyCodeSchema } from "./currency";
 
-initFirebase();
 
 export const TransactionPayloadSchema = z.object({
   id: z.string(),

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -11,12 +11,11 @@ import {
   writeBatch,
   QueryDocumentSnapshot,
 } from "firebase/firestore";
-import { db, initFirebase } from "../lib/firebase";
+import { db } from "../lib/firebase";
 import type { Transaction, Debt, Goal } from "../lib/types";
 import { getCurrentTime } from "../lib/internet-time";
 import { logger } from "../lib/logger";
 
-initFirebase();
 
 /**
  * Moves transactions older than the provided cutoff date to an archive collection


### PR DESCRIPTION
## Summary
- initialize Firebase once at module load
- remove redundant `initFirebase` calls across components and services
- adjust test mocks to satisfy lint rules

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2bcd099e483318fe928729add966e