### PR TITLE
Validate positive integer chunk size

### DIFF
--- a/src/__tests__/chunkTransactions.test.ts
+++ b/src/__tests__/chunkTransactions.test.ts
@@ -3,7 +3,13 @@ import { chunkTransactions } from "../lib/transactions";
 describe("chunkTransactions", () => {
   it.each([0, -1])("throws for non-positive chunkSize %i", (size) => {
     expect(() => chunkTransactions([1, 2], size)).toThrow(
-      /chunkSize must be greater than 0/
+      /chunkSize must be a positive integer/
+    );
+  });
+
+  it("throws for non-integer chunkSize", () => {
+    expect(() => chunkTransactions([1, 2], 2.5)).toThrow(
+      /chunkSize must be a positive integer/
     );
   });
 });

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -59,8 +59,8 @@ export function chunkTransactions<T>(
   transactions: T[],
   chunkSize = 500
 ): T[][] {
-  if (chunkSize <= 0) {
-    throw new Error("chunkSize must be greater than 0");
+  if (chunkSize <= 0 || !Number.isInteger(chunkSize)) {
+    throw new Error("chunkSize must be a positive integer");
   }
   const chunks: T[][] = [];
   for (let i = 0; i < transactions.length; i += chunkSize) {


### PR DESCRIPTION
## Summary
- ensure `chunkTransactions` rejects non-integer chunk sizes
- test that non-integer `chunkSize` values throw an error

## Testing
- `npm test src/__tests__/chunkTransactions.test.ts`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d00afc608331b932653ee4338acf