### PR TITLE
Improve goal management error handling and tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -29,3 +29,23 @@ process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'test'
 process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'test'
 process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'test'
 process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'test'
+
+// Mock lucide-react icons for all tests to avoid ESM issues
+jest.mock('lucide-react', () => new Proxy({}, { get: () => () => null }))
+
+// Provide a basic matchMedia mock for components relying on it
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  })
+}

--- a/src/__tests__/goals-page.test.tsx
+++ b/src/__tests__/goals-page.test.tsx
@@ -1,0 +1,86 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import GoalsPage from '@/app/goals/page';
+import type { Goal } from '@/lib/types';
+
+const toastMock = jest.fn();
+const loggerErrorMock = jest.fn();
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: { error: (...args: unknown[]) => loggerErrorMock(...args) },
+}));
+
+jest.mock('@/lib/firebase', () => ({ db: {}, initFirebase: jest.fn() }));
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  getDocs: jest.fn(),
+  addDoc: jest.fn(),
+  updateDoc: jest.fn(),
+  deleteDoc: jest.fn(),
+  doc: jest.fn(),
+}));
+
+jest.mock('@/components/goals/add-goal-dialog', () => ({
+  AddGoalDialog: ({ onSave }: { onSave: (goal: Goal) => void }) => (
+    <button onClick={() => onSave({
+      id: '',
+      name: 'Test',
+      targetAmount: 100,
+      currentAmount: 0,
+      deadline: '2024-01-01',
+      importance: 1,
+    })}>Add Goal</button>
+  ),
+}));
+
+jest.mock('@/components/goals/goal-card', () => ({
+  GoalCard: ({ goal, onDelete }: { goal: Goal; onDelete: (id: string) => void }) => (
+    <div>
+      <span>{goal.name}</span>
+      <button onClick={() => onDelete(goal.id)}>Delete</button>
+    </div>
+  ),
+}));
+
+import { getDocs, addDoc, deleteDoc } from 'firebase/firestore';
+
+describe('GoalsPage error handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows toast when fetching goals fails', async () => {
+    (getDocs as jest.Mock).mockRejectedValue(new Error('fetch error'));
+    render(<GoalsPage />);
+    await waitFor(() => expect(loggerErrorMock).toHaveBeenCalled());
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Failed to load goals' }));
+    await screen.findByText(/failed to load goals/i);
+  });
+
+  it('shows toast when saving a goal fails', async () => {
+    (getDocs as jest.Mock).mockResolvedValue({ docs: [] });
+    (addDoc as jest.Mock).mockRejectedValue(new Error('save error'));
+    render(<GoalsPage />);
+    await waitFor(() => expect(screen.getByText('Add Goal')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Add Goal'));
+    await waitFor(() => expect(loggerErrorMock).toHaveBeenCalledWith('Error saving goal:', expect.any(Error)));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Failed to save goal' }));
+  });
+
+  it('shows toast when deleting a goal fails', async () => {
+    const goalData = { name: 'Goal', targetAmount: 100, currentAmount: 0, deadline: '2024-01-01', importance: 1 };
+    (getDocs as jest.Mock).mockResolvedValue({ docs: [{ id: '1', data: () => goalData }] });
+    (deleteDoc as jest.Mock).mockRejectedValue(new Error('delete error'));
+    render(<GoalsPage />);
+    fireEvent.click(await screen.findByText('Delete'));
+    await waitFor(() => expect(loggerErrorMock).toHaveBeenCalledWith('Error deleting goal:', expect.any(Error)));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Failed to delete goal' }));
+  });
+});
+

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -6,47 +6,95 @@ import { GoalCard } from "@/components/goals/goal-card";
 import { AddGoalDialog } from "@/components/goals/add-goal-dialog";
 import { collection, addDoc, getDocs, updateDoc, deleteDoc, doc } from "firebase/firestore";
 import { db, initFirebase } from "@/lib/firebase";
+import { useToast } from "@/hooks/use-toast";
+import { logger } from "@/lib/logger";
+import { Loader2 } from "lucide-react";
 
 initFirebase();
 
 export default function GoalsPage() {
   const [goals, setGoals] = useState<Goal[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { toast } = useToast();
 
   useEffect(() => {
     const fetchGoals = async () => {
-      const snap = await getDocs(collection(db, "goals"));
-      const data = snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Goal, "id">) })) as Goal[];
-      setGoals(data);
+      setIsLoading(true);
+      try {
+        const snap = await getDocs(collection(db, "goals"));
+        const data = snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Goal, "id">) })) as Goal[];
+        setGoals(data);
+      } catch (err) {
+        logger.error("Error fetching goals:", err);
+        setError("Failed to load goals");
+        toast({
+          title: "Failed to load goals",
+          description: "Please try again.",
+          variant: "destructive",
+        });
+      } finally {
+        setIsLoading(false);
+      }
     };
     fetchGoals();
-  }, []);
+  }, [toast]);
 
   const handleSaveGoal = async (goal: Goal) => {
-    if (goal.id) {
-      await updateDoc(doc(db, "goals", goal.id), {
-        name: goal.name,
-        targetAmount: goal.targetAmount,
-        currentAmount: goal.currentAmount,
-        deadline: goal.deadline,
-        importance: goal.importance,
+    try {
+      if (goal.id) {
+        await updateDoc(doc(db, "goals", goal.id), {
+          name: goal.name,
+          targetAmount: goal.targetAmount,
+          currentAmount: goal.currentAmount,
+          deadline: goal.deadline,
+          importance: goal.importance,
+        });
+        setGoals(prev => prev.map(g => (g.id === goal.id ? goal : g)));
+        toast({ title: "Goal Updated" });
+      } else {
+        const docRef = await addDoc(collection(db, "goals"), {
+          name: goal.name,
+          targetAmount: goal.targetAmount,
+          currentAmount: goal.currentAmount,
+          deadline: goal.deadline,
+          importance: goal.importance,
+        });
+        setGoals(prev => [{ ...goal, id: docRef.id }, ...prev]);
+        toast({ title: "Goal Added" });
+      }
+    } catch (err) {
+      logger.error("Error saving goal:", err);
+      toast({
+        title: "Failed to save goal",
+        description: "Please try again.",
+        variant: "destructive",
       });
-      setGoals(prev => prev.map(g => g.id === goal.id ? goal : g));
-    } else {
-      const docRef = await addDoc(collection(db, "goals"), {
-        name: goal.name,
-        targetAmount: goal.targetAmount,
-        currentAmount: goal.currentAmount,
-        deadline: goal.deadline,
-        importance: goal.importance,
-      });
-      setGoals(prev => [{ ...goal, id: docRef.id }, ...prev]);
     }
   };
 
   const handleDeleteGoal = async (id: string) => {
-    await deleteDoc(doc(db, "goals", id));
-    setGoals(prev => prev.filter(g => g.id !== id));
+    try {
+      await deleteDoc(doc(db, "goals", id));
+      setGoals(prev => prev.filter(g => g.id !== id));
+      toast({ title: "Goal Deleted" });
+    } catch (err) {
+      logger.error("Error deleting goal:", err);
+      toast({
+        title: "Failed to delete goal",
+        description: "Please try again.",
+        variant: "destructive",
+      });
+    }
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -57,6 +105,7 @@ export default function GoalsPage() {
         </div>
         <AddGoalDialog onSave={handleSaveGoal} />
       </div>
+      {error && <p className="text-destructive">{error}</p>}
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {goals.map(goal => (
           <GoalCard key={goal.id} goal={goal} onDelete={handleDeleteGoal} onUpdate={handleSaveGoal} />


### PR DESCRIPTION
## Summary
- add toast and logging based error handling to goal CRUD operations
- show loading and error states on goals page
- mock lucide icons and matchMedia in tests and add coverage for Firestore failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2cb562c9c8331a415d16b05213aea