### PR TITLE
chore: tidy up test files

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -2,7 +2,7 @@
 /** @jest-environment jsdom */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '../components/auth/auth-provider';
+import { useAuth } from '../components/auth/auth-provider';
 import { ClientProviders } from '@/components/layout/client-providers';
 
 let mockPathname = '/';

--- a/src/__tests__/carousel.test.tsx
+++ b/src/__tests__/carousel.test.tsx
@@ -9,7 +9,15 @@ jest.mock('lucide-react', () => ({
 
 const onMock = jest.fn();
 const offMock = jest.fn();
-let emblaApi: any;
+type EmblaApiMock = {
+  on: jest.Mock;
+  off: jest.Mock;
+  canScrollPrev: jest.Mock;
+  canScrollNext: jest.Mock;
+  scrollPrev: jest.Mock;
+  scrollNext: jest.Mock;
+};
+let emblaApi: EmblaApiMock;
 
 function mockUseEmbla() {
   emblaApi = {

--- a/src/__tests__/debt-calendar.test.tsx
+++ b/src/__tests__/debt-calendar.test.tsx
@@ -1,7 +1,7 @@
 
 /** @jest-environment jsdom */
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { webcrypto } from 'crypto';
 import DebtCalendar from '../components/debts/DebtCalendar';
 import { mockDebts } from '@/lib/data';

--- a/src/__tests__/mapWorker.test.ts
+++ b/src/__tests__/mapWorker.test.ts
@@ -31,7 +31,7 @@ describe("mapWorker", () => {
     const worker = createWorker()
     const result = await new Promise(resolve => {
       worker.once("message", resolve)
-      worker.postMessage({ type: "square", payload: [1, "a"] as any })
+      worker.postMessage({ type: "square", payload: [1, "a"] as unknown as number[] })
     })
     await worker.terminate()
     expect(result).toEqual({
@@ -44,7 +44,7 @@ describe("mapWorker", () => {
     const worker = createWorker()
     const result = await new Promise(resolve => {
       worker.once("message", resolve)
-      worker.postMessage({ type: "boom", payload: [] as any })
+      worker.postMessage({ type: "boom", payload: [] as unknown as number[] })
     })
     await worker.terminate()
     expect(result).toEqual({

--- a/src/__tests__/transactions-sync.test.ts
+++ b/src/__tests__/transactions-sync.test.ts
@@ -25,7 +25,7 @@ const baseTx = {
 
 describe("/api/transactions/sync persistence", () => {
   beforeEach(() => {
-    ;(saveTransactions as jest.Mock).mockClear()
+    (saveTransactions as jest.Mock).mockClear()
   })
 
   it("saves transactions via saveTransactions", async () => {
@@ -45,7 +45,7 @@ describe("/api/transactions/sync persistence", () => {
   })
 
   it("propagates persistence errors", async () => {
-    ;(saveTransactions as jest.Mock).mockRejectedValueOnce(
+    (saveTransactions as jest.Mock).mockRejectedValueOnce(
       Object.assign(new Error("db failed"), { status: 503 }),
     )
 


### PR DESCRIPTION
## Summary
- drop unused AuthProvider import
- type carousel mock instead of using `any`
- remove unused test imports and semicolons

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError from lucide-react ESM module in auth-provider and debt-calendar tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd457f48833191ff9f27fc4f7e78