### PR TITLE
chore: rename cost-of-living dataset to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ defaults to the pay period beginning on January 7, 2024.
 ## Cost of Living Dataset
 
 Annual expense benchmarks are sourced from the **BEA Regional Price Parities**
-release. The data file `src/data/costOfLiving2024.ts` stores per-adult yearly
+release. The data file `src/data/costOfLiving2025.ts` stores per-adult yearly
 costs for housing, groceries, utilities, transportation, healthcare, and
 miscellaneous categories. Use `calculateCostOfLiving` to scale values by
 household composition. Run `node scripts/update-cost-of-living.ts` each year to

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,4 +1,4 @@
-import type { Region } from '@/data/costOfLiving2024';
+import type { Region } from '@/data/costOfLiving2025';
 
 interface Schema<T = unknown> {
   parse: (value: unknown) => T;

--- a/src/ai/flows/cost-of-living.ts
+++ b/src/ai/flows/cost-of-living.ts
@@ -1,4 +1,4 @@
-import { costOfLiving2024, Region, RegionCost } from '@/data/costOfLiving2024';
+import { costOfLiving2025, Region, RegionCost } from '@/data/costOfLiving2025';
 
 export interface CalculateCostOfLivingInput {
   region: Region;
@@ -24,7 +24,7 @@ export function calculateCostOfLiving({ region, adults, children }: CalculateCos
   if (adults <= 0 || children < 0) {
     throw new Error('Invalid household composition');
   }
-  const base = costOfLiving2024.regions[region];
+  const base = costOfLiving2025.regions[region];
   if (!base) {
     throw new Error(`Unknown region: ${region}`);
   }

--- a/src/app/cost-of-living/page.tsx
+++ b/src/app/cost-of-living/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from 'react';
-import { costOfLiving2024 } from '@/data/costOfLiving2024';
+import { costOfLiving2025 } from '@/data/costOfLiving2025';
 import { calculateCostOfLiving, CostOfLivingBreakdown } from '@/ai/flows/cost-of-living';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -16,7 +16,7 @@ import {
 } from '@/components/ui/select';
 
 export default function CostOfLivingPage() {
-  const regions = Object.keys(costOfLiving2024.regions);
+  const regions = Object.keys(costOfLiving2025.regions);
   const [region, setRegion] = useState(regions[0]);
   const [adults, setAdults] = useState(1);
   const [children, setChildren] = useState(0);
@@ -25,7 +25,7 @@ export default function CostOfLivingPage() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const breakdown = calculateCostOfLiving({
-      region: region as keyof typeof costOfLiving2024.regions,
+      region: region as keyof typeof costOfLiving2025.regions,
       adults,
       children,
     });
@@ -119,7 +119,7 @@ export default function CostOfLivingPage() {
                 ${Math.round(result.annual.total).toLocaleString()} / yr
               </p>
               <p className="text-xs text-muted-foreground mt-2">
-                Source: {costOfLiving2024.source} ({costOfLiving2024.baseYear})
+                Source: {costOfLiving2025.source} ({costOfLiving2025.baseYear})
               </p>
             </CardContent>
           </Card>

--- a/src/data/__tests__/cost-of-living-dataset.test.ts
+++ b/src/data/__tests__/cost-of-living-dataset.test.ts
@@ -1,7 +1,7 @@
-import { costOfLiving2024 } from '@/data/costOfLiving2024';
+import { costOfLiving2025 } from '@/data/costOfLiving2025';
 
 describe('cost-of-living dataset', () => {
   it('is current', () => {
-    expect(costOfLiving2024.baseYear).toBeGreaterThanOrEqual(new Date().getFullYear());
+    expect(costOfLiving2025.baseYear).toBeGreaterThanOrEqual(new Date().getFullYear());
   });
 });

--- a/src/data/costOfLiving2025.ts
+++ b/src/data/costOfLiving2025.ts
@@ -13,7 +13,7 @@ export interface CostOfLivingDataset {
   regions: Record<string, RegionCost>;
 }
 
-export const costOfLiving2024: CostOfLivingDataset = {
+export const costOfLiving2025: CostOfLivingDataset = {
   baseYear: 2025,
   source: 'BEA Regional Price Parities 2024',
   regions: {
@@ -36,4 +36,4 @@ export const costOfLiving2024: CostOfLivingDataset = {
   },
 } as const;
 
-export type Region = keyof typeof costOfLiving2024.regions;
+export type Region = keyof typeof costOfLiving2025.regions;


### PR DESCRIPTION
## Summary
- rename cost-of-living dataset and constant to 2025
- update imports in app, AI flow, tests, and docs

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in src/__tests__/use-debts.test.tsx)*
- `npx eslint src/data/costOfLiving2025.ts src/ai/flows/cost-of-living.ts src/app/cost-of-living/page.tsx src/ai/flows/__tests__/validation.test.ts src/data/__tests__/cost-of-living-dataset.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2bccf7ed08331bb3265b884c74381