### PR TITLE
test: type firebase mocks in use-debts tests

### DIFF
--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { render, act } from "@testing-library/react";
 import { useDebts } from "@/lib/debts/use-debts";
+import type {
+  onSnapshot as firestoreOnSnapshot,
+  deleteDoc as firestoreDeleteDoc,
+} from "firebase/firestore";
 
 // Mock logger to silence output
 jest.mock("@/lib/logger", () => ({ logger: { error: jest.fn() } }));
@@ -14,9 +18,15 @@ const onSnapshotMock = jest.fn();
 const deleteDocMock = jest.fn();
 
 jest.mock("firebase/firestore", () => ({
-  onSnapshot: (...args: any[]) => onSnapshotMock(...args),
+  onSnapshot: (
+    ...args: Parameters<typeof firestoreOnSnapshot>
+  ): ReturnType<typeof firestoreOnSnapshot> =>
+    onSnapshotMock(...args),
   setDoc: jest.fn(),
-  deleteDoc: (...args: any[]) => deleteDocMock(...args),
+  deleteDoc: (
+    ...args: Parameters<typeof firestoreDeleteDoc>
+  ): ReturnType<typeof firestoreDeleteDoc> =>
+    deleteDocMock(...args),
   updateDoc: jest.fn(),
   arrayUnion: jest.fn(),
   arrayRemove: jest.fn(),


### PR DESCRIPTION
## Summary
- type Firebase mock parameters in use-debts tests to avoid `any`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2beeedb4c8331a4d0f975897540ff