### PR TITLE
docs: clarify transaction sync persistence

### DIFF
--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -8,9 +8,9 @@ import { logger } from "@/lib/logger"
 /**
  * Generic transaction syncing endpoint.
  * Unlike `/api/bank/import`, this expects transactions that have already
- * been fetched from any source. The current implementation only validates
- * and reports how many transactions were received without persisting them.
- * TODO: Implement database persistence for received transactions.
+ * been fetched from any source. Transactions are validated and persisted
+ * via `saveTransactions`, and the response reports how many transactions
+ * were received.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),


### PR DESCRIPTION
## Summary
- update transaction sync route comment to note validation and persistence via `saveTransactions`

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db78c59c8331b240541bf822c9a9