### PR TITLE
feat(worker): validate messages and forward errors

### DIFF
--- a/src/__tests__/mapWorker.test.ts
+++ b/src/__tests__/mapWorker.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+import { Worker } from "node:worker_threads"
+import fs from "node:fs"
+import path from "node:path"
+import ts from "typescript"
+
+function createWorker() {
+  const filePath = path.resolve(__dirname, "../lib/mapWorker.ts")
+  const source = fs.readFileSync(filePath, "utf8")
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS },
+  })
+  return new Worker(outputText, { eval: true })
+}
+
+describe("mapWorker", () => {
+  it("squares numbers", async () => {
+    const worker = createWorker()
+    const result = await new Promise((resolve, reject) => {
+      worker.once("message", resolve)
+      worker.once("error", reject)
+      worker.postMessage({ type: "square", payload: [2, 3] })
+    })
+    await worker.terminate()
+    expect(result).toEqual({ type: "square", payload: [4, 9] })
+  })
+
+  it("rejects invalid inputs", async () => {
+    const worker = createWorker()
+    const result = await new Promise(resolve => {
+      worker.once("message", resolve)
+      worker.postMessage({ type: "square", payload: [1, "a"] as any })
+    })
+    await worker.terminate()
+    expect(result).toEqual({
+      type: "error",
+      error: "Input must be an array of numbers",
+    })
+  })
+
+  it("propagates worker errors", async () => {
+    const worker = createWorker()
+    const result = await new Promise(resolve => {
+      worker.once("message", resolve)
+      worker.postMessage({ type: "boom", payload: [] as any })
+    })
+    await worker.terminate()
+    expect(result).toEqual({
+      type: "error",
+      error: expect.stringContaining("Unknown message type"),
+    })
+  })
+})

--- a/src/lib/mapWorker.ts
+++ b/src/lib/mapWorker.ts
@@ -1,9 +1,50 @@
 import { parentPort } from "node:worker_threads"
 
+export interface SquareMessage {
+  type: "square"
+  payload: number[]
+}
+
+export interface ErrorMessage {
+  type: "error"
+  error: string
+}
+
+type IncomingMessage = SquareMessage & { [key: string]: unknown }
+type OutgoingMessage = SquareMessage | ErrorMessage
+
 export function square(numbers: number[]): number[] {
   return numbers.map(n => n * n)
 }
 
-parentPort?.on("message", (numbers: number[]) => {
-  parentPort?.postMessage(square(numbers))
+parentPort?.on("error", err => {
+  parentPort?.postMessage({
+    type: "error",
+    error: err instanceof Error ? err.message : String(err),
+  })
+})
+
+parentPort?.on("message", (message: IncomingMessage) => {
+  if (message?.type !== "square") {
+    parentPort?.emit(
+      "error",
+      new Error(`Unknown message type: ${String(message?.type)}`)
+    )
+    return
+  }
+
+  const numbers = message.payload
+
+  if (!Array.isArray(numbers) || numbers.some(n => typeof n !== "number")) {
+    parentPort?.postMessage({
+      type: "error",
+      error: "Input must be an array of numbers",
+    } satisfies ErrorMessage)
+    return
+  }
+
+  parentPort?.postMessage({
+    type: "square",
+    payload: square(numbers),
+  } satisfies OutgoingMessage)
 })


### PR DESCRIPTION
## Summary
- validate incoming worker messages and propagate worker errors
- cover worker error propagation and invalid input with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bf7ed7488331bf98c61a8fe0ea7f