### PR TITLE
Validate WorkerPool maxQueueSize parameter

### DIFF
--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -37,6 +37,15 @@ describe("WorkerPool", () => {
     }
   )
 
+  it.each([0, -1, 1.5])(
+    "throws an error when maxQueueSize is %p",
+    maxQueueSize => {
+      expect(() => new WorkerPool("fake", 1, maxQueueSize)).toThrow(
+        "maxQueueSize must be a positive integer"
+      )
+    }
+  )
+
   it("continues processing after a worker crash", async () => {
     const pool = new WorkerPool<number | string, number>("fake", 1)
 

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -22,10 +22,22 @@ export class WorkerPool<T = unknown, R = unknown> {
   private queue: Task<T, R>[] = []
   private destroyed = false
 
-  constructor(private readonly file: string, size: number) {
+  constructor(
+    private readonly file: string,
+    size: number,
+    private readonly maxQueueSize?: number
+  ) {
     if (!Number.isInteger(size) || size <= 0) {
       throw new Error("Worker pool size must be a positive integer")
     }
+
+    if (
+      maxQueueSize !== undefined &&
+      (!Number.isInteger(maxQueueSize) || maxQueueSize <= 0)
+    ) {
+      throw new Error("maxQueueSize must be a positive integer")
+    }
+
     for (let i = 0; i < size; i++) {
       this.spawn()
     }


### PR DESCRIPTION
## Summary
- validate optional `maxQueueSize` argument in `WorkerPool` constructor
- throw helpful error if `maxQueueSize` is not a positive integer
- test invalid `maxQueueSize` values

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module in auth-provider.test.tsx, debt-calendar.test.tsx)*
- `npm test -- src/__tests__/worker-pool.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2ce6deb38833194f8987f117b897d