### PR TITLE
test: use unknown for Firestore mocks

### DIFF
--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -14,9 +14,9 @@ const onSnapshotMock = jest.fn();
 const deleteDocMock = jest.fn();
 
 jest.mock("firebase/firestore", () => ({
-  onSnapshot: (...args: any[]) => onSnapshotMock(...args),
+  onSnapshot: (...args: unknown[]) => onSnapshotMock(...args),
   setDoc: jest.fn(),
-  deleteDoc: (...args: any[]) => deleteDocMock(...args),
+  deleteDoc: (...args: unknown[]) => deleteDocMock(...args),
   updateDoc: jest.fn(),
   arrayUnion: jest.fn(),
   arrayRemove: jest.fn(),


### PR DESCRIPTION
## Summary
- use unknown[] instead of any[] in use-debts Firestore mocks

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b2be5781448331a911bb8ee2935268