### PR TITLE
feat(transactions): cache categories with TTL

### DIFF
--- a/src/__tests__/importTransactions.test.ts
+++ b/src/__tests__/importTransactions.test.ts
@@ -1,4 +1,8 @@
-import { importTransactions } from "../lib/transactions";
+import {
+  importTransactions,
+  __clearCategoryCache,
+  __CATEGORY_CACHE_TTL_MS,
+} from "../lib/transactions";
 import { getDocs } from "firebase/firestore";
 
 jest.mock("firebase/firestore", () => {
@@ -10,10 +14,29 @@ jest.mock("firebase/firestore", () => {
 });
 
 describe("importTransactions", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    __clearCategoryCache();
+    jest.clearAllMocks();
+  });
+
   it("throws a descriptive error when fetching categories fails", async () => {
     (getDocs as jest.Mock).mockRejectedValue(new Error("network failure"));
     await expect(importTransactions([])).rejects.toThrow(
       /Failed to fetch categories: network failure/
     );
+  });
+
+  it("refetches categories after TTL expiry", async () => {
+    jest.useFakeTimers();
+    (getDocs as jest.Mock).mockResolvedValue({ docs: [{ id: "Misc" }] });
+
+    await importTransactions([]);
+    await importTransactions([]);
+    expect(getDocs).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(__CATEGORY_CACHE_TTL_MS + 1);
+    await importTransactions([]);
+    expect(getDocs).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- cache fetched categories for 5 minutes
- expose cache reset helper for tests
- ensure importTransactions refetches categories after TTL expires

## Testing
- `npm test src/__tests__/importTransactions.test.ts`
- `npm test` *(fails: Jest encountered an unexpected token in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd39fda08331b29e2e163ca20197