### PR TITLE
Avoid re-registering existing service workers

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -128,4 +128,34 @@ describe("Service worker registration", () => {
       configurable: true,
     })
   })
+
+  it("does not register when existing registration without controller", async () => {
+    const register = jest.fn().mockResolvedValue(undefined)
+    const getRegistration = jest.fn().mockResolvedValue({})
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        register,
+        getRegistration,
+        controller: undefined,
+      },
+      configurable: true,
+    })
+    Object.defineProperty(navigator, "onLine", {
+      value: false,
+      configurable: true,
+    })
+
+    render(<ServiceWorker />)
+
+    await act(async () => {})
+
+    expect(register).not.toHaveBeenCalled()
+
+    const nav = navigator as Navigator & { serviceWorker?: ServiceWorkerContainer }
+    delete nav.serviceWorker
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      configurable: true,
+    })
+  })
 })

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -98,7 +98,14 @@ export function ServiceWorker() {
     const registerAndListen = async () => {
       if ("serviceWorker" in navigator) {
         try {
-          await navigator.serviceWorker.register("/sw.js", { type: "module" })
+          const existing = navigator.serviceWorker.getRegistration
+            ? await navigator.serviceWorker.getRegistration()
+            : undefined
+          if (!navigator.serviceWorker.controller && existing) {
+            // Service worker already registered, no need to register again
+          } else {
+            await navigator.serviceWorker.register("/sw.js", { type: "module" })
+          }
         } catch (error) {
           logger.error("Service worker registration failed", error)
         }


### PR DESCRIPTION
## Summary
- skip service worker registration when a registration already exists without a controller
- add test to ensure registration is skipped when a service worker is already registered

## Testing
- `npm test src/__tests__/service-worker.test.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2be7ccb1c8331a1085c5c64a7dadb