### PR TITLE
feat: add housekeeping operations

### DIFF
--- a/src/lib/housekeeping.ts
+++ b/src/lib/housekeeping.ts
@@ -1,13 +1,61 @@
 import { getAuth } from "firebase/auth";
+import { getCurrentTime } from "./internet-time";
 import { logger } from "./logger";
+import {
+  archiveOldTransactions,
+  cleanupDebts,
+  backupData,
+} from "../services/housekeeping";
 
-// Placeholder housekeeping service that cleans up outdated data.
-// Replace with actual implementation as needed.
 export async function runHousekeeping(): Promise<void> {
-  // Example: ensure auth SDK is initialized to avoid cold-start costs
-  // and perform cleanup tasks such as removing expired sessions.
+  // Ensure auth SDK is initialized to avoid cold-start costs
   getAuth();
-  if (process.env.NEXT_PUBLIC_ENABLE_HOUSEKEEPING_LOG === "true") {
-    logger.info("Housekeeping job executed: Firebase auth initialized");
+
+  const logEnabled =
+    process.env.NEXT_PUBLIC_ENABLE_HOUSEKEEPING_LOG === "true";
+  const retention = Number.parseInt(process.env.RETENTION_DAYS || "", 10);
+  const retentionDays = Number.isNaN(retention) ? 30 : retention;
+
+  let now: Date;
+  try {
+    now = await getCurrentTime();
+  } catch (err) {
+    logger.error("Failed to obtain network time", err);
+    now = new Date();
+  }
+
+  const cutoffDate = new Date(
+    now.getTime() - retentionDays * 24 * 60 * 60 * 1000
+  ).toISOString();
+
+  if (logEnabled) {
+    logger.info(`Housekeeping started with cutoff ${cutoffDate}`);
+  }
+
+  try {
+    await archiveOldTransactions(cutoffDate);
+    if (logEnabled) {
+      logger.info(`Archived transactions older than ${cutoffDate}`);
+    }
+  } catch (err) {
+    logger.error("Failed to archive old transactions", err);
+  }
+
+  try {
+    await cleanupDebts();
+    if (logEnabled) {
+      logger.info("Cleaned up debts");
+    }
+  } catch (err) {
+    logger.error("Failed to clean up debts", err);
+  }
+
+  try {
+    await backupData();
+    if (logEnabled) {
+      logger.info("Backup completed");
+    }
+  } catch (err) {
+    logger.error("Failed to backup data", err);
   }
 }


### PR DESCRIPTION
## Summary
- schedule archiving, debt cleanup, and backups via housekeeping service
- compute cutoff date using RETENTION_DAYS and network time
- log success or errors for each housekeeping step

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module from lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cffd92b48331b355e81668cacf79