### PR TITLE
Add configurable CORS handling

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -22,6 +22,37 @@ if (typeof (global as any).Headers === 'undefined') {
   (global as any).Headers = class {}
 }
 
+// Basic browser APIs used by some components
+if (
+  typeof window !== 'undefined' &&
+  typeof (window as any).matchMedia !== 'function'
+) {
+  ;(window as any).matchMedia = () => ({
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+    media: '',
+  })
+}
+
+jest.mock('lucide-react', () => {
+  const React = require('react')
+  return new Proxy(
+    {},
+    {
+      get: () => () => React.createElement('svg'),
+    },
+  )
+})
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => '/',
+}))
+
 // Stub Firebase environment variables expected by zod validation
 process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'test'
 process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'test'

--- a/src/__tests__/cors.test.ts
+++ b/src/__tests__/cors.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment node
+ */
+
+process.env.ALLOWED_ORIGINS = "http://allowed.com";
+
+jest.mock("@/lib/transactions", () => {
+  const actual = jest.requireActual("@/lib/transactions");
+  return {
+    ...actual,
+    saveTransactions: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { POST as transactionsSync } from "@/app/api/transactions/sync/route";
+
+describe("CORS", () => {
+  const body = JSON.stringify({ transactions: [] });
+
+  it("allows requests from configured origins", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: {
+        Origin: "http://allowed.com",
+        Authorization: "Bearer test-token",
+      },
+      body,
+    });
+
+    const res = await transactionsSync(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "http://allowed.com"
+    );
+  });
+
+  it("rejects requests from other origins", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: {
+        Origin: "http://evil.com",
+        Authorization: "Bearer test-token",
+      },
+      body,
+    });
+
+    const res = await transactionsSync(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 for missing auth even if origin allowed", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Origin: "http://allowed.com" },
+      body,
+    });
+
+    const res = await transactionsSync(req);
+    expect(res.status).toBe(401);
+  });
+});
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { withAllowedOrigin } from '@/lib/allowed-origins';
 
 export function middleware(request: NextRequest) {
   const cspNonce = Buffer.from(crypto.randomUUID()).toString('base64');
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', cspNonce);
 
-  const response = NextResponse.next({
+  let response = NextResponse.next({
     request: {
       headers: requestHeaders,
     },
@@ -33,10 +34,7 @@ export function middleware(request: NextRequest) {
     'max-age=63072000; includeSubDomains; preload'
   );
 
-  if (process.env.NODE_ENV === 'development') {
-    response.headers.set('Access-Control-Allow-Origin', '*');
-  }
-
+  response = withAllowedOrigin(request, response);
   return response;
 }
 


### PR DESCRIPTION
## Summary
- add helper to validate origins and apply CORS headers
- use origin helper in API routes and middleware
- test that allowed and disallowed origins are handled correctly

## Testing
- `npm test` *(fails: src/__tests__/debt-calendar.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db877a0c8331bd1f28d03b664d37