### PR TITLE
Reject submissions after worker pool destruction

### DIFF
--- a/src/__tests__/worker-pool.test.ts
+++ b/src/__tests__/worker-pool.test.ts
@@ -103,4 +103,20 @@ describe("WorkerPool", () => {
 
     await destroyPromise
   })
+
+  it("rejects submissions after destruction", async () => {
+    const pool = new WorkerPool<number, number>("fake", 1)
+
+    await pool.destroy()
+
+    await expect(pool.run(1)).rejects.toThrow("Worker pool destroyed")
+  })
+
+  it("rejects submissions after destroy is called", async () => {
+    const pool = new WorkerPool<number, number>("fake", 1)
+
+    const destroyPromise = pool.destroy()
+    await expect(pool.run(1)).rejects.toThrow("Worker pool destroyed")
+    await destroyPromise
+  })
 })

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -64,6 +64,10 @@ export class WorkerPool<T = unknown, R = unknown> {
    * emits an error or terminates with a non-zero exit code.
    */
   run(data: T): Promise<R> {
+    if (this.destroyed) {
+      return Promise.reject(new Error("Worker pool destroyed"))
+    }
+
     return new Promise((resolve, reject) => {
       this.queue.push({ data, resolve, reject })
       this.process()


### PR DESCRIPTION
## Summary
- prevent WorkerPool from accepting new tasks after destruction
- add tests for post-destroy task submissions

## Testing
- `npm test -- src/__tests__/worker-pool.test.ts`
- `npm test` *(fails: Cannot use import statement outside a module in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d00214888331b55d1ba38d3e5d80