### PR TITLE
Simplify service worker registration logic

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -129,13 +129,11 @@ describe("Service worker registration", () => {
     })
   })
 
-  it("does not register when existing registration without controller", async () => {
+  it("registers when controller is absent", async () => {
     const register = jest.fn().mockResolvedValue(undefined)
-    const getRegistration = jest.fn().mockResolvedValue({})
     Object.defineProperty(navigator, "serviceWorker", {
       value: {
         register,
-        getRegistration,
         controller: undefined,
       },
       configurable: true,
@@ -149,7 +147,7 @@ describe("Service worker registration", () => {
 
     await act(async () => {})
 
-    expect(register).not.toHaveBeenCalled()
+    expect(register).toHaveBeenCalledWith("/sw.js", { type: "module" })
 
     const nav = navigator as Navigator & { serviceWorker?: ServiceWorkerContainer }
     delete nav.serviceWorker

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -98,12 +98,7 @@ export function ServiceWorker() {
     const registerAndListen = async () => {
       if ("serviceWorker" in navigator) {
         try {
-          const existing = navigator.serviceWorker.getRegistration
-            ? await navigator.serviceWorker.getRegistration()
-            : undefined
-          if (!navigator.serviceWorker.controller && existing) {
-            // Service worker already registered, no need to register again
-          } else {
+          if (!navigator.serviceWorker.controller) {
             await navigator.serviceWorker.register("/sw.js", { type: "module" })
           }
         } catch (error) {


### PR DESCRIPTION
## Summary
- streamline service worker registration by registering when no controller is present
- adjust service worker tests to expect registration when controller is missing

## Testing
- `npm test` (fails: SyntaxError from lucide-react in auth-provider.test.tsx and debt-calendar.test.tsx)
- `npm run lint` (fails: lint errors in test files)


------
https://chatgpt.com/codex/tasks/task_e_68b2cff34f808331994224453927d11a