### PR TITLE
feat: add prompt redaction middleware

### DIFF
--- a/src/ai/__tests__/redact.test.ts
+++ b/src/ai/__tests__/redact.test.ts
@@ -1,0 +1,41 @@
+import {redactSensitiveMiddleware} from '@/ai/redact';
+import type {GenerateRequest, GenerateResponseData} from 'genkit/model';
+
+describe('redactSensitiveMiddleware', () => {
+  it('redacts emails, phone numbers, and account digits', async () => {
+    const req: GenerateRequest = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'Email: test@example.com Phone: +1 (123) 456-7890 Account: 1234567890123456',
+            },
+          ],
+        },
+      ],
+    } as any;
+
+    const next = jest.fn(async (_req: GenerateRequest): Promise<GenerateResponseData> => ({
+      message: {
+        role: 'model',
+        content: [
+          {
+            text: 'Got test@example.com and 123-456-7890 account 6543210987654321',
+          },
+        ],
+      },
+    }) as any);
+
+    const res = await redactSensitiveMiddleware(req, next);
+
+    const redactedInput = next.mock.calls[0][0] as GenerateRequest;
+    expect(redactedInput.messages[0].content[0].text).toBe(
+      'Email: [REDACTED] Phone: [REDACTED] Account: [REDACTED]'
+    );
+
+    expect(res.message!.content[0].text).toBe(
+      'Got [REDACTED] and [REDACTED] account [REDACTED]'
+    );
+  });
+});

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,9 +1,11 @@
 import {genkit} from 'genkit';
 import {googleAI} from '@genkit-ai/googleai';
+import {redactSensitiveMiddleware} from './redact';
 
 const model = process.env.GENKIT_MODEL || 'googleai/gemini-2.5-flash';
 
 export const ai = genkit({
   plugins: [googleAI()],
   model,
-});
+  use: [redactSensitiveMiddleware],
+} as any);

--- a/src/ai/redact.ts
+++ b/src/ai/redact.ts
@@ -1,0 +1,40 @@
+import type { ModelMiddleware, Part, MessageData, GenerateResponseData } from 'genkit/model';
+
+const REDACTED = '[REDACTED]';
+
+const EMAIL_REGEX = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const PHONE_REGEX = /\+?\d[\d\s\-()]{7,}\d/g;
+const ACCOUNT_REGEX = /\b\d{8,}\b/g;
+
+function redactText(text: string): string {
+  return text
+    .replace(EMAIL_REGEX, REDACTED)
+    .replace(PHONE_REGEX, REDACTED)
+    .replace(ACCOUNT_REGEX, REDACTED);
+}
+
+function redactParts(parts: Part[]): Part[] {
+  return parts.map(part =>
+    part.text ? { ...part, text: redactText(part.text) } : part
+  );
+}
+
+function redactMessage(message: MessageData): MessageData {
+  return { ...message, content: redactParts(message.content) };
+}
+
+export const redactSensitiveMiddleware: ModelMiddleware = async (req, next) => {
+  const redactedReq = { ...req, messages: req.messages.map(redactMessage) };
+  const response = await next(redactedReq);
+  const redactedResponse: GenerateResponseData = {
+    ...response,
+    message: response.message ? redactMessage(response.message) : response.message,
+    candidates: response.candidates?.map(candidate => ({
+      ...candidate,
+      content: redactParts(candidate.content),
+    })),
+  } as GenerateResponseData;
+  return redactedResponse;
+};
+
+export { redactText };


### PR DESCRIPTION
## Summary
- add middleware that strips emails, phone numbers, and long digit sequences from Genkit prompts and responses
- register the redaction middleware when initializing Genkit
- test middleware redaction across common sensitive patterns

## Testing
- `npm test src/ai/__tests__/redact.test.ts`
- `npm test` *(fails: Jest encountered ESM import errors in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db87d5d88331add197a56aefef11