### PR TITLE
add onboarding page and plaid workers

### DIFF
--- a/apps/web/src/app/(auth)/onboarding/page.tsx
+++ b/apps/web/src/app/(auth)/onboarding/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  initializeApp, getApps, FirebaseApp
+} from 'firebase/app';
+import {
+  getAuth, onAuthStateChanged, signOut, User
+} from 'firebase/auth';
+import {
+  getFirestore, doc, setDoc, serverTimestamp
+} from 'firebase/firestore';
+
+// --- Minimal Firebase client init (web) ---
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!
+};
+
+function useFirebase(): { app: FirebaseApp } {
+  const app = useMemo(() => (getApps()[0] ?? initializeApp(firebaseConfig)), []);
+  return { app };
+}
+
+type NurseRole = 'travel' | 'staff' | 'student';
+
+export default function OnboardingPage() {
+  const { app } = useFirebase();
+  const auth = useMemo(() => getAuth(app), [app]);
+  const db = useMemo(() => getFirestore(app), [app]);
+  const router = useRouter();
+
+  const [user, setUser] = useState<User | null>(null);
+  const [loadingAuth, setLoadingAuth] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [firstName, setFirstName] = useState('');
+  const [role, setRole] = useState<NurseRole>('travel');
+  const [specialty, setSpecialty] = useState('');
+  const [homeState, setHomeState] = useState('');
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoadingAuth(false);
+      if (!u) router.replace('/login');
+    });
+    return () => unsub();
+  }, [auth, router]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!user) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const profileRef = doc(db, 'users', user.uid);
+      await setDoc(
+        profileRef,
+        {
+          user_id: user.uid,
+          email: user.email ?? null,
+          role,
+          first_name: firstName || null,
+          specialty: specialty || null,
+          home_state: homeState || null,
+          marketing_opt_in: marketingOptIn,
+          created_at: serverTimestamp(),
+          last_login: serverTimestamp()
+        },
+        { merge: true }
+      );
+      router.replace('/dashboard');
+    } catch (err: any) {
+      console.error(err);
+      setError(err?.message ?? 'Failed to save profile');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loadingAuth) {
+    return (
+      <div className="min-h-[60vh] grid place-items-center">
+        <p className="text-sm opacity-70">Checking session…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold">Welcome! Let’s set up your profile.</h1>
+        <p className="text-sm text-gray-500 mt-1">This helps tailor categories, budgets, and insights for nurses.</p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <label className="block text-sm font-medium">First name</label>
+          <input
+            className="mt-1 w-full rounded-lg border p-2"
+            placeholder="Alex"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Role</label>
+          <div className="mt-2 grid grid-cols-3 gap-2">
+            {([
+              ['travel', 'Travel'],
+              ['staff', 'Staff'],
+              ['student', 'Student']
+            ] as [NurseRole, string][]).map(([key, label]) => (
+              <button
+                type="button"
+                key={key}
+                onClick={() => setRole(key)}
+                className={`rounded-lg border p-2 text-sm ${
+                  role === key ? 'border-black ring-2 ring-black' : 'opacity-80'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium">Specialty (optional)</label>
+            <input
+              className="mt-1 w-full rounded-lg border p-2"
+              placeholder="ER, ICU, Med‑Surg, OR…"
+              value={specialty}
+              onChange={(e) => setSpecialty(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Home state (US)</label>
+            <input
+              className="mt-1 w-full rounded-lg border p-2"
+              placeholder="CA"
+              maxLength={2}
+              value={homeState}
+              onChange={(e) => setHomeState(e.target.value.toUpperCase())}
+            />
+          </div>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={marketingOptIn} onChange={(e) => setMarketingOptIn(e.target.checked)} />
+          Send product tips & beta invites
+        </label>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-black text-white px-4 py-2 disabled:opacity-60"
+          >
+            {submitting ? 'Saving…' : 'Continue'}
+          </button>
+          <button
+            type="button"
+            onClick={() => signOut(auth)}
+            className="text-sm underline opacity-70"
+          >
+            Sign out
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@nursefinai/domain",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "zod": "^3.24.2"
+  }
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,0 +1,1 @@
+export * from './zod';

--- a/packages/domain/src/zod.ts
+++ b/packages/domain/src/zod.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+
+export const NurseRoleEnum = z.enum(['travel', 'staff', 'student']);
+
+export const UserSchema = z.object({
+  user_id: z.string(),
+  email: z.string().email().nullable().optional(),
+  role: NurseRoleEnum,
+  first_name: z.string().nullable().optional(),
+  specialty: z.string().nullable().optional(),
+  home_state: z.string().length(2).nullable().optional(),
+  marketing_opt_in: z.boolean().default(false),
+  created_at: z.any().optional(),
+  last_login: z.any().optional(),
+});
+export type UserDoc = z.infer<typeof UserSchema>;
+
+export const AccountSchema = z.object({
+  user_id: z.string(),
+  item_id: z.string(),
+  name: z.string(),
+  official_name: z.string().nullable().optional(),
+  mask: z.string().nullable().optional(),
+  type: z.string(),
+  subtype: z.string().nullable().optional(),
+  currency: z.string().default('USD'),
+  current_balance: z.number().nullable().optional(),
+  available_balance: z.number().nullable().optional(),
+  last_sync_at: z.any().optional(),
+});
+export type AccountDoc = z.infer<typeof AccountSchema>;
+
+export const TransactionSchema = z.object({
+  user_id: z.string(),
+  account_id: z.string(),
+  item_id: z.string(),
+  amount: z.number(),
+  iso_currency: z.string().default('USD'),
+  iso_date: z.string(),
+  pending: z.boolean().optional(),
+  merchant_name: z.string().nullable().optional(),
+  mcc: z.string().nullable().optional(),
+  location: z.any().nullable().optional(),
+  raw_description: z.string().nullable().optional(),
+  category: z.array(z.string()).default([]),
+  nurse_category: z.string().nullable().optional(),
+  rule_id: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  tags: z.array(z.string()).default([]),
+  duplicates: z.array(z.string()).default([]),
+  fingerprint: z.string(),
+  receipt_id: z.string().nullable().optional(),
+  posted_at: z.any().optional(),
+  created_at: z.any().optional(),
+  updated_at: z.any().optional(),
+});
+export type TransactionDoc = z.infer<typeof TransactionSchema>;
+
+export const RuleMatchSchema = z.object({
+  merchant: z.string().optional(),
+  mcc: z.string().optional(),
+  amount_tolerance: z.number().optional(),
+  contains: z.array(z.string()).optional(),
+});
+export const RuleActionSchema = z.object({
+  nurse_category: z.string(),
+  split: z.array(
+    z.object({ pct: z.number().optional(), amount: z.number().optional(), category: z.string() })
+  ).optional(),
+});
+export const RuleSchema = z.object({
+  user_id: z.string(),
+  priority: z.number().int().min(0).default(100),
+  enabled: z.boolean().default(true),
+  match: RuleMatchSchema,
+  action: RuleActionSchema,
+});
+export type RuleDoc = z.infer<typeof RuleSchema>;
+
+export const ReceiptSchema = z.object({
+  user_id: z.string(),
+  storage_path: z.string(),
+  sha256: z.string(),
+  source: z.enum(['upload', 'email', 'sms']).default('upload'),
+  ocr: z.object({ status: z.string(), provider: z.string(), extracted_at: z.any().optional(), kv: z.any().optional() }).optional(),
+  linked_tx: z.array(z.string()).default([]),
+  created_at: z.any().optional(),
+});
+export type ReceiptDoc = z.infer<typeof ReceiptSchema>;
+
+export const PaystubSchema = z.object({
+  user_id: z.string(),
+  storage_path: z.string(),
+  sha256: z.string(),
+  pay_period: z.object({ start: z.string(), end: z.string(), pay_date: z.string() }),
+  employer: z.string().nullable().optional(),
+  gross_pay: z.number().nullable().optional(),
+  net_pay: z.number().nullable().optional(),
+  components: z.array(z.object({ type: z.string(), amount: z.number() })).optional(),
+  taxes: z.array(z.object({ code: z.string(), amount: z.number() })).optional(),
+  hours: z.object({ regular: z.number().optional(), ot: z.number().optional(), double: z.number().optional() }).optional(),
+  stipends: z.object({ housing: z.number().optional(), meals: z.number().optional(), travel: z.number().optional() }).optional(),
+  parsed_confidence: z.number().nullable().optional(),
+  linked_tx: z.array(z.string()).default([]),
+});
+export type PaystubDoc = z.infer<typeof PaystubSchema>;
+
+export const AssignmentSchema = z.object({
+  user_id: z.string(),
+  agency: z.string(),
+  facility: z.string(),
+  state: z.string().length(2),
+  specialty: z.string().optional(),
+  bill_rate: z.number().optional(),
+  ot_rate: z.number().optional(),
+  stipend: z.object({ housing: z.number().optional(), meals: z.number().optional() }).partial(),
+  shifts_per_week: z.number().optional(),
+  start: z.string(),
+  end: z.string(),
+  contract_pdf: z.string().nullable().optional(),
+});
+export type AssignmentDoc = z.infer<typeof AssignmentSchema>;
+
+export const BudgetEnvelopeSchema = z.object({ category: z.string(), planned: z.number(), carryover: z.boolean().default(false) });
+export const BudgetSchema = z.object({
+  user_id: z.string(),
+  month: z.string().regex(/^\d{4}-\d{2}$/),
+  envelopes: z.array(BudgetEnvelopeSchema),
+  locked: z.boolean().default(false),
+});
+export type BudgetDoc = z.infer<typeof BudgetSchema>;
+
+export const DebtSchema = z.object({
+  user_id: z.string(),
+  kind: z.enum(['loan', 'card', 'other']),
+  name: z.string(),
+  apr: z.number().nonnegative(),
+  balance: z.number().nonnegative(),
+  min_payment: z.number().nonnegative(),
+  due_day: z.number().int().min(1).max(28),
+  extra_payment: z.number().nonnegative().default(0),
+});
+export type DebtDoc = z.infer<typeof DebtSchema>;
+
+export const GoalSchema = z.object({
+  user_id: z.string(),
+  name: z.string(),
+  target_amount: z.number().positive(),
+  target_date: z.string(),
+  funding_strategy: z.enum(['monthly', 'windfall', 'roundups']).default('monthly'),
+  envelope_category: z.string().nullable().optional(),
+});
+export type GoalDoc = z.infer<typeof GoalSchema>;
+
+export const TaxProfileSchema = z.object({
+  user_id: z.string(),
+  filing_status: z.enum(['single', 'married_joint', 'married_separate', 'head_household']),
+  dependents: z.number().int().min(0).default(0),
+  w4_allowances: z.number().int().min(0).default(0),
+  additional_withholding: z.number().min(0).default(0),
+  roth_contribs_year_to_date: z.number().min(0).default(0),
+  hsa_fsa: z.number().min(0).default(0),
+});
+export type TaxProfileDoc = z.infer<typeof TaxProfileSchema>;
+
+// Useful constants
+export const NurseCategories = [
+  'scrubs', 'ceus', 'licensure', 'agency_fees', 'housing_stipend_overage', 'mileage', 'lodging',
+  'per_diem', 'union_dues', 'equipment', 'parking', 'meals_on_shift', 'certifications', 'travel_misc'
+] as const;
+export type NurseCategory = typeof NurseCategories[number];

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@nursefinai/workers",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@google-cloud/kms": "^3.6.0",
+    "plaid": "^16.0.0",
+    "firebase-admin": "^13.4.0",
+    "firebase-functions": "^4.8.0",
+    "zod": "^3.24.2"
+  }
+}

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,0 +1,1 @@
+export * from './plaid';

--- a/packages/workers/src/plaid.ts
+++ b/packages/workers/src/plaid.ts
@@ -1,0 +1,269 @@
+/**
+ * Firebase Functions (v2) — Plaid Link + Transactions Sync
+ * - createLinkToken: client obtains link_token
+ * - exchangePublicToken: store encrypted access_token; seed accounts
+ * - plaidWebhook: handle Plaid webhooks; trigger /sync
+ * - syncItemNow: manual sync endpoint for a given item
+ */
+
+import { onRequest } from 'firebase-functions/v2/https';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { defineSecret } from 'firebase-functions/params';
+import * as logger from 'firebase-functions/logger';
+import * as admin from 'firebase-admin';
+import crypto from 'node:crypto';
+import { KeyManagementServiceClient } from '@google-cloud/kms';
+import {
+  Configuration,
+  PlaidApi,
+  PlaidEnvironments,
+  CountryCode,
+  TransactionsSyncRequest,
+} from 'plaid';
+
+// --- Secrets ---
+const PLAID_CLIENT_ID = defineSecret('PLAID_CLIENT_ID');
+const PLAID_SECRET = defineSecret('PLAID_SECRET');
+const PLAID_ENV = defineSecret('PLAID_ENV'); // 'sandbox' | 'development' | 'production'
+const KMS_KEY = defineSecret('KMS_KEY'); // projects/.../locations/.../keyRings/.../cryptoKeys/... (symmetric)
+
+// --- Init ---
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+const db = admin.firestore();
+const kms = new KeyManagementServiceClient();
+
+function plaidClient(): PlaidApi {
+  const cfg = new Configuration({
+    basePath: PlaidEnvironments[PLAID_ENV.value() as keyof typeof PlaidEnvironments],
+    baseOptions: {
+      headers: {
+        'PLAID-CLIENT-ID': PLAID_CLIENT_ID.value(),
+        'PLAID-SECRET': PLAID_SECRET.value(),
+      },
+    },
+  });
+  return new PlaidApi(cfg);
+}
+
+// --- Helpers ---
+async function verifyAuth(req: any): Promise<string> {
+  const authHeader = req.headers?.authorization || '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token) throw new Error('Missing Authorization bearer token');
+  const decoded = await admin.auth().verifyIdToken(token);
+  return decoded.uid;
+}
+
+async function encrypt(value: string): Promise<string> {
+  const [resp] = await kms.encrypt({ name: KMS_KEY.value(), plaintext: Buffer.from(value) });
+  return resp.ciphertext!.toString('base64');
+}
+
+async function decrypt(ciphertextB64: string): Promise<string> {
+  const [resp] = await kms.decrypt({ name: KMS_KEY.value(), ciphertext: Buffer.from(ciphertextB64, 'base64') });
+  return Buffer.from(resp.plaintext as Buffer).toString('utf8');
+}
+
+function txFingerprint(accountId: string, amount: number, merchant: string | undefined, dateISO: string) {
+  const base = `${accountId}|${amount.toFixed(2)}|${merchant ?? ''}|${dateISO}`;
+  return crypto.createHash('sha1').update(base).digest('hex');
+}
+
+// --- HTTP: create link token ---
+export const createLinkToken = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV] }, async (req, res) => {
+  try {
+    const uid = await verifyAuth(req);
+    const client = plaidClient();
+    const resp = await client.linkTokenCreate({
+      user: { client_user_id: uid },
+      client_name: 'NurseFinAI',
+      products: ['transactions'],
+      country_codes: [CountryCode.Us],
+      language: 'en',
+      // redirect_uri: 'https://<your-domain>/plaid/callback' // if using redirect
+    });
+    res.json({ link_token: resp.data.link_token });
+  } catch (e: any) {
+    logger.error('createLinkToken error', e);
+    res.status(400).json({ error: e.message });
+  }
+});
+
+// --- HTTP: exchange public token ---
+export const exchangePublicToken = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV, KMS_KEY] }, async (req, res) => {
+  try {
+    const uid = await verifyAuth(req);
+    const publicToken = req.body?.public_token as string;
+    if (!publicToken) throw new Error('public_token required');
+
+    const client = plaidClient();
+    const exch = await client.itemPublicTokenExchange({ public_token: publicToken });
+    const accessToken = exch.data.access_token;
+    const itemId = exch.data.item_id;
+
+    // Encrypt and persist institution
+    const cipher = await encrypt(accessToken);
+    const instRef = db.collection('institutions').doc(itemId);
+    await instRef.set({
+      user_id: uid,
+      plaid_access_token: cipher,
+      status: 'active',
+      webhook_ver: 'v2',
+      created_at: admin.firestore.FieldValue.serverTimestamp(),
+      cursor: null,
+    });
+
+    // Seed accounts
+    const accs = await client.accountsGet({ access_token: accessToken });
+    const batch = db.batch();
+    for (const a of accs.data.accounts) {
+      const accRef = db.collection('accounts').doc(a.account_id);
+      batch.set(accRef, {
+        user_id: uid,
+        item_id: itemId,
+        name: a.name,
+        official_name: a.official_name ?? null,
+        mask: a.mask ?? null,
+        type: a.type,
+        subtype: a.subtype ?? null,
+        currency: a.balances.iso_currency_code ?? 'USD',
+        current_balance: a.balances.current ?? null,
+        available_balance: a.balances.available ?? null,
+        last_sync_at: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    }
+    await batch.commit();
+
+    // Kick off first sync
+    await runSync(uid, itemId, accessToken);
+
+    res.json({ item_id: itemId, accounts: accs.data.accounts.length });
+  } catch (e: any) {
+    logger.error('exchangePublicToken error', e);
+    res.status(400).json({ error: e.message });
+  }
+});
+
+// --- HTTP: manual sync ---
+export const syncItemNow = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV, KMS_KEY] }, async (req, res) => {
+  try {
+    const uid = await verifyAuth(req);
+    const itemId = (req.query.item_id as string) || req.body?.item_id;
+    if (!itemId) throw new Error('item_id required');
+
+    const inst = await db.collection('institutions').doc(itemId).get();
+    if (!inst.exists || inst.get('user_id') !== uid) throw new Error('not found');
+
+    const token = await decrypt(inst.get('plaid_access_token'));
+    await runSync(uid, itemId, token);
+    res.json({ ok: true });
+  } catch (e: any) {
+    logger.error('syncItemNow error', e);
+    res.status(400).json({ error: e.message });
+  }
+});
+
+// --- Plaid webhook ---
+export const plaidWebhook = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV, KMS_KEY] }, async (req, res) => {
+  try {
+    const body = req.body || {};
+    const itemId = body.item_id as string | undefined;
+    const webhookType = body.webhook_type as string;
+    const webhookCode = body.webhook_code as string;
+
+    logger.info('Plaid webhook', { webhookType, webhookCode, itemId });
+
+    if (webhookType === 'TRANSACTIONS' && webhookCode === 'SYNC_UPDATES_AVAILABLE' && itemId) {
+      const inst = await db.collection('institutions').doc(itemId).get();
+      if (!inst.exists) return res.status(200).send('ok');
+      const uid = inst.get('user_id');
+      const token = await decrypt(inst.get('plaid_access_token'));
+      await runSync(uid, itemId, token);
+    }
+
+    res.status(200).send('ok');
+  } catch (e: any) {
+    logger.error('webhook error', e);
+    res.status(200).send('ok'); // Always 200 to avoid retries storms
+  }
+});
+
+// --- Core sync loop ---
+async function runSync(uid: string, itemId: string, accessToken: string) {
+  const client = plaidClient();
+  const instRef = db.collection('institutions').doc(itemId);
+  const instSnap = await instRef.get();
+  let cursor: string | null = instSnap.get('cursor') ?? null;
+
+  let hasMore = true;
+  let addedCount = 0;
+  let modifiedCount = 0;
+  let removedCount = 0;
+
+  while (hasMore) {
+    const req: TransactionsSyncRequest = { access_token: accessToken, cursor: cursor ?? undefined, count: 500 };
+    const resp = await client.transactionsSync(req);
+
+    // Upsert added & modified
+    const batch = db.batch();
+    for (const tx of [...resp.data.added, ...resp.data.modified]) {
+      const merchant = tx.merchant_name || tx.name || '';
+      const fp = txFingerprint(tx.account_id, tx.amount, merchant, tx.date);
+      const txRef = db.collection('transactions').doc(tx.transaction_id);
+      batch.set(txRef, {
+        user_id: uid,
+        account_id: tx.account_id,
+        item_id: itemId,
+        amount: tx.amount,
+        iso_currency: tx.iso_currency_code || 'USD',
+        iso_date: tx.iso_currency_code ? tx.date : tx.date, // keep yyyy-mm-dd
+        pending: tx.pending,
+        merchant_name: merchant || null,
+        mcc: tx.personal_finance_category?.primary || null,
+        location: tx.location || null,
+        raw_description: tx.name || null,
+        category: tx.category || [],
+        nurse_category: null,
+        rule_id: null,
+        notes: null,
+        tags: [],
+        duplicates: [],
+        fingerprint: fp,
+        created_at: admin.firestore.FieldValue.serverTimestamp(),
+        posted_at: new Date(tx.date),
+        updated_at: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    }
+
+    // Remove deleted (mark as removed)
+    for (const r of resp.data.removed) {
+      const txRef = db.collection('transactions').doc(r.transaction_id);
+      batch.set(txRef, { removed: true, updated_at: admin.firestore.FieldValue.serverTimestamp() }, { merge: true });
+    }
+
+    batch.set(instRef, { cursor: resp.data.next_cursor, last_sync_at: admin.firestore.FieldValue.serverTimestamp() }, { merge: true });
+    await batch.commit();
+
+    addedCount += resp.data.added.length;
+    modifiedCount += resp.data.modified.length;
+    removedCount += resp.data.removed.length;
+
+    cursor = resp.data.next_cursor;
+    hasMore = !!resp.data.has_more;
+  }
+
+  logger.info('sync complete', { itemId, addedCount, modifiedCount, removedCount });
+}
+
+// Optional nightly safety sync for stragglers
+export const nightlySafetySync = onSchedule('0 5 * * *', async () => {
+  const insts = await db.collection('institutions').where('status', '==', 'active').get();
+  for (const docSnap of insts.docs) {
+    const uid = docSnap.get('user_id');
+    const token = await decrypt(docSnap.get('plaid_access_token'));
+    await runSync(uid, docSnap.id, token);
+  }
+});
+

--- a/packages/workers/tsconfig.json
+++ b/packages/workers/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add client-side onboarding page that captures nurse profile and stores it in Firestore
- add Firebase Functions for Plaid token exchange, webhooks, and nightly sync
- centralize zod schemas for Firestore documents

## Testing
- `npm test` *(fails: SyntaxError in lucide-react ESM module)*


------
https://chatgpt.com/codex/tasks/task_e_68b2d03782e083318cdfbca5263e19c3