### PR TITLE
feat: cache transaction categories

### DIFF
--- a/src/__tests__/importTransactions.test.ts
+++ b/src/__tests__/importTransactions.test.ts
@@ -1,4 +1,4 @@
-import { importTransactions } from "../lib/transactions";
+import { importTransactions, invalidateCategoriesCache } from "../lib/transactions";
 import { getDocs } from "firebase/firestore";
 
 jest.mock("firebase/firestore", () => {
@@ -10,10 +10,26 @@ jest.mock("firebase/firestore", () => {
 });
 
 describe("importTransactions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    invalidateCategoriesCache();
+  });
+
   it("throws a descriptive error when fetching categories fails", async () => {
     (getDocs as jest.Mock).mockRejectedValue(new Error("network failure"));
     await expect(importTransactions([])).rejects.toThrow(
       /Failed to fetch categories: network failure/
     );
+  });
+
+  it("uses cached categories to avoid extra Firestore reads", async () => {
+    (getDocs as jest.Mock).mockResolvedValue({
+      docs: [{ id: "food" }, { id: "rent" }],
+    });
+
+    await importTransactions([]);
+    await importTransactions([]);
+
+    expect(getDocs).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- cache Firestore categories in memory with an invalidation helper
- reuse cached categories when importing transactions
- test repeated imports to ensure categories are fetched only once

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module in some test suites)*
- `npm run lint` *(fails: ESLint errors in unrelated test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d009a2a48331bc68c1e1e40c1b20