### PR TITLE
test: stub matchMedia in jest setup

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -22,6 +22,23 @@ if (typeof (global as any).Headers === 'undefined') {
   (global as any).Headers = class {}
 }
 
+// Provide a stub for matchMedia expected by some components
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  })
+}
+
 // Stub Firebase environment variables expected by zod validation
 process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'test'
 process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'test'


### PR DESCRIPTION
## Summary
- mock `window.matchMedia` in Jest setup to satisfy components expecting it

## Testing
- `npm test` *(fails: SyntaxError in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d04096f08331b9df4eea5d9bfc34