### PR TITLE
test: mock lucide-react for jest

### DIFF
--- a/__mocks__/lucide-react.ts
+++ b/__mocks__/lucide-react.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const handler: ProxyHandler<any> = {
+  get: (_target, prop) => {
+    if (prop === '__esModule') {
+      return true;
+    }
+    return (props: any) => React.createElement('svg', props);
+  },
+};
+
+export = new Proxy({}, handler);

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^lucide-react$': '<rootDir>/__mocks__/lucide-react.ts',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -5,6 +5,20 @@ import { TextEncoder, TextDecoder } from 'node:util'
 Object.assign(globalThis as any, { TextEncoder, TextDecoder })
 
 
+// Provide a window.matchMedia mock for libraries that expect it
+if (typeof window !== 'undefined' && (window as any).matchMedia === undefined) {
+  (window as any).matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }))
+}
+
 // Provide a minimal fetch polyfill for tests that expect it
 ;(global as any).fetch = jest.fn(() =>
   Promise.resolve({


### PR DESCRIPTION
## Summary
- mock lucide-react with moduleNameMapper so Jest can import icons
- polyfill `window.matchMedia` in tests
- update debt calendar test with navigation and Firestore stubs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2dd3325848331ae03fd7077029d72