### PR TITLE
feat: add AI prompt redaction middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ To get started, take a look at src/app/page.tsx.
 - Run `npm install` to install Husky pre-commit hooks that run tests and reject commits containing standalone '...' lines.
 - `node scripts/update-cost-of-living.ts` – refresh cost of living dataset from BEA.
 
+## AI redaction
+
+All prompts and model responses are sanitized before leaving the server. The
+redaction middleware in `src/ai/redact.ts` removes email addresses, phone
+numbers, and obvious account identifiers. Each flow applies this redaction step
+prior to invoking the model to help maintain compliance with data handling
+requirements.
+
 ## Package manager
 
 This project uses **npm** exclusively. Install dependencies with `npm ci` and

--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -9,9 +9,10 @@
  * - AnalyzeReceiptOutput - The return type for the analyzeReceipt function.
  */
 
-import {ai} from '@/ai/genkit';
-import {DATA_URI_REGEX} from '@/lib/data-uri';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { redact } from '@/ai/redact';
+import { DATA_URI_REGEX } from '@/lib/data-uri';
+import { z } from 'genkit';
 
 export const AnalyzeReceiptInputSchema = z.object({
   receiptImage: z
@@ -50,10 +51,11 @@ const analyzeReceiptFlow = ai.defineFlow(
     outputSchema: AnalyzeReceiptOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const cleanInput = redact(input);
+    const { output } = await prompt(cleanInput);
     if (!output) {
       throw new Error('No output returned from analyzeReceiptPrompt');
     }
-    return output;
+    return redact(output);
   }
 );

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -11,9 +11,10 @@
  * - AnalyzeSpendingHabitsOutput - The return type for the analyzeSpendingHabits function.
  */
 
-import {ai} from '@/ai/genkit';
-import {DATA_URI_REGEX} from '@/lib/data-uri';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { redact } from '@/ai/redact';
+import { DATA_URI_REGEX } from '@/lib/data-uri';
+import { z } from 'genkit';
 
 const GoalSchema = z.object({
     id: z.string(),
@@ -90,10 +91,11 @@ const analyzeSpendingHabitsFlow = ai.defineFlow(
     outputSchema: AnalyzeSpendingHabitsOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const cleanInput = redact(input);
+    const { output } = await prompt(cleanInput);
     if (!output) {
       throw new Error('No output returned from analyzeSpendingHabitsPrompt');
     }
-    return output;
+    return redact(output);
   }
 );

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -9,8 +9,9 @@
  * - CalculateCashflowOutput - The return type for the calculateCashflow function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { redact } from '@/ai/redact';
+import { z } from 'genkit';
 
 const CalculateCashflowInputSchema = z.object({
   annualIncome: z
@@ -71,10 +72,11 @@ const calculateCashflowFlow = ai.defineFlow(
     outputSchema: CalculateCashflowOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const cleanInput = redact(input);
+    const { output } = await prompt(cleanInput);
     if (!output) {
       throw new Error('No output returned from calculateCashflowFlow');
     }
-    return output;
+    return redact(output);
   }
 );

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -9,8 +9,9 @@
  * - SpendingForecastOutput - The return type for the predictSpending function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { redact } from '@/ai/redact';
+import { z } from 'genkit';
 
 const TransactionSchema = z.object({
   date: z
@@ -68,10 +69,11 @@ const spendingForecastFlow = ai.defineFlow(
     outputSchema: SpendingForecastOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const cleanInput = redact(input);
+    const { output } = await prompt(cleanInput);
     if (!output) {
       throw new Error('No output returned from spendingForecastPrompt');
     }
-    return output;
+    return redact(output);
   }
 );

--- a/src/ai/flows/suggest-category.ts
+++ b/src/ai/flows/suggest-category.ts
@@ -2,6 +2,7 @@
 'use server';
 
 import { ai } from '@/ai/genkit';
+import { redact } from '@/ai/redact';
 import { z } from 'genkit';
 
 import { classifyCategory } from '../train/category-model';
@@ -31,12 +32,13 @@ const suggestCategoryFlow = ai.defineFlow(
     inputSchema: SuggestCategoryInputSchema,
     outputSchema: SuggestCategoryOutputSchema,
   },
-  async (input) => {
-    const { output } = await prompt(input);
+  async input => {
+    const cleanInput = redact(input);
+    const { output } = await prompt(cleanInput);
     if (!output) {
       throw new Error('No output returned from suggestCategoryFlow');
     }
-    return output;
+    return redact(output);
   }
 );
 

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -9,8 +9,9 @@
  * - SuggestDebtStrategyOutput - The return type for the suggestDebtStrategy function.
  */
 
-import {ai} from '@/ai/genkit';
-import {z} from 'genkit';
+import { ai } from '@/ai/genkit';
+import { redact } from '@/ai/redact';
+import { z } from 'genkit';
 import { RecurrenceValues } from '@/lib/types';
 
 const DebtSchema = z.object({
@@ -71,10 +72,11 @@ const suggestDebtStrategyFlow = ai.defineFlow(
     outputSchema: SuggestDebtStrategyOutputSchema,
   },
   async input => {
-    const {output} = await prompt(input);
+    const cleanInput = redact(input);
+    const { output } = await prompt(cleanInput);
     if (!output) {
       throw new Error('No output returned from suggestDebtStrategyFlow');
     }
-    return output;
+    return redact(output);
   }
 );

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,9 +1,13 @@
-import {genkit} from 'genkit';
-import {googleAI} from '@genkit-ai/googleai';
+import { genkit } from 'genkit';
+import { googleAI } from '@genkit-ai/googleai';
+import { redactMiddleware } from './redact';
 
-const model = process.env.GENKIT_MODEL || 'googleai/gemini-2.5-flash';
+const modelName = (process.env.GENKIT_MODEL || 'gemini-2.5-flash').replace(
+  /^googleai\//,
+  ''
+);
 
 export const ai = genkit({
   plugins: [googleAI()],
-  model,
+  model: googleAI.model(modelName, { use: [redactMiddleware] }),
 });

--- a/src/ai/redact.ts
+++ b/src/ai/redact.ts
@@ -1,0 +1,56 @@
+import type { ModelMiddleware } from '@genkit-ai/ai/model';
+import { genkitPlugin } from 'genkit';
+
+const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const PHONE_REGEX = /\b(?:\+?1[-.\s]?)?(?:\(\d{3}\)|\d{3})[-.\s]?\d{3}[-.\s]?\d{4}\b/g;
+const ACCOUNT_REGEX = /(account|acct|iban|routing|ssn)[^\d]{0,10}\d{2,}/gi;
+
+export function redactText(text: string): string {
+  return text
+    .replace(EMAIL_REGEX, '[REDACTED]')
+    .replace(PHONE_REGEX, '[REDACTED]')
+    .replace(ACCOUNT_REGEX, '[REDACTED]');
+}
+
+export function redact<T>(data: T): T {
+  if (typeof data === 'string') {
+    return redactText(data) as unknown as T;
+  }
+  if (Array.isArray(data)) {
+    return data.map(item => redact(item)) as unknown as T;
+  }
+  if (data && typeof data === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+      result[key] = redact(value);
+    }
+    return result as T;
+  }
+  return data;
+}
+
+export const redactMiddleware: ModelMiddleware = async (req, next) => {
+  const messages = req.messages.map(m => ({
+    ...m,
+    content: m.content.map(part =>
+      part.text ? { ...part, text: redactText(part.text) } : part
+    ),
+  }));
+  const res = await next({ ...req, messages });
+  if (res.candidates) {
+    return {
+      ...res,
+      candidates: res.candidates.map(c => ({
+        ...c,
+        content: c.content.map(part =>
+          part.text ? { ...part, text: redactText(part.text) } : part
+        ),
+      })),
+    };
+  }
+  return res;
+};
+
+export function redactionPlugin() {
+  return genkitPlugin('redaction', () => {});
+}


### PR DESCRIPTION
## Summary
- sanitize prompts and model outputs with new redact utility
- plug redaction middleware into genkit configuration
- document redaction compliance behavior in README

## Testing
- `npm test` *(fails: Jest could not parse ES module lucide-react)*
- `npm run lint` *(fails: eslint rule violations in existing test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db8ba4688331ab23e377ab3c6d7a