### PR TITLE
Allow category model retrain timer to unref

### DIFF
--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -14,9 +14,11 @@ const onSnapshotMock = jest.fn();
 const deleteDocMock = jest.fn();
 
 jest.mock("firebase/firestore", () => ({
-  onSnapshot: (...args: any[]) => onSnapshotMock(...args),
+  onSnapshot: (...args: unknown[]) =>
+    onSnapshotMock(...(args as Parameters<typeof onSnapshotMock>)),
   setDoc: jest.fn(),
-  deleteDoc: (...args: any[]) => deleteDocMock(...args),
+  deleteDoc: (...args: unknown[]) =>
+    deleteDocMock(...(args as Parameters<typeof deleteDocMock>)),
   updateDoc: jest.fn(),
   arrayUnion: jest.fn(),
   arrayRemove: jest.fn(),

--- a/src/ai/train/category-model.ts
+++ b/src/ai/train/category-model.ts
@@ -89,6 +89,7 @@ export async function initCategoryModel(): Promise<void> {
   intervalId = setInterval(() => {
     trainCategoryModel();
   }, 60 * 60 * 1000);
+  intervalId.unref();
 }
 
 export function teardownCategoryModel(): void {


### PR DESCRIPTION
## Summary
- unref category model retraining interval so process can exit naturally
- replace explicit any types in use-debts test mocks to satisfy lint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2bcca5e788331bba393ce5f132df6