### PR TITLE
refactor: add firebase accessor

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -12,14 +12,15 @@ jest.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
 }));
 
-jest.mock('@/lib/firebase', () => ({
-  auth: {
+jest.mock('@/lib/firebase', () => {
+  const auth = {
     currentUser: null,
     app: { options: { apiKey: 'test' }, name: '[DEFAULT]' },
-  },
-  initFirebase: jest.fn(),
-}));
-import { auth as authStub, initFirebase } from '@/lib/firebase';
+  };
+  return { getFirebase: jest.fn(() => ({ auth })) };
+});
+import { getFirebase } from '@/lib/firebase';
+const { auth: authStub } = getFirebase();
 
 beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'test';
@@ -28,7 +29,7 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'test';
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'test';
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'test';
-  initFirebase();
+  getFirebase();
 });
 
 type User = { uid: string } | null;

--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -3,11 +3,9 @@ import { setDoc, deleteDoc } from "firebase/firestore";
 import { logger } from "@/lib/logger";
 
 jest.mock("@/lib/firebase", () => ({
-  db: {},
-  categoriesCollection: {},
-  initFirebase: jest.fn(),
+  getFirebase: jest.fn(() => ({ db: {}, categoriesCollection: {} })),
 }));
-import { initFirebase } from "@/lib/firebase";
+import { getFirebase } from "@/lib/firebase";
 
 beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
@@ -16,7 +14,7 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
-  initFirebase();
+  getFirebase();
 });
 
 jest.mock("firebase/firestore", () => ({

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -13,8 +13,8 @@ jest.mock("@/lib/internet-time", () => ({
   getCurrentTime: jest.fn(),
 }));
 
-jest.mock("@/lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
-import { initFirebase } from "@/lib/firebase";
+jest.mock("@/lib/firebase", () => ({ getFirebase: jest.fn(() => ({ db: {} })) }));
+import { getFirebase } from "@/lib/firebase";
 
 beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
@@ -23,7 +23,7 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
-  initFirebase();
+  getFirebase();
 });
 
 jest.mock("firebase/firestore", () => {

--- a/src/__tests__/saveTransactions.integration.test.ts
+++ b/src/__tests__/saveTransactions.integration.test.ts
@@ -1,8 +1,8 @@
 import { saveTransactions } from "../lib/transactions";
 import type { Transaction } from "../lib/types";
 
-jest.mock("../lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
-import { initFirebase } from "../lib/firebase";
+jest.mock("../lib/firebase", () => ({ getFirebase: jest.fn(() => ({ db: {} })) }));
+import { getFirebase } from "../lib/firebase";
 
 beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
@@ -11,7 +11,7 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
-  initFirebase();
+  getFirebase();
 });
 
 const store = new Map<string, Transaction>();

--- a/src/__tests__/saveTransactions.test.ts
+++ b/src/__tests__/saveTransactions.test.ts
@@ -1,7 +1,7 @@
 import { saveTransactions } from "../lib/transactions";
 
-jest.mock("../lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
-import { initFirebase } from "../lib/firebase";
+jest.mock("../lib/firebase", () => ({ getFirebase: jest.fn(() => ({ db: {} })) }));
+import { getFirebase } from "../lib/firebase";
 
 beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
@@ -10,7 +10,7 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
-  initFirebase();
+  getFirebase();
 });
 
 const mockSet = jest.fn();

--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -11,10 +11,11 @@ jest.mock("../lib/offline", () => ({
 }))
 
 jest.mock("../lib/firebase", () => ({
-  auth: { currentUser: { getIdToken: jest.fn().mockResolvedValue("token") } },
-  initFirebase: jest.fn(),
+  getFirebase: jest.fn(() => ({
+    auth: { currentUser: { getIdToken: jest.fn().mockResolvedValue("token") } },
+  })),
 }))
-import { initFirebase } from "../lib/firebase"
+import { getFirebase } from "../lib/firebase"
 
 beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test"
@@ -23,7 +24,7 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test"
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test"
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test"
-  initFirebase()
+  getFirebase()
 })
 
 jest.mock("../hooks/use-toast", () => ({ toast: jest.fn() }))

--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -14,9 +14,9 @@ const onSnapshotMock = jest.fn();
 const deleteDocMock = jest.fn();
 
 jest.mock("firebase/firestore", () => ({
-  onSnapshot: (...args: any[]) => onSnapshotMock(...args),
+  onSnapshot: (...args: unknown[]) => onSnapshotMock(...args),
   setDoc: jest.fn(),
-  deleteDoc: (...args: any[]) => deleteDocMock(...args),
+  deleteDoc: (...args: unknown[]) => deleteDocMock(...args),
   updateDoc: jest.fn(),
   arrayUnion: jest.fn(),
   arrayRemove: jest.fn(),

--- a/src/ai/train/category-model.ts
+++ b/src/ai/train/category-model.ts
@@ -1,7 +1,7 @@
 import { collection, getDocs, onSnapshot } from "firebase/firestore";
-import { db, initFirebase } from "@/lib/firebase";
+import { getFirebase } from "@/lib/firebase";
 
-initFirebase();
+const { db } = getFirebase();
 
 interface FeedbackPair {
   description: string;

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 import { runHousekeeping } from "@/lib/housekeeping";
-import { db, initFirebase } from "@/lib/firebase";
+import { getFirebase } from "@/lib/firebase";
 import { getCurrentTime } from "@/lib/internet-time";
 import { doc, runTransaction, setDoc } from "firebase/firestore";
 import { logger } from "@/lib/logger";
 
 const HEADER_NAME = "x-cron-secret";
 const WINDOW_MS = 60_000; // 1 minute
-initFirebase();
+const { db } = getFirebase();
 const STATE_DOC = doc(db, "cron", "housekeeping");
 
 // Exposed for tests to reset the persisted rate limiter

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -5,9 +5,9 @@ import type { Goal } from "@/lib/types";
 import { GoalCard } from "@/components/goals/goal-card";
 import { AddGoalDialog } from "@/components/goals/add-goal-dialog";
 import { collection, addDoc, getDocs, updateDoc, deleteDoc, doc } from "firebase/firestore";
-import { db, initFirebase } from "@/lib/firebase";
+import { getFirebase } from "@/lib/firebase";
 
-initFirebase();
+const { db } = getFirebase();
 
 export default function GoalsPage() {
   const [goals, setGoals] = useState<Goal[]>([]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,7 @@ import {
   createUserWithEmailAndPassword,
   type AuthError,
 } from "firebase/auth"
-import { auth, initFirebase } from "@/lib/firebase"
-
-initFirebase()
+import { getFirebase } from "@/lib/firebase"
 import { authErrorMessages, DEFAULT_AUTH_ERROR_MESSAGE } from "@/lib/auth-errors"
 
 import { Button } from "@/components/ui/button"
@@ -21,6 +19,8 @@ import { NurseFinAILogo } from "@/components/icons"
 import { useToast } from "@/hooks/use-toast"
 import { Loader2 } from "lucide-react"
 import { logger } from "@/lib/logger"
+
+const { auth } = getFirebase()
 
 export default function LoginPage() {
   const router = useRouter()

--- a/src/components/auth/auth-provider.tsx
+++ b/src/components/auth/auth-provider.tsx
@@ -8,11 +8,11 @@ import {
   startTransition,
 } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
-import { auth, initFirebase } from "@/lib/firebase";
+import { getFirebase } from "@/lib/firebase";
 import { usePathname, useRouter } from "next/navigation";
 import { z } from "zod";
 
-initFirebase();
+const { auth } = getFirebase();
 
 interface AuthContextType {
   user: User | null;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { auth, initFirebase } from "@/lib/firebase"
+import { getFirebase } from "@/lib/firebase"
 import { signOut } from "firebase/auth"
 import {
   CircleUser,
@@ -30,7 +30,7 @@ import { useToast } from "@/hooks/use-toast"
 import { ThemeToggle } from "@/components/ThemeToggle"
 import { logger } from "@/lib/logger"
 
-initFirebase()
+const { auth } = getFirebase()
 
 export default function AppHeader() {
   const router = useRouter()

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useRef } from "react"
 import { getQueuedTransactions, clearQueuedTransactions } from "@/lib/offline"
-import { auth, initFirebase } from "@/lib/firebase"
+import { getFirebase } from "@/lib/firebase"
 import { toast } from "@/hooks/use-toast"
 import { logger } from "@/lib/logger"
 
-initFirebase()
+const { auth } = getFirebase()
 
 export function ServiceWorker() {
   const debounceId = useRef<ReturnType<typeof setTimeout> | null>(null)

--- a/src/lib/category-feedback.ts
+++ b/src/lib/category-feedback.ts
@@ -1,8 +1,8 @@
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
-import { db, initFirebase } from "./firebase";
+import { getFirebase } from "./firebase";
 import { logger } from "./logger";
 
-initFirebase();
+const { db } = getFirebase();
 
 /**
  * Persist a (description, category) feedback pair. This is used when a user

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -3,10 +3,10 @@
 // case-insensitive manner while preserving their original casing for display.
 
 import { doc, getDocs, setDoc, deleteDoc, writeBatch } from "firebase/firestore";
-import { db, categoriesCollection, initFirebase } from "./firebase";
+import { getFirebase } from "./firebase";
 import { logger } from "./logger";
 
-initFirebase();
+const { db, categoriesCollection } = getFirebase();
 
 const STORAGE_KEY = "categories";
 

--- a/src/lib/debts/index.ts
+++ b/src/lib/debts/index.ts
@@ -1,5 +1,5 @@
 import { collection, doc, QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
-import { db, initFirebase } from "../firebase";
+import { getFirebase } from "../firebase";
 import type { Debt } from "../types";
 
 // Firestore data converter for `Debt` documents.
@@ -14,6 +14,6 @@ const debtConverter = {
 };
 
 // `debts` collection reference using the converter.
-initFirebase();
+const { db } = getFirebase();
 export const debtsCollection = collection(db, "debts").withConverter(debtConverter);
 export const debtDoc = (id: string) => doc(db, "debts", id).withConverter(debtConverter);

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -27,10 +27,14 @@ const envSchema = z.object({
   NEXT_PUBLIC_FIREBASE_APP_ID: nonPlaceholder,
 });
 
-let app: ReturnType<typeof initializeApp>;
-let auth: ReturnType<typeof getAuth>;
-let db: ReturnType<typeof getFirestore>;
-let categoriesCollection: ReturnType<typeof collection>;
+type FirebaseServices = {
+  app: ReturnType<typeof initializeApp>;
+  auth: ReturnType<typeof getAuth>;
+  db: ReturnType<typeof getFirestore>;
+  categoriesCollection: ReturnType<typeof collection>;
+};
+
+let services: FirebaseServices | null = null;
 
 // A function to check if all required environment variables are present.
 // This provides a clearer error message than the generic Firebase error.
@@ -52,9 +56,9 @@ function validateFirebaseConfig(config: FirebaseOptions): void {
   }
 }
 
-export function initFirebase() {
-  if (app) {
-    return { app, auth, db, categoriesCollection };
+export function getFirebase(): FirebaseServices {
+  if (services) {
+    return services;
   }
   const env = envSchema.parse(process.env);
   const firebaseConfig: FirebaseOptions = {
@@ -66,12 +70,12 @@ export function initFirebase() {
     appId: env.NEXT_PUBLIC_FIREBASE_APP_ID,
   };
   validateFirebaseConfig(firebaseConfig);
-  app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
-  auth = getAuth(app);
-  db = getFirestore(app);
-  categoriesCollection = collection(db, "categories");
-  return { app, auth, db, categoriesCollection };
+  const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+  const auth = getAuth(app);
+  const db = getFirestore(app);
+  const categoriesCollection = collection(db, "categories");
+  services = { app, auth, db, categoriesCollection };
+  return services;
 }
 
-export { app, auth, db, categoriesCollection };
 

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 import { collection, doc, writeBatch, getDocs } from "firebase/firestore";
-import { db, initFirebase } from "./firebase";
+import { getFirebase } from "./firebase";
 import type { Transaction } from "./types";
 import { currencyCodeSchema } from "./currency";
 
-initFirebase();
+const { db } = getFirebase();
 
 export const TransactionPayloadSchema = z.object({
   id: z.string(),

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -11,12 +11,12 @@ import {
   writeBatch,
   QueryDocumentSnapshot,
 } from "firebase/firestore";
-import { db, initFirebase } from "../lib/firebase";
+import { getFirebase } from "../lib/firebase";
 import type { Transaction, Debt, Goal } from "../lib/types";
 import { getCurrentTime } from "../lib/internet-time";
 import { logger } from "../lib/logger";
 
-initFirebase();
+const { db } = getFirebase();
 
 /**
  * Moves transactions older than the provided cutoff date to an archive collection


### PR DESCRIPTION
## Summary
- replace global firebase exports with getFirebase accessor
- update firebase consumers to destructure services from getFirebase
- adjust tests for new firebase accessor

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2bf79e424833197011df5ddefcc6c