### PR TITLE
refactor: centralize random id generation

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -7,6 +7,7 @@ import type {
   ToastActionElement,
   ToastProps,
 } from "@/components/ui/toast"
+import { getRandomId } from "@/lib/random-id"
 
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 5000
@@ -16,10 +17,6 @@ type ToasterToast = ToastProps & {
   title?: React.ReactNode
   description?: React.ReactNode
   action?: ToastActionElement
-}
-
-function genId() {
-  return crypto.randomUUID()
 }
 
 type Action =
@@ -136,7 +133,7 @@ function dismissToast(toastId?: string) {
 type Toast = Omit<ToasterToast, "id">
 
 function toast({ ...props }: Toast) {
-  const id = genId()
+  const id = getRandomId()
 
   const update = (props: ToasterToast) =>
     dispatch({

--- a/src/lib/random-id.ts
+++ b/src/lib/random-id.ts
@@ -1,0 +1,7 @@
+export function getRandomId(): string {
+  const globalCrypto = typeof globalThis !== "undefined" ? globalThis.crypto : undefined;
+  if (globalCrypto && typeof globalCrypto.randomUUID === "function") {
+    return globalCrypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -3,6 +3,7 @@ import { collection, doc, writeBatch, getDocs } from "firebase/firestore";
 import { db, initFirebase } from "./firebase";
 import type { Transaction } from "./types";
 import { currencyCodeSchema } from "./currency";
+import { getRandomId } from "./random-id";
 
 initFirebase();
 
@@ -108,7 +109,7 @@ export function validateTransactions(
     const parsedAmount = Number(amountString);
 
     const tx: Transaction = {
-      id: crypto.randomUUID(),
+      id: getRandomId(),
       date: data.date,
       description: data.description,
       amount: parsedAmount,


### PR DESCRIPTION
## Summary
- add `getRandomId` helper to use `crypto.randomUUID` with fallback
- use helper in toast hook and transaction validation

## Testing
- `npm test` *(fails: SyntaxError in lucide-react ESM)*
- `npm run lint` *(fails: various lint errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cfedc79c8331a5809d5ce9a7f06a