### PR TITLE
Ensure carousel listeners are cleaned up

### DIFF
--- a/src/__tests__/carousel.test.tsx
+++ b/src/__tests__/carousel.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Carousel } from '@/components/ui/carousel';
+
+jest.mock('lucide-react', () => ({
+  ArrowLeft: () => null,
+  ArrowRight: () => null,
+}));
+
+const onMock = jest.fn();
+const offMock = jest.fn();
+let emblaApi: any;
+
+function mockUseEmbla() {
+  emblaApi = {
+    on: onMock,
+    off: offMock,
+    canScrollPrev: jest.fn().mockReturnValue(false),
+    canScrollNext: jest.fn().mockReturnValue(false),
+    scrollPrev: jest.fn(),
+    scrollNext: jest.fn(),
+  };
+  return [jest.fn(), emblaApi];
+}
+
+jest.mock('embla-carousel-react', () => ({
+  __esModule: true,
+  default: mockUseEmbla,
+  useEmblaCarousel: mockUseEmbla,
+}));
+
+describe('Carousel', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes event listeners on unmount', () => {
+    const { unmount } = render(
+      <Carousel>
+        <div />
+      </Carousel>
+    );
+
+    expect(onMock).toHaveBeenCalledWith('reInit', expect.any(Function));
+    expect(onMock).toHaveBeenCalledWith('select', expect.any(Function));
+
+    const listener = onMock.mock.calls[0][1];
+
+    unmount();
+
+    expect(offMock).toHaveBeenCalledWith('select', listener);
+    expect(offMock).toHaveBeenCalledWith('reInit', listener);
+  });
+});

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -116,7 +116,8 @@ const Carousel = React.forwardRef<
       api.on("select", onSelect)
 
       return () => {
-        api?.off("select", onSelect)
+        api.off("select", onSelect)
+        api.off("reInit", onSelect)
       }
     }, [api, onSelect])
 


### PR DESCRIPTION
## Summary
- Remove `select` and `reInit` listeners during carousel cleanup
- Add unit test verifying both listeners are detached on unmount

## Testing
- `npm test src/__tests__/carousel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b2bf8664ec8331b09ff0988c9b1fc5