### PR TITLE
docs: update transactions sync comments

### DIFF
--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -7,10 +7,14 @@ import { logger } from "@/lib/logger"
 
 /**
  * Generic transaction syncing endpoint.
+ *
  * Unlike `/api/bank/import`, this expects transactions that have already
- * been fetched from any source. The current implementation only validates
- * and reports how many transactions were received without persisting them.
- * TODO: Implement database persistence for received transactions.
+ * been fetched from any source. Incoming transactions are validated and
+ * persisted to Firestore; the response reports how many were saved.
+ *
+ * A Firebase Authentication token is required. Once user scoping is
+ * implemented, transactions will be stored under the authenticated user's
+ * account.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),


### PR DESCRIPTION
## Summary
- document validation and Firestore persistence in transactions sync endpoint
- note Firebase auth requirement and upcoming user scoping

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db83b9108331bd34bef96afd875d