### PR TITLE
Refactor toast dismissal scheduling

### DIFF
--- a/src/__tests__/use-toast.test.ts
+++ b/src/__tests__/use-toast.test.ts
@@ -1,0 +1,30 @@
+import { renderHook, act } from "@testing-library/react"
+import { useToast, toast } from "../hooks/use-toast"
+
+describe("dismissToast", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("schedules removal after dismiss", () => {
+    const { result } = renderHook(() => useToast())
+
+    act(() => {
+      const { dismiss } = toast({ description: "test" })
+      dismiss()
+    })
+
+    expect(result.current.toasts).toHaveLength(1)
+    expect(result.current.toasts[0].open).toBe(false)
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(result.current.toasts).toHaveLength(0)
+  })
+})

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -81,16 +81,6 @@ export const reducer = (state: State, action: Action): State => {
     case "DISMISS_TOAST": {
       const { toastId } = action
 
-      // ! Side effects ! - This could be extracted into a dismissToast() action,
-      // but I'll keep it here for simplicity
-      if (toastId) {
-        addToRemoveQueue(toastId)
-      } else {
-        state.toasts.forEach((toast) => {
-          addToRemoveQueue(toast.id)
-        })
-      }
-
       return {
         ...state,
         toasts: state.toasts.map((t) =>
@@ -131,6 +121,18 @@ function dispatch(action: Action) {
   })
 }
 
+function dismissToast(toastId?: string) {
+  if (toastId) {
+    addToRemoveQueue(toastId)
+    dispatch({ type: "DISMISS_TOAST", toastId })
+  } else {
+    memoryState.toasts.forEach((toast) => {
+      addToRemoveQueue(toast.id)
+    })
+    dispatch({ type: "DISMISS_TOAST" })
+  }
+}
+
 type Toast = Omit<ToasterToast, "id">
 
 function toast({ ...props }: Toast) {
@@ -141,7 +143,7 @@ function toast({ ...props }: Toast) {
       type: "UPDATE_TOAST",
       toast: { ...props, id },
     })
-  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+  const dismiss = () => dismissToast(id)
 
   dispatch({
     type: "ADD_TOAST",
@@ -175,7 +177,7 @@ function useToast() {
   return {
     ...state,
     toast,
-    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+    dismiss: (toastId?: string) => dismissToast(toastId),
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `dismissToast` helper to schedule removal and dispatch `DISMISS_TOAST`
- Remove reducer side-effects and route `toast` and `useToast` dismissals through the new helper
- Test that dismissing a toast schedules its removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bf7d35208331a83c9f3a8d0c15d5