### PR TITLE
test: avoid any in firestore mocks

### DIFF
--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -14,9 +14,9 @@ const onSnapshotMock = jest.fn();
 const deleteDocMock = jest.fn();
 
 jest.mock("firebase/firestore", () => ({
-  onSnapshot: (...args: any[]) => onSnapshotMock(...args),
+  onSnapshot: (...args: unknown[]) => onSnapshotMock(...args),
   setDoc: jest.fn(),
-  deleteDoc: (...args: any[]) => deleteDocMock(...args),
+  deleteDoc: (...args: unknown[]) => deleteDocMock(...args),
   updateDoc: jest.fn(),
   arrayUnion: jest.fn(),
   arrayRemove: jest.fn(),


### PR DESCRIPTION
## Summary
- replace `any[]` rest parameters with `unknown[]` in Firestore mocks

## Testing
- `npm test src/__tests__/use-debts.test.tsx`
- `npm run lint -- --file src/__tests__/use-debts.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b2be7c517883319e1233d83cf840b8