### PR TITLE
Persist transactions and test sync endpoint

### DIFF
--- a/src/__tests__/transactions-sync.test.ts
+++ b/src/__tests__/transactions-sync.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/transactions", () => {
+  const actual = jest.requireActual("@/lib/transactions")
+  return {
+    ...actual,
+    saveTransactions: jest.fn().mockResolvedValue(undefined),
+  }
+})
+
+import { POST as transactionsSync } from "@/app/api/transactions/sync/route"
+import { saveTransactions } from "@/lib/transactions"
+
+const baseTx = {
+  id: "1",
+  date: "2024-01-01",
+  description: "Test",
+  amount: 1,
+  currency: "USD",
+  type: "Income" as const,
+  category: "Misc",
+}
+
+describe("/api/transactions/sync persistence", () => {
+  beforeEach(() => {
+    ;(saveTransactions as jest.Mock).mockClear()
+  })
+
+  it("saves transactions via saveTransactions", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ transactions: [baseTx] }),
+    })
+
+    const res = await transactionsSync(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data).toEqual({ received: 1 })
+    expect(saveTransactions).toHaveBeenCalledTimes(1)
+    expect(saveTransactions).toHaveBeenCalledWith([baseTx])
+  })
+
+  it("propagates persistence errors", async () => {
+    ;(saveTransactions as jest.Mock).mockRejectedValueOnce(
+      Object.assign(new Error("db failed"), { status: 503 }),
+    )
+
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ transactions: [baseTx] }),
+    })
+
+    const res = await transactionsSync(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(503)
+    expect(data).toEqual({ error: "db failed" })
+  })
+})

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
-import { TransactionPayloadSchema } from "@/lib/transactions"
+import { TransactionPayloadSchema, saveTransactions } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
+import { logger } from "@/lib/logger"
 
 /**
  * Generic transaction syncing endpoint.
@@ -53,12 +54,16 @@ export async function POST(req: Request) {
   const { transactions } = parsed.data
 
   try {
-    // TODO: Persist transactions to the database.
+    await saveTransactions(transactions)
     return NextResponse.json({ received: transactions.length })
-  } catch {
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    )
+  } catch (err) {
+    logger.error("Failed to persist transactions", err)
+    const message =
+      err instanceof Error ? err.message : "Internal server error"
+    const status =
+      typeof err === "object" && err && "status" in err
+        ? (err as { status?: number }).status || 500
+        : 500
+    return NextResponse.json({ error: message }, { status })
   }
 }


### PR DESCRIPTION
## Summary
- save transactions in `/api/transactions/sync` endpoint
- log and propagate persistence errors
- add tests verifying transaction storage and error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bf7bce00833180f665fdb41bb78e