### PR TITLE
feat: persist bank import transactions

### DIFF
--- a/src/__tests__/bank-import.test.ts
+++ b/src/__tests__/bank-import.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/transactions", () => {
+  const actual = jest.requireActual("@/lib/transactions")
+  return {
+    ...actual,
+    saveTransactions: jest.fn().mockResolvedValue(undefined),
+  }
+})
+
+import { POST as bankImport } from "@/app/api/bank/import/route"
+import { saveTransactions } from "@/lib/transactions"
+
+const baseTx = {
+  id: "1",
+  date: "2024-01-01",
+  description: "Test",
+  amount: 1,
+  currency: "USD",
+  type: "Income" as const,
+  category: "Misc",
+}
+
+describe("/api/bank/import persistence", () => {
+  beforeEach(() => {
+    ;(saveTransactions as jest.Mock).mockClear()
+  })
+
+  it("saves transactions with user ID", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ provider: "plaid", transactions: [baseTx] }),
+    })
+
+    const res = await bankImport(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data).toEqual({ provider: "plaid", imported: 1 })
+    expect(saveTransactions).toHaveBeenCalledTimes(1)
+    expect(saveTransactions).toHaveBeenCalledWith([
+      { ...baseTx, userId: "test-user" },
+    ])
+  })
+
+  it("propagates persistence errors", async () => {
+    ;(saveTransactions as jest.Mock).mockRejectedValueOnce(
+      new Error("db failed"),
+    )
+
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ provider: "plaid", transactions: [baseTx] }),
+    })
+
+    const res = await bankImport(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(data).toEqual({ error: "db failed" })
+  })
+})

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -6,7 +6,7 @@ import { getAuth } from "firebase-admin/auth";
  * In test environments, a token value of "test-token" is accepted.
  * @throws Error if the token is missing or invalid.
  */
-export async function verifyFirebaseToken(req: Request): Promise<void> {
+export async function verifyFirebaseToken(req: Request): Promise<string> {
   const authHeader = req.headers.get("Authorization");
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
     throw new Error("Missing Authorization header");
@@ -18,12 +18,13 @@ export async function verifyFirebaseToken(req: Request): Promise<void> {
     if (token !== "test-token") {
       throw new Error("Invalid token");
     }
-    return;
+    return "test-user";
   }
 
   if (!getApps().length) {
     initializeApp();
   }
 
-  await getAuth().verifyIdToken(token);
+  const decoded = await getAuth().verifyIdToken(token);
+  return decoded.uid;
 }


### PR DESCRIPTION
## Summary
- save bank import transactions to Firestore with authenticated user ID
- return user identifier from `verifyFirebaseToken`
- test successful and failed saves in bank import route

## Testing
- `npm test` *(fails: Cannot use import statement outside a module for auth-provider.test.tsx, debt-calendar.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db86541083318ab08115008cd4d1