### PR TITLE
test: type Embla carousel mock

### DIFF
--- a/src/__tests__/carousel.test.tsx
+++ b/src/__tests__/carousel.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Carousel } from '@/components/ui/carousel';
+import type { EmblaCarouselType } from 'embla-carousel-react';
 
 jest.mock('lucide-react', () => ({
   ArrowLeft: () => null,
@@ -9,7 +10,7 @@ jest.mock('lucide-react', () => ({
 
 const onMock = jest.fn();
 const offMock = jest.fn();
-let emblaApi: any;
+let emblaApi: EmblaCarouselType;
 
 function mockUseEmbla() {
   emblaApi = {
@@ -19,7 +20,7 @@ function mockUseEmbla() {
     canScrollNext: jest.fn().mockReturnValue(false),
     scrollPrev: jest.fn(),
     scrollNext: jest.fn(),
-  };
+  } as unknown as EmblaCarouselType;
   return [jest.fn(), emblaApi];
 }
 


### PR DESCRIPTION
## Summary
- import `EmblaCarouselType` in carousel tests
- replace loose `any` Embla API with explicit type and cast

## Testing
- `npm test -- src/__tests__/carousel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b2cff45d948331a4d82dd3ed5f5ee6