### PR TITLE
fix: transform lucide-react esm in jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
-    '^.+\\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+    '^.+\\\.(ts|tsx|js|jsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
   },
   transformIgnorePatterns: [
     "/node_modules/(?!lucide-react|d3-.*|recharts|embla-carousel-react)",


### PR DESCRIPTION
## Summary
- allow ts-jest to transform JS/JSX so lucide-react's ESM build is handled during tests

## Testing
- `npm test` *(fails: expected app router to be mounted, window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd447c108331a2e43c672d2542da