### PR TITLE
docs: clarify transaction sync endpoint

### DIFF
--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -8,9 +8,8 @@ import { logger } from "@/lib/logger"
 /**
  * Generic transaction syncing endpoint.
  * Unlike `/api/bank/import`, this expects transactions that have already
- * been fetched from any source. The current implementation only validates
- * and reports how many transactions were received without persisting them.
- * TODO: Implement database persistence for received transactions.
+ * been fetched from any source. Validates and saves transactions via
+ * `saveTransactions`.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),


### PR DESCRIPTION
## Summary
- doc: transaction sync endpoint documentation now notes transactions are persisted via `saveTransactions`

## Testing
- `npm test` *(fails: SyntaxError in lucide-react ESM module)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d00889788331947302503bff938e