### PR TITLE
chore: transform js modules in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
     '^.+\\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+    '^.+\\\.(js|jsx|mjs|cjs)$': ['babel-jest', { plugins: ['@babel/plugin-transform-modules-commonjs'] }],
   },
   transformIgnorePatterns: [
     "/node_modules/(?!lucide-react|d3-.*|recharts|embla-carousel-react)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
         "@playwright/test": "^1.55.0",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
@@ -600,6 +601,23 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+      "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "nextn",
   "version": "0.1.0",
@@ -64,6 +63,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.27.1",
     "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
## Summary
- transform JS modules with babel-jest
- keep lucide-react whitelist in transformIgnorePatterns

## Testing
- `npm test` *(fails: window.matchMedia is not a function, invariant expected app router to be mounted)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd3878c08331ac34ff551ef34a6f