### PR TITLE
feat: add year option to cost-of-living script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To get started, take a look at src/app/page.tsx.
 - `npm test` – run unit tests with Jest.
 - `npm run e2e` – run Playwright end-to-end tests. Run `npx playwright install-deps` first to install required system dependencies.
 - Run `npm install` to install Husky pre-commit hooks that run tests and reject commits containing standalone '...' lines.
-- `node scripts/update-cost-of-living.ts` – refresh cost of living dataset from BEA.
+- `node scripts/update-cost-of-living.ts [--year YYYY]` – refresh cost of living dataset from BEA.
 
 ## Package manager
 
@@ -93,5 +93,5 @@ Annual expense benchmarks are sourced from the **BEA Regional Price Parities**
 release. The data file `src/data/costOfLiving2024.ts` stores per-adult yearly
 costs for housing, groceries, utilities, transportation, healthcare, and
 miscellaneous categories. Use `calculateCostOfLiving` to scale values by
-household composition. Run `node scripts/update-cost-of-living.ts` each year to
-fetch new figures.
+household composition. Run `node scripts/update-cost-of-living.ts --year <YYYY>`
+each year to fetch new figures. The `--year` flag defaults to the current year.

--- a/scripts/update-cost-of-living.ts
+++ b/scripts/update-cost-of-living.ts
@@ -26,12 +26,24 @@ async function fetchRpp(year: number, apiKey: string) {
 }
 
 async function main() {
-  const year = new Date().getFullYear();
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  let year = new Date().getFullYear();
+  const yearFlag = args.find((arg) => arg.startsWith('--year'));
+  if (yearFlag) {
+    const value = yearFlag.includes('=')
+      ? yearFlag.split('=')[1]
+      : args[args.indexOf(yearFlag) + 1];
+    const parsed = Number(value);
+    if (!value || Number.isNaN(parsed)) {
+      throw new Error('--year requires a valid number');
+    }
+    year = parsed;
+  }
   const apiKey = process.env.BEA_API_KEY;
   if (!apiKey) {
     throw new Error('BEA_API_KEY environment variable is required');
   }
-  const dryRun = process.argv.includes('--dry-run');
   const rows = await fetchRpp(year, apiKey);
   const regions = rows.reduce((acc, row) => {
     const index = Number(row.DataValue.replace(/,/g, '')) / 100; // convert index to multiplier


### PR DESCRIPTION
## Summary
- add optional `--year` flag to `update-cost-of-living` script
- default to current year and apply to dataset fetch and output filename
- document usage in README

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in lucide-react)*
- `npm run lint` *(fails: lint errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d002e0308331bef012973c1a95f0