### PR TITLE
refactor: initialize firebase within form submission

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,7 @@ import {
   createUserWithEmailAndPassword,
   type AuthError,
 } from "firebase/auth"
-import { auth, initFirebase } from "@/lib/firebase"
-
-initFirebase()
+import { initFirebase } from "@/lib/firebase"
 import { authErrorMessages, DEFAULT_AUTH_ERROR_MESSAGE } from "@/lib/auth-errors"
 
 import { Button } from "@/components/ui/button"
@@ -33,6 +31,7 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
+    const { auth } = initFirebase()
 
     try {
       if (isLoginView) {


### PR DESCRIPTION
## Summary
- initialize Firebase inside login form submission handler
- remove direct `auth` import prior to Firebase initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2beefdf748331a8951454d194ce31