### PR TITLE
Implement origin-based CORS middleware

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -2,14 +2,44 @@
  * @jest-environment node
  */
 import { NextRequest } from 'next/server'
-import { middleware } from '@/middleware'
 
 describe('middleware', () => {
-  it('includes wss scheme in connect-src CSP directive', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    delete process.env.ALLOWED_ORIGINS
+  })
+
+  it('includes wss scheme in connect-src CSP directive', async () => {
+    const { middleware } = await import('@/middleware')
     const request = new NextRequest('http://localhost')
     const response = middleware(request)
     const csp = response.headers.get('Content-Security-Policy') ?? ''
     expect(csp).toContain("connect-src 'self' https: wss:")
+  })
+
+  it('sets Access-Control-Allow-Origin for allowed origin', async () => {
+    process.env.ALLOWED_ORIGINS = 'http://allowed.com'
+    const { middleware } = await import('@/middleware')
+    const request = new NextRequest('http://localhost', {
+      headers: { origin: 'http://allowed.com' },
+    })
+    const response = middleware(request)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+      'http://allowed.com'
+    )
+  })
+
+  it('does not set Access-Control-Allow-Origin for disallowed origin', async () => {
+    process.env.ALLOWED_ORIGINS = 'http://allowed.com'
+    const { middleware } = await import('@/middleware')
+    const request = new NextRequest('http://localhost', {
+      headers: { origin: 'http://not-allowed.com' },
+    })
+    const response = middleware(request)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
   })
 })
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { allowedOrigins } from '@/lib/allowed-origins';
 
 export function middleware(request: NextRequest) {
   const cspNonce = Buffer.from(crypto.randomUUID()).toString('base64');
@@ -33,8 +34,14 @@ export function middleware(request: NextRequest) {
     'max-age=63072000; includeSubDomains; preload'
   );
 
-  if (process.env.NODE_ENV === 'development') {
-    response.headers.set('Access-Control-Allow-Origin', '*');
+  const origin = request.headers.get('origin');
+  if (
+    origin &&
+    allowedOrigins.some((allowed) =>
+      typeof allowed === 'string' ? allowed === origin : allowed.test(origin)
+    )
+  ) {
+    response.headers.set('Access-Control-Allow-Origin', origin);
   }
 
   return response;


### PR DESCRIPTION
## Summary
- check request origins against a configured allowlist and set `Access-Control-Allow-Origin` accordingly
- test middleware CORS behavior for allowed and disallowed origins

## Testing
- `npm test src/__tests__/middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2db7989448331a3dca8a14b601c33