### PR TITLE
fix lint issues in test files

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -2,7 +2,7 @@
 /** @jest-environment jsdom */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '../components/auth/auth-provider';
+import { useAuth } from '../components/auth/auth-provider';
 import { ClientProviders } from '@/components/layout/client-providers';
 
 let mockPathname = '/';
@@ -56,6 +56,10 @@ function DisplayUser() {
 // Mock the ServiceWorker component as it's not relevant to this test
 jest.mock('@/components/service-worker', () => ({
   ServiceWorker: () => null,
+}));
+
+jest.mock('lucide-react', () => ({
+  X: () => null,
 }));
 
 

--- a/src/__tests__/carousel.test.tsx
+++ b/src/__tests__/carousel.test.tsx
@@ -9,10 +9,9 @@ jest.mock('lucide-react', () => ({
 
 const onMock = jest.fn();
 const offMock = jest.fn();
-let emblaApi: any;
 
 function mockUseEmbla() {
-  emblaApi = {
+  const emblaApi = {
     on: onMock,
     off: offMock,
     canScrollPrev: jest.fn().mockReturnValue(false),

--- a/src/__tests__/debt-calendar.test.tsx
+++ b/src/__tests__/debt-calendar.test.tsx
@@ -1,7 +1,7 @@
 
 /** @jest-environment jsdom */
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { webcrypto } from 'crypto';
 import DebtCalendar from '../components/debts/DebtCalendar';
 import { mockDebts } from '@/lib/data';
@@ -26,6 +26,10 @@ jest.mock('../components/ui/select', () => ({
 }));
 jest.mock('../components/ui/textarea', () => ({
   Textarea: (props: React.ComponentProps<'textarea'>) => <textarea {...props} />,
+}));
+
+jest.mock('lucide-react', () => ({
+  X: () => null,
 }));
 
 describe('DebtCalendar', () => {

--- a/src/__tests__/mapWorker.test.ts
+++ b/src/__tests__/mapWorker.test.ts
@@ -31,7 +31,7 @@ describe("mapWorker", () => {
     const worker = createWorker()
     const result = await new Promise(resolve => {
       worker.once("message", resolve)
-      worker.postMessage({ type: "square", payload: [1, "a"] as any })
+      worker.postMessage({ type: "square", payload: [1, "a"] })
     })
     await worker.terminate()
     expect(result).toEqual({
@@ -44,7 +44,7 @@ describe("mapWorker", () => {
     const worker = createWorker()
     const result = await new Promise(resolve => {
       worker.once("message", resolve)
-      worker.postMessage({ type: "boom", payload: [] as any })
+      worker.postMessage({ type: "boom", payload: [] })
     })
     await worker.terminate()
     expect(result).toEqual({

--- a/src/__tests__/transactions-sync.test.ts
+++ b/src/__tests__/transactions-sync.test.ts
@@ -25,7 +25,7 @@ const baseTx = {
 
 describe("/api/transactions/sync persistence", () => {
   beforeEach(() => {
-    ;(saveTransactions as jest.Mock).mockClear()
+    (saveTransactions as jest.Mock).mockClear()
   })
 
   it("saves transactions via saveTransactions", async () => {
@@ -45,7 +45,7 @@ describe("/api/transactions/sync persistence", () => {
   })
 
   it("propagates persistence errors", async () => {
-    ;(saveTransactions as jest.Mock).mockRejectedValueOnce(
+    (saveTransactions as jest.Mock).mockRejectedValueOnce(
       Object.assign(new Error("db failed"), { status: 503 }),
     )
 


### PR DESCRIPTION
## Summary
- remove unused imports and add lucide-react mocks in tests
- drop `any` and extra semicolons to satisfy ESLint rules

## Testing
- `npm run lint`
- `npm test` *(fails: window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd3966248331893e09ea6f0b0b15