### PR TITLE
Document transaction sync persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ costs for housing, groceries, utilities, transportation, healthcare, and
 miscellaneous categories. Use `calculateCostOfLiving` to scale values by
 household composition. Run `node scripts/update-cost-of-living.ts` each year to
 fetch new figures.
+
+## Transaction sync API
+
+Use the `/api/transactions/sync` endpoint to persist transactions that have
+already been retrieved from an external source. The endpoint validates the
+payload and writes accepted records to Firestore, responding with a count of
+transactions saved. See [docs/transactions-sync.md](docs/transactions-sync.md)
+for details on the request format.

--- a/docs/transactions-sync.md
+++ b/docs/transactions-sync.md
@@ -1,0 +1,25 @@
+# Transaction sync API
+
+The `/api/transactions/sync` endpoint accepts an array of transactions that
+have already been gathered from an external source. Each item must match the
+`TransactionPayloadSchema` (id, date, description, amount, currency, type, and
+category).
+
+The server validates the payload and persists accepted transactions to
+Firestore. A successful response reports how many records were saved:
+
+```http
+POST /api/transactions/sync
+{
+  "transactions": [/* ... */]
+}
+
+HTTP/1.1 200 OK
+{
+  "received": 3
+}
+```
+
+If validation fails, the endpoint responds with `400` and error details.
+Failures during persistence return an appropriate status code and error
+message.

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -8,9 +8,9 @@ import { logger } from "@/lib/logger"
 /**
  * Generic transaction syncing endpoint.
  * Unlike `/api/bank/import`, this expects transactions that have already
- * been fetched from any source. The current implementation only validates
- * and reports how many transactions were received without persisting them.
- * TODO: Implement database persistence for received transactions.
+ * been fetched from any source. The endpoint validates each record,
+ * persists the transactions to the database, and responds with the count
+ * of accepted items.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),


### PR DESCRIPTION
## Summary
- clarify that `/api/transactions/sync` persists transactions
- document sync API usage and link from README

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(fails: lint errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db886fc88331b002b17c62609666