### PR TITLE
docs: clarify sync transaction persistence

### DIFF
--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -7,10 +7,11 @@ import { logger } from "@/lib/logger"
 
 /**
  * Generic transaction syncing endpoint.
- * Unlike `/api/bank/import`, this expects transactions that have already
- * been fetched from any source. The current implementation only validates
- * and reports how many transactions were received without persisting them.
- * TODO: Implement database persistence for received transactions.
+ * Unlike `/api/bank/import`, this expects transactions that have already been
+ * fetched from any source. Validated transactions are persisted via
+ * `saveTransactions`. The request body is limited to 1MB. Invalid JSON or
+ * payloads return a 400 response, oversized payloads a 413, and persistence
+ * errors are logged and forwarded to the client.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),


### PR DESCRIPTION
## Summary
- note that validated transactions are saved via `saveTransactions`
- document request size limit and error responses in transaction sync endpoint

## Testing
- `npm test` *(fails: SyntaxError in lucide-react ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cffbec708331add3fc45374d6965