### PR TITLE
feat: add rule engine and builder

### DIFF
--- a/apps/web/src/app/rules/page.tsx
+++ b/apps/web/src/app/rules/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { db, auth } from '@/app/src/lib/firebaseClient';
+import { collection, onSnapshot, query, where, orderBy } from 'firebase/firestore';
+import RuleBuilder from '@/app/src/components/RuleBuilder';
+
+export default function RulesPage() {
+  const [uid, setUid] = useState<string|null>(null);
+  const [rules, setRules] = useState<any[]>([]);
+  const [selected, setSelected] = useState<any|null>(null);
+
+  useEffect(()=> auth.onAuthStateChanged(u=> setUid(u?.uid??null)),[]);
+  useEffect(()=>{
+    if (!uid) return;
+    const q = query(collection(db, 'rules'), where('user_id','==',uid), orderBy('priority','asc'));
+    return onSnapshot(q, (snap)=> setRules(snap.docs.map(d=> ({ id: d.id, ...d.data() } as any))));
+  },[uid]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Rules</h1>
+        <button className="rounded bg-black text-white px-4 py-2" onClick={()=> setSelected(null)}>New rule</button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="md:col-span-1 border rounded-xl">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50"><tr><th className="text-left p-2">Priority</th><th className="text-left p-2">Category</th><th className="text-left p-2">Enabled</th></tr></thead>
+            <tbody>
+              {rules.map(r=> (
+                <tr key={r.id} className="border-t hover:bg-gray-50 cursor-pointer" onClick={()=> setSelected(r)}>
+                  <td className="p-2">{r.priority ?? 100}</td>
+                  <td className="p-2">{r.action?.nurse_category}</td>
+                  <td className="p-2">{String(r.enabled ?? true)}</td>
+                </tr>
+              ))}
+              {rules.length===0 && <tr><td className="p-2" colSpan={3}>No rules yet.</td></tr>}
+            </tbody>
+          </table>
+        </div>
+        <div className="md:col-span-2">
+          <RuleBuilder existing={selected||undefined} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/RuleBuilder.tsx
+++ b/apps/web/src/components/RuleBuilder.tsx
@@ -1,0 +1,130 @@
+'use client';
+import React, { useState } from 'react';
+import { createRule, updateRule, apiPreviewRule, apiApplyRules } from '@/app/src/lib/rulesClient';
+
+const nurseCats = [
+  'scrubs','ceus','licensure','agency_fees','housing_stipend_overage','mileage','lodging','per_diem','union_dues','equipment','parking','meals_on_shift','certifications','travel_misc'
+];
+
+export default function RuleBuilder({ existing }: { existing?: any }) {
+  const [match, setMatch] = useState<any>(existing?.match || { merchant: '', mcc: '', contains: [] as string[], amount_tolerance: undefined });
+  const [action, setAction] = useState<any>(existing?.action || { nurse_category: nurseCats[0], split: [] as any[] });
+  const [priority, setPriority] = useState<number>(existing?.priority ?? 100);
+  const [enabled, setEnabled] = useState<boolean>(existing?.enabled ?? true);
+  const [containsInput, setContainsInput] = useState('');
+  const [preview, setPreview] = useState<{count:number; sample:any[]} | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string>('');
+
+  function addContains() {
+    const tok = containsInput.trim(); if (!tok) return;
+    setMatch({ ...match, contains: [...(match.contains||[]), tok] });
+    setContainsInput('');
+  }
+  function removeContains(i: number) {
+    const arr = [...(match.contains||[])]; arr.splice(i,1); setMatch({ ...match, contains: arr });
+  }
+
+  async function onPreview() {
+    setBusy(true); setMsg('');
+    try {
+      const res = await apiPreviewRule({ match, action, priority });
+      setPreview(res);
+      setMsg(`Matches: ${res.count}`);
+    } catch (e:any) { setMsg(e.message); }
+    finally { setBusy(false); }
+  }
+
+  async function onSave() {
+    setBusy(true); setMsg('');
+    try {
+      if (existing?.id) await updateRule(existing.id, { match, action, priority, enabled });
+      else await createRule({ match, action, priority, enabled });
+      setMsg('Saved');
+    } catch (e:any) { setMsg(e.message); }
+    finally { setBusy(false); }
+  }
+
+  async function onApply() {
+    if (!confirm('Apply rules to past transactions? This will modify categories.')) return;
+    setBusy(true); setMsg('');
+    try {
+      const res = await apiApplyRules({ dryRun: false });
+      setMsg(`Applied: changed ${res.totalChanged} of ${res.totalScanned}. Showing first ${res.changes?.length||0}.`);
+      setPreview({ count: res.totalChanged, sample: res.changes||[] });
+    } catch (e:any) { setMsg(e.message); }
+    finally { setBusy(false); }
+  }
+
+  return (
+    <div className="space-y-4 border rounded-xl p-4">
+      <h3 className="text-lg font-semibold">Rule</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <h4 className="font-medium">Match</h4>
+          <label className="block text-sm mt-2">Merchant contains</label>
+          <input className="mt-1 w-full border rounded p-2" value={match.merchant||''} onChange={e=>setMatch({...match, merchant: e.target.value})} placeholder="e.g., starbucks" />
+
+          <label className="block text-sm mt-3">MCC</label>
+          <input className="mt-1 w-full border rounded p-2" value={match.mcc||''} onChange={e=>setMatch({...match, mcc: e.target.value})} placeholder="e.g., 5814" />
+
+          <label className="block text-sm mt-3">Text must contain (all)</label>
+          <div className="flex gap-2 mt-1">
+            <input className="flex-1 border rounded p-2" value={containsInput} onChange={e=>setContainsInput(e.target.value)} placeholder="keyword" />
+            <button type="button" className="border rounded px-3" onClick={addContains}>Add</button>
+          </div>
+          <div className="flex gap-2 mt-2 flex-wrap">
+            {(match.contains||[]).map((t:string,i:number)=> (
+              <span key={i} className="text-xs border rounded px-2 py-1">{t} <button className="ml-1" onClick={()=>removeContains(i)}>×</button></span>
+            ))}
+          </div>
+
+          <label className="block text-sm mt-3">Amount tolerance (optional)</label>
+          <input type="number" step="0.01" className="mt-1 w-full border rounded p-2" value={match.amount_tolerance ?? ''} onChange={e=>setMatch({...match, amount_tolerance: e.target.value ? Number(e.target.value): undefined})} placeholder="e.g., 0.50" />
+        </div>
+
+        <div>
+          <h4 className="font-medium">Action</h4>
+          <label className="block text-sm mt-2">Nurse category</label>
+          <select className="mt-1 w-full border rounded p-2" value={action.nurse_category} onChange={e=>setAction({...action, nurse_category: e.target.value})}>
+            {nurseCats.map(c => <option key={c} value={c}>{c}</option>)}
+          </select>
+
+          <label className="block text-sm mt-3">Priority</label>
+          <input type="number" className="mt-1 w-full border rounded p-2" value={priority} onChange={e=>setPriority(Number(e.target.value))} />
+
+          <label className="mt-3 inline-flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={enabled} onChange={e=>setEnabled(e.target.checked)} /> Enabled
+          </label>
+        </div>
+      </div>
+
+      <div className="flex gap-3 items-center">
+        <button className="rounded bg-black text-white px-4 py-2" disabled={busy} onClick={onPreview}>Preview</button>
+        <button className="rounded border px-4 py-2" disabled={busy} onClick={onSave}>Save</button>
+        <button className="rounded border px-4 py-2" disabled={busy} onClick={onApply}>Apply All Enabled Rules</button>
+        {busy && <span className="text-sm opacity-70">Working…</span>}
+      </div>
+
+      {msg && <p className="text-sm">{msg}</p>}
+      {preview && (
+        <div className="border rounded p-3 mt-2">
+          <h4 className="font-medium">Preview results</h4>
+          <p className="text-sm opacity-70">Matches: {preview.count}. Showing up to {preview.sample.length} examples.</p>
+          <table className="w-full text-sm mt-2">
+            <thead><tr><th className="text-left">Merchant</th><th className="text-left">Amount</th><th className="text-left">Why</th></tr></thead>
+            <tbody>
+              {preview.sample.map((s:any)=> (
+                <tr key={s.id} className="border-t">
+                  <td className="p-2">{s.merchant_name||'—'}</td>
+                  <td className="p-2">${'{'}(s.amount||0).toFixed(2){'}'}</td>
+                  <td className="p-2 text-xs">{Array.isArray(s.reason)? s.reason.join('; ') : ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/rulesClient.ts
+++ b/apps/web/src/lib/rulesClient.ts
@@ -1,0 +1,24 @@
+'use client';
+import { db } from '@/app/src/lib/firebaseClient';
+import { collection, addDoc, serverTimestamp, updateDoc, doc } from 'firebase/firestore';
+import { auth } from '@/app/src/lib/firebaseClient';
+import { apiApplyRules, apiPreviewRule } from './rulesFunctionsClient';
+
+export async function createRule(input: { match: any; action: any; priority?: number; enabled?: boolean; }) {
+  const uid = auth.currentUser?.uid; if (!uid) throw new Error('Not signed in');
+  const ref = await addDoc(collection(db, 'rules'), {
+    user_id: uid,
+    match: input.match,
+    action: input.action,
+    priority: input.priority ?? 100,
+    enabled: input.enabled ?? true,
+    created_at: serverTimestamp(),
+  });
+  return { id: ref.id };
+}
+
+export async function updateRule(ruleId: string, patch: any) {
+  await updateDoc(doc(db, 'rules', ruleId), patch);
+}
+
+export { apiApplyRules, apiPreviewRule };

--- a/apps/web/src/lib/rulesFunctionsClient.ts
+++ b/apps/web/src/lib/rulesFunctionsClient.ts
@@ -1,0 +1,12 @@
+'use client';
+import { auth, FUNCTIONS_ORIGIN } from '@/app/src/lib/firebaseClient';
+
+async function idToken(): Promise<string> { const u = auth.currentUser; if (!u) throw new Error('Not authenticated'); return u.getIdToken(true); }
+async function call<T=any>(path: string, body?: any): Promise<T> {
+  const url = `${FUNCTIONS_ORIGIN}${path.startsWith('/')?'':'/'}${path}`;
+  const res = await fetch(url, { method: 'POST', headers: { 'Content-Type':'application/json', 'Authorization': `Bearer ${await idToken()}` }, body: JSON.stringify(body||{})});
+  if (!res.ok) throw new Error(await res.text());
+  return await res.json();
+}
+export async function apiPreviewRule(payload: { ruleId?: string; match?: any; action?: any; priority?: number; }) { return call('/previewRuleMatches', payload); }
+export async function apiApplyRules(payload: { ruleId?: string; dryRun?: boolean; }) { return call('/applyRulesNow', payload); }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isOwner(uid) {
+      return request.auth != null && request.auth.uid == uid;
+    }
+    match /{col=transactions|receipts|paystubs|debts|budgets|rules}/{docId} {
+      allow read, write: if isOwner(resource.data.user_id);
+    }
+  }
+}

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,0 +1,1 @@
+export * from './rules';

--- a/packages/workers/src/rules.ts
+++ b/packages/workers/src/rules.ts
@@ -1,0 +1,163 @@
+/**
+ * Rules engine endpoints
+ * - previewRuleMatches: dry-run a single rule and return matches with explanations
+ * - applyRulesNow: apply rules (single rule or all enabled) to user transactions
+ */
+import { onRequest } from 'firebase-functions/v2/https';
+import { defineSecret } from 'firebase-functions/params';
+import * as admin from 'firebase-admin';
+import * as logger from 'firebase-functions/logger';
+
+if (!admin.apps.length) admin.initializeApp();
+const db = admin.firestore();
+
+// --- Types (lightweight) ---
+interface RuleDoc { user_id: string; enabled?: boolean; priority?: number; match: any; action: any; }
+interface Tx { id: string; user_id: string; merchant_name?: string; amount: number; mcc?: string; raw_description?: string; posted_at?: FirebaseFirestore.Timestamp; nurse_category?: string|null; rule_id?: string|null; }
+
+// --- Auth helper ---
+async function requireUser(req: any): Promise<string> {
+  const hdr = req.headers?.authorization || '';
+  const token = hdr.startsWith('Bearer ') ? hdr.slice(7) : '';
+  if (!token) throw new Error('Missing Authorization token');
+  const decoded = await admin.auth().verifyIdToken(token);
+  return decoded.uid;
+}
+
+// --- Match logic ---
+function normalize(s?: string|null) { return (s||'').toLowerCase(); }
+function containsAll(hay: string, needles: string[]) { return needles.every(n => hay.includes(n.toLowerCase())); }
+
+function matchRule(tx: Tx, rule: RuleDoc): { matches: boolean; reason: string[] } {
+  const reasons: string[] = [];
+  const m = rule.match || {};
+  let ok = true;
+
+  if (m.merchant) {
+    const target = normalize(m.merchant);
+    const name = normalize(tx.merchant_name) || normalize(tx.raw_description);
+    const hit = !!name && name.includes(target);
+    ok = ok && hit; if (hit) reasons.push(`merchant contains "${m.merchant}"`);
+  }
+  if (m.mcc) {
+    const hit = normalize(tx.mcc) === normalize(m.mcc);
+    ok = ok && hit; if (hit) reasons.push(`mcc == ${m.mcc}`);
+  }
+  if (m.contains && Array.isArray(m.contains) && m.contains.length) {
+    const name = `${normalize(tx.merchant_name)} ${normalize(tx.raw_description)}`;
+    const hit = containsAll(name, m.contains);
+    ok = ok && hit; if (hit) reasons.push(`text contains: ${m.contains.join(', ')}`);
+  }
+  if (m.amount_tolerance != null) {
+    const tol = Number(m.amount_tolerance) || 0;
+    const target = Number(rule.action?.amount) || null; // optional target
+    if (target != null) {
+      const diff = Math.abs((tx.amount ?? 0) - target);
+      const hit = diff <= tol;
+      ok = ok && hit; if (hit) reasons.push(`|amount - ${target}| ≤ ${tol}`);
+    }
+  }
+  return { matches: ok, reason: reasons };
+}
+
+// Rank rules by priority (lower first)
+function sortRules(rules: RuleDoc[]) {
+  return [...rules].sort((a,b) => (a.priority ?? 100) - (b.priority ?? 100));
+}
+
+async function loadUserRules(uid: string, onlyEnabled = true): Promise<RuleDoc[]> {
+  let q: FirebaseFirestore.Query = db.collection('rules').where('user_id','==',uid);
+  if (onlyEnabled) q = q.where('enabled','==',true);
+  const snap = await q.get();
+  return snap.docs.map(d => ({ ...(d.data() as any), id: d.id }));
+}
+
+// Evaluate a single rule against recent transactions
+async function findMatches(uid: string, rule: RuleDoc, limitCount = 2000): Promise<{ matches: (Tx & { reason: string[] })[]; }> {
+  // scope: last 12 months for MVP
+  const since = admin.firestore.Timestamp.fromDate(new Date(Date.now() - 365*24*3600*1000));
+  const q = db.collection('transactions').where('user_id','==',uid).where('posted_at','>=',since);
+  const snap = await q.get();
+  const rows: (Tx & { reason: string[] })[] = [];
+  for (const d of snap.docs) {
+    const v = d.data() as any; const tx: Tx = { id: d.id, ...v } as any;
+    const res = matchRule(tx, rule);
+    if (res.matches) { rows.push({ ...tx, reason: res.reason }); }
+    if (rows.length >= limitCount) break;
+  }
+  return { matches: rows };
+}
+
+// Apply first-matching rule per tx (deterministic, by priority)
+async function applyRules(uid: string, rules: RuleDoc[], dryRun = true, maxWrite = 1000) {
+  const since = admin.firestore.Timestamp.fromDate(new Date(Date.now() - 365*24*3600*1000));
+  const snap = await db.collection('transactions').where('user_id','==',uid).where('posted_at','>=',since).get();
+  const ordered = sortRules(rules);
+  const changes: Array<{ id: string; from: string|null; to: string; rule_id: string; reason: string[] }> = [];
+
+  for (const d of snap.docs) {
+    const tx = { id: d.id, ...(d.data() as any) } as Tx;
+    // already categorized? still allow override by priority rules
+    let chosen: { to: string; rule_id: string; reason: string[] } | null = null;
+    for (const r of ordered) {
+      const res = matchRule(tx, r);
+      if (res.matches) { chosen = { to: r.action?.nurse_category, rule_id: (r as any).id || '', reason: res.reason }; break; }
+    }
+    if (chosen && chosen.to && (tx.nurse_category !== chosen.to || tx.rule_id !== chosen.rule_id)) {
+      changes.push({ id: tx.id, from: tx.nurse_category ?? null, to: chosen.to, rule_id: chosen.rule_id, reason: chosen.reason });
+      if (!dryRun && changes.length <= maxWrite) {
+        await d.ref.set({ nurse_category: chosen.to, rule_id: chosen.rule_id, updated_at: admin.firestore.FieldValue.serverTimestamp() }, { merge: true });
+      }
+      if (!dryRun && changes.length === maxWrite) break; // safety cap
+    }
+  }
+  return { totalScanned: snap.size, totalChanged: changes.length, changes: changes.slice(0, 100) };
+}
+
+export const previewRuleMatches = onRequest(async (req, res) => {
+  try {
+    const uid = await requireUser(req);
+    const body = req.body || {};
+    const ruleId = body.ruleId as string | undefined;
+    let rule: RuleDoc | null = null;
+
+    if (ruleId) {
+      const doc = await db.collection('rules').doc(ruleId).get();
+      if (!doc.exists || doc.get('user_id') !== uid) throw new Error('rule not found');
+      rule = { ...(doc.data() as any), id: doc.id };
+    } else {
+      rule = { user_id: uid, match: body.match || {}, action: body.action || {}, enabled: true, priority: body.priority ?? 100 } as any;
+    }
+
+    const { matches } = await findMatches(uid, rule!, 1000);
+    // summarize
+    const sample = matches.slice(0, 25).map(m => ({ id: m.id, merchant_name: m.merchant_name, amount: m.amount, reason: m.reason }));
+    res.json({ count: matches.length, sample });
+  } catch (e: any) {
+    logger.error('previewRuleMatches error', e);
+    res.status(400).json({ error: e.message });
+  }
+});
+
+export const applyRulesNow = onRequest(async (req, res) => {
+  try {
+    const uid = await requireUser(req);
+    const { ruleId, dryRun = false } = req.body || {};
+
+    let rules: RuleDoc[];
+    if (ruleId) {
+      const doc = await db.collection('rules').doc(ruleId).get();
+      if (!doc.exists || doc.get('user_id') !== uid) throw new Error('rule not found');
+      rules = [{ ...(doc.data() as any), id: doc.id }];
+    } else {
+      rules = await loadUserRules(uid, true);
+    }
+
+    const result = await applyRules(uid, rules, !!dryRun, 1000);
+    res.json({ dryRun: !!dryRun, ...result });
+  } catch (e: any) {
+    logger.error('applyRulesNow error', e);
+    res.status(400).json({ error: e.message });
+  }
+});
+


### PR DESCRIPTION
## Summary
- add Firebase functions for previewing and applying transaction rules
- allow `rules` collection in Firestore security rules
- add web rule builder UI and client utilities

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dc4d70808331985578e1d3ee0c13