### PR TITLE
Persist bank import transactions

### DIFF
--- a/src/__tests__/bank-import.test.ts
+++ b/src/__tests__/bank-import.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/transactions", () => {
+  const actual = jest.requireActual("@/lib/transactions")
+  return {
+    ...actual,
+    saveTransactions: jest.fn().mockResolvedValue(undefined),
+  }
+})
+
+import { POST as bankImport } from "@/app/api/bank/import/route"
+import { saveTransactions } from "@/lib/transactions"
+
+const baseTx = {
+  id: "1",
+  date: "2024-01-01",
+  description: "Test",
+  amount: 1,
+  currency: "USD",
+  type: "Income" as const,
+  category: "Misc",
+}
+
+describe("/api/bank/import persistence", () => {
+  beforeEach(() => {
+    ;(saveTransactions as jest.Mock).mockClear()
+  })
+
+  it("saves transactions via saveTransactions", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ provider: "plaid", transactions: [baseTx] }),
+    })
+
+    const res = await bankImport(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data).toEqual({ provider: "plaid", imported: 1 })
+    expect(saveTransactions).toHaveBeenCalledTimes(1)
+    expect(saveTransactions).toHaveBeenCalledWith([baseTx])
+  })
+
+  it("propagates persistence errors", async () => {
+    ;(saveTransactions as jest.Mock).mockRejectedValueOnce(
+      Object.assign(new Error("db failed"), { status: 503 }),
+    )
+
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ provider: "plaid", transactions: [baseTx] }),
+    })
+
+    const res = await bankImport(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(503)
+    expect(data).toEqual({ error: "db failed" })
+  })
+})


### PR DESCRIPTION
## Summary
- Persist imported bank transactions using `saveTransactions`
- Surface Firestore persistence errors with logger-based handling
- Add tests confirming `/api/bank/import` saves transactions and reports persistence failures

## Testing
- `npm test` *(fails: SyntaxError in auth-provider.test.tsx, debt-calendar.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db8b024c8331a7592e5aba144138