### PR TITLE
feat: redact sensitive data before model calls

### DIFF
--- a/src/ai/flows/__tests__/redaction.test.ts
+++ b/src/ai/flows/__tests__/redaction.test.ts
@@ -1,0 +1,53 @@
+import type { ZodType } from 'zod';
+
+interface FlowConfig<I, O> {
+  name: string;
+  inputSchema: ZodType<I>;
+  outputSchema: ZodType<O>;
+}
+
+type FlowHandler<I, O> = (input: I) => Promise<O>;
+
+function setupRedactionMocks<O>(output: O) {
+  let captured: any = null;
+  const promptFn = jest.fn(async (input: any) => {
+    captured = input;
+    return { output };
+  });
+  const definePromptMock = jest.fn().mockReturnValue(promptFn);
+  const defineFlowMock = jest.fn(<I>(config: FlowConfig<I, O>, handler: FlowHandler<I, O>) => {
+    return async (input: I) => handler(config.inputSchema.parse(input));
+  });
+  jest.doMock('@/ai/genkit', () => ({ ai: { definePrompt: definePromptMock, defineFlow: defineFlowMock } }));
+  return { promptFn, getCaptured: () => captured };
+}
+
+describe('redaction utility in flows', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('redacts sensitive text in suggestCategory before model call', async () => {
+    const { getCaptured } = setupRedactionMocks({ category: 'Food' });
+    const { suggestCategory } = await import('@/ai/flows/suggest-category');
+    await suggestCategory({
+      description: 'Dinner with john.doe@example.com call 555-123-4567 account 1234567890123456',
+    });
+    const called = getCaptured().description;
+    expect(called).not.toMatch(/john\.doe@example\.com/);
+    expect(called).not.toMatch(/555-123-4567/);
+    expect(called).not.toMatch(/1234567890123456/);
+  });
+
+  it('redacts sensitive data in analyzeReceipt before model call', async () => {
+    const { getCaptured } = setupRedactionMocks({ description: '', amount: 0, category: '' });
+    const { analyzeReceipt } = await import('@/ai/flows/analyze-receipt');
+    const sensitive = 'Email john@example.com phone 800-555-1212 account 1234567890123';
+    const base64 = Buffer.from(sensitive, 'utf8').toString('base64');
+    await analyzeReceipt({ receiptImage: `data:text/plain;base64,${base64}` });
+    const called = getCaptured().receiptImage;
+    expect(called).not.toMatch(/john@example.com/);
+    expect(called).not.toMatch(/800-555-1212/);
+    expect(called).not.toMatch(/1234567890123/);
+  });
+});

--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -10,6 +10,7 @@
  */
 
 import {ai} from '@/ai/genkit';
+import {redactInput} from '@/ai/redaction';
 import {DATA_URI_REGEX} from '@/lib/data-uri';
 import {z} from 'genkit';
 
@@ -50,7 +51,8 @@ const analyzeReceiptFlow = ai.defineFlow(
     outputSchema: AnalyzeReceiptOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const redacted = redactInput(input);
+    const {output} = await prompt(redacted);
     if (!output) {
       throw new Error('No output returned from analyzeReceiptPrompt');
     }

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -12,6 +12,7 @@
  */
 
 import {ai} from '@/ai/genkit';
+import {redactInput} from '@/ai/redaction';
 import {DATA_URI_REGEX} from '@/lib/data-uri';
 import {z} from 'genkit';
 
@@ -90,7 +91,8 @@ const analyzeSpendingHabitsFlow = ai.defineFlow(
     outputSchema: AnalyzeSpendingHabitsOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const redacted = redactInput(input);
+    const {output} = await prompt(redacted);
     if (!output) {
       throw new Error('No output returned from analyzeSpendingHabitsPrompt');
     }

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -10,6 +10,7 @@
  */
 
 import {ai} from '@/ai/genkit';
+import {redactInput} from '@/ai/redaction';
 import {z} from 'genkit';
 
 const CalculateCashflowInputSchema = z.object({
@@ -71,7 +72,8 @@ const calculateCashflowFlow = ai.defineFlow(
     outputSchema: CalculateCashflowOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const redacted = redactInput(input);
+    const {output} = await prompt(redacted);
     if (!output) {
       throw new Error('No output returned from calculateCashflowFlow');
     }

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -10,6 +10,7 @@
  */
 
 import {ai} from '@/ai/genkit';
+import {redactInput} from '@/ai/redaction';
 import {z} from 'genkit';
 
 const TransactionSchema = z.object({
@@ -68,7 +69,8 @@ const spendingForecastFlow = ai.defineFlow(
     outputSchema: SpendingForecastOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const redacted = redactInput(input);
+    const {output} = await prompt(redacted);
     if (!output) {
       throw new Error('No output returned from spendingForecastPrompt');
     }

--- a/src/ai/flows/suggest-category.ts
+++ b/src/ai/flows/suggest-category.ts
@@ -2,6 +2,7 @@
 'use server';
 
 import { ai } from '@/ai/genkit';
+import { redactInput } from '@/ai/redaction';
 import { z } from 'genkit';
 
 import { classifyCategory } from '../train/category-model';
@@ -32,7 +33,8 @@ const suggestCategoryFlow = ai.defineFlow(
     outputSchema: SuggestCategoryOutputSchema,
   },
   async (input) => {
-    const { output } = await prompt(input);
+    const redacted = redactInput(input);
+    const { output } = await prompt(redacted);
     if (!output) {
       throw new Error('No output returned from suggestCategoryFlow');
     }

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -10,6 +10,7 @@
  */
 
 import {ai} from '@/ai/genkit';
+import {redactInput} from '@/ai/redaction';
 import {z} from 'genkit';
 import { RecurrenceValues } from '@/lib/types';
 
@@ -71,7 +72,8 @@ const suggestDebtStrategyFlow = ai.defineFlow(
     outputSchema: SuggestDebtStrategyOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const redacted = redactInput(input);
+    const {output} = await prompt(redacted);
     if (!output) {
       throw new Error('No output returned from suggestDebtStrategyFlow');
     }

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,9 +1,11 @@
 import {genkit} from 'genkit';
 import {googleAI} from '@genkit-ai/googleai';
+import {redactionMiddleware} from './redaction';
 
 const model = process.env.GENKIT_MODEL || 'googleai/gemini-2.5-flash';
 
 export const ai = genkit({
   plugins: [googleAI()],
   model,
-});
+  use: [redactionMiddleware],
+} as any);

--- a/src/ai/redaction.ts
+++ b/src/ai/redaction.ts
@@ -1,0 +1,71 @@
+import { type ModelMiddleware } from '@genkit-ai/ai/model';
+
+/**
+ * Redact sensitive information from a string.
+ * Removes email addresses, phone numbers, and long account numbers.
+ */
+export function redactText(value: string): string {
+  return value
+    // Emails
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[REDACTED]')
+    // Phone numbers (e.g., 123-456-7890, (123) 456-7890, +1 123 456 7890)
+    .replace(/\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?){2}\d{4}\b/g, '[REDACTED]')
+    // Account numbers or long digit sequences (9+ digits)
+    .replace(/\b\d{9,}\b/g, '[REDACTED]');
+}
+
+/**
+ * If the value is a data URI, decode the payload, redact, then re-encode.
+ */
+function redactDataUri(uri: string): string {
+  if (!uri.startsWith('data:')) return redactText(uri);
+  const [prefix, data] = uri.split(',', 2);
+  try {
+    const decoded = Buffer.from(data, 'base64').toString('utf8');
+    const redacted = redactText(decoded);
+    return `${prefix},${Buffer.from(redacted, 'utf8').toString('base64')}`;
+  } catch {
+    return redactText(uri);
+  }
+}
+
+/**
+ * Recursively redact all string fields within the provided input.
+ */
+export function redactInput<T>(input: T): T {
+  if (typeof input === 'string') {
+    return redactDataUri(input) as unknown as T;
+  }
+  if (Array.isArray(input)) {
+    return input.map((item) => redactInput(item)) as unknown as T;
+  }
+  if (input && typeof input === 'object') {
+    const result: any = {};
+    for (const [key, value] of Object.entries(input as any)) {
+      result[key] = redactInput(value);
+    }
+    return result;
+  }
+  return input;
+}
+
+/**
+ * Genkit model middleware to ensure any remaining sensitive data in messages is redacted.
+ */
+export const redactionMiddleware: ModelMiddleware = async (req, next) => {
+  const messages = req.messages.map((message) => ({
+    ...message,
+    content: message.content.map((part) => {
+      if (part.text) {
+        return { ...part, text: redactText(part.text) };
+      }
+      if (part.media?.url) {
+        return { ...part, media: { ...part.media, url: redactDataUri(part.media.url) } };
+      }
+      return part;
+    }),
+  }));
+  return next({ ...req, messages });
+};
+
+export default redactInput;


### PR DESCRIPTION
## Summary
- add utility and middleware to remove emails, phone numbers, and account numbers from inputs
- register redaction middleware in Genkit and preprocess inputs in all AI flows
- add tests ensuring redaction occurs before model invocation

## Testing
- `npm test --silent --runInBand` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npx jest src/ai/flows/__tests__/redaction.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b2db8263708331ad63ef1561ef03e7