### PR TITLE
Refactor service worker sync flow

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -11,10 +11,10 @@ jest.mock("../lib/offline", () => ({
 }))
 
 jest.mock("../lib/firebase", () => ({
-  auth: { currentUser: { getIdToken: jest.fn().mockResolvedValue("token") } },
-  initFirebase: jest.fn(),
+  initFirebase: jest.fn(() => ({
+    auth: { currentUser: { getIdToken: jest.fn().mockResolvedValue("token") } },
+  })),
 }))
-import { initFirebase } from "../lib/firebase"
 
 beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test"
@@ -23,7 +23,6 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test"
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test"
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test"
-  initFirebase()
 })
 
 jest.mock("../hooks/use-toast", () => ({ toast: jest.fn() }))

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -1,104 +1,30 @@
 "use client"
 
 import { useEffect, useRef } from "react"
-import { getQueuedTransactions, clearQueuedTransactions } from "@/lib/offline"
-import { auth, initFirebase } from "@/lib/firebase"
-import { toast } from "@/hooks/use-toast"
+import { syncQueuedTransactions } from "@/lib/sync-queued-transactions"
+import { initFirebase } from "@/lib/firebase"
 import { logger } from "@/lib/logger"
-
-initFirebase()
 
 export function ServiceWorker() {
   const debounceId = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const retryTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const retryCount = useRef(0)
-  const notified = useRef(false)
-  const abortController = useRef<AbortController | null>(null)
+  const syncCleanup = useRef<(() => void) | null>(null)
 
   useEffect(() => {
-    const syncQueued = async () => {
-      const queuedResult = await getQueuedTransactions()
-      if (!queuedResult.ok) {
-        logger.error("Failed to retrieve queued transactions", queuedResult.error)
-        return
-      }
-      const queued = queuedResult.value
-      if (!queued.length) return
-
-      abortController.current?.abort()
-      const controller = new AbortController()
-      abortController.current = controller
-
-      let timedOut = false
-      const timeoutId = setTimeout(() => {
-        timedOut = true
-        controller.abort()
-      }, 10000)
-
-      try {
-        const user = auth.currentUser
-        const token = user ? await user.getIdToken() : null
-        if (!token) {
-          logger.error("Cannot sync queued transactions without auth")
-          return
-        }
-
-        const response = await fetch("/api/transactions/sync", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ transactions: queued }),
-          signal: controller.signal,
-        })
-
-        if (!response.ok) {
-          throw new Error(await response.text())
-        }
-
-        const clearResult = await clearQueuedTransactions()
-        if (!clearResult.ok) {
-          logger.error("Failed to clear queued transactions", clearResult.error)
-        }
-        retryCount.current = 0
-        notified.current = false
-      } catch (error) {
-        if (controller.signal.aborted && !timedOut) return
-
-        retryCount.current += 1
-        const delay = Math.min(1000 * 2 ** (retryCount.current - 1), 30000)
-
-        if (retryCount.current >= 5 && !notified.current) {
-          toast({
-            title: "Sync failed",
-            description:
-              "Unable to sync offline transactions. We'll keep trying in the background.",
-          })
-          notified.current = true
-        }
-
-        logger.error("Failed to sync queued transactions", error)
-        if (retryTimeoutId.current) clearTimeout(retryTimeoutId.current)
-        retryTimeoutId.current = setTimeout(syncQueued, delay)
-      } finally {
-        clearTimeout(timeoutId)
-      }
-    }
+    const { auth } = initFirebase()
 
     const handleOnline = () => {
-      abortController.current?.abort()
+      syncCleanup.current?.()
       if (debounceId.current) clearTimeout(debounceId.current)
-      if (retryTimeoutId.current) clearTimeout(retryTimeoutId.current)
-      retryCount.current = 0
-      notified.current = false
-      debounceId.current = setTimeout(syncQueued, 1000)
+      debounceId.current = setTimeout(() => {
+        syncCleanup.current = syncQueuedTransactions(auth)
+      }, 1000)
     }
 
     const registerAndListen = async () => {
       if ("serviceWorker" in navigator) {
         try {
           await navigator.serviceWorker.register("/sw.js", { type: "module" })
+          logger.info("Service worker registered")
         } catch (error) {
           logger.error("Service worker registration failed", error)
         }
@@ -113,8 +39,7 @@ export function ServiceWorker() {
     return () => {
       window.removeEventListener("online", handleOnline)
       if (debounceId.current) clearTimeout(debounceId.current)
-      if (retryTimeoutId.current) clearTimeout(retryTimeoutId.current)
-      abortController.current?.abort()
+      syncCleanup.current?.()
     }
   }, [])
 

--- a/src/lib/sync-queued-transactions.ts
+++ b/src/lib/sync-queued-transactions.ts
@@ -1,0 +1,92 @@
+import type { Auth } from "firebase/auth";
+import { getQueuedTransactions, clearQueuedTransactions } from "./offline";
+import { toast } from "@/hooks/use-toast";
+import { logger } from "./logger";
+
+/**
+ * Sync queued transactions with the backend using exponential backoff.
+ * Returns a cleanup function to abort in-flight requests and clear timers.
+ */
+export function syncQueuedTransactions(auth: Auth): () => void {
+  let controller: AbortController | null = null;
+  let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  let retryCount = 0;
+  let notified = false;
+
+  const sync = async (): Promise<void> => {
+    const queuedResult = await getQueuedTransactions();
+    if (!queuedResult.ok) {
+      logger.error("Failed to retrieve queued transactions", queuedResult.error);
+      return;
+    }
+    const queued = queuedResult.value;
+    if (!queued.length) return;
+
+    controller?.abort();
+    controller = new AbortController();
+
+    let timedOut = false;
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller?.abort();
+    }, 10000);
+
+    try {
+      const user = auth.currentUser;
+      const token = user ? await user.getIdToken() : null;
+      if (!token) {
+        logger.error("Cannot sync queued transactions without auth");
+        return;
+      }
+
+      const response = await fetch("/api/transactions/sync", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ transactions: queued }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+
+      const clearResult = await clearQueuedTransactions();
+      if (!clearResult.ok) {
+        logger.error("Failed to clear queued transactions", clearResult.error);
+      }
+      retryCount = 0;
+      notified = false;
+    } catch (error) {
+      if (controller?.signal.aborted && !timedOut) return;
+
+      retryCount += 1;
+      const delay = Math.min(1000 * 2 ** (retryCount - 1), 30000);
+
+      if (retryCount >= 5 && !notified) {
+        toast({
+          title: "Sync failed",
+          description:
+            "Unable to sync offline transactions. We'll keep trying in the background.",
+        });
+        notified = true;
+      }
+
+      logger.error("Failed to sync queued transactions", error);
+      logger.info(`Retrying sync in ${delay}ms`);
+      if (retryTimeoutId) clearTimeout(retryTimeoutId);
+      retryTimeoutId = setTimeout(sync, delay);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  };
+
+  sync();
+
+  return () => {
+    controller?.abort();
+    if (retryTimeoutId) clearTimeout(retryTimeoutId);
+  };
+}


### PR DESCRIPTION
## Summary
- initialize Firebase inside `ServiceWorker` effect
- move queued transaction syncing with backoff to `syncQueuedTransactions`
- add logging and cleanup for network retries and service worker registration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bf7e36088331ba4d843e83a66acd