### PR TITLE
Return count from saveTransactions

### DIFF
--- a/src/__tests__/saveTransactions.test.ts
+++ b/src/__tests__/saveTransactions.test.ts
@@ -55,7 +55,8 @@ describe("saveTransactions", () => {
   });
 
   it("adds all transactions in a single batch and commits once when within limit", async () => {
-    await saveTransactions(transactions);
+    const count = await saveTransactions(transactions);
+    expect(count).toBe(transactions.length);
     expect(mockSet).toHaveBeenCalledTimes(transactions.length);
     expect(mockWriteBatch).toHaveBeenCalledTimes(1);
     expect(mockCommit).toHaveBeenCalledTimes(1);
@@ -75,7 +76,8 @@ describe("saveTransactions", () => {
       isRecurring: false,
     }));
 
-    await saveTransactions(manyTransactions);
+    const count = await saveTransactions(manyTransactions);
+    expect(count).toBe(manyTransactions.length);
     expect(mockSet).toHaveBeenCalledTimes(manyTransactions.length);
     // Should create and commit two batches for 501 items
     expect(mockWriteBatch).toHaveBeenCalledTimes(2);

--- a/src/__tests__/transactions-sync.test.ts
+++ b/src/__tests__/transactions-sync.test.ts
@@ -6,7 +6,7 @@ jest.mock("@/lib/transactions", () => {
   const actual = jest.requireActual("@/lib/transactions")
   return {
     ...actual,
-    saveTransactions: jest.fn().mockResolvedValue(undefined),
+    saveTransactions: jest.fn().mockResolvedValue(1),
   }
 })
 

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
-import { TransactionPayloadSchema } from "@/lib/transactions"
+import { TransactionPayloadSchema, saveTransactions } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
 
 /**
@@ -52,9 +52,10 @@ export async function POST(req: Request) {
   const { provider, transactions } = parsed.data
 
   try {
+    const imported = await saveTransactions(transactions)
     return NextResponse.json({
       provider,
-      imported: transactions.length,
+      imported,
     })
   } catch {
     return NextResponse.json(

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -136,9 +136,13 @@ export function validateTransactions(
  * @throws {Error} If the Firestore batch commit fails.
  * @remarks Writes to Firestore and performs network I/O.
  */
-export async function saveTransactions(transactions: Transaction[]): Promise<void> {
+export async function saveTransactions(
+  transactions: Transaction[],
+): Promise<number> {
   const colRef = collection(db, "transactions");
   const chunks = chunkTransactions(transactions);
+  let persisted = 0;
+
   for (const chunk of chunks) {
     const batch = writeBatch(db);
     chunk.forEach((tx) => {
@@ -147,6 +151,7 @@ export async function saveTransactions(transactions: Transaction[]): Promise<voi
 
     try {
       await batch.commit();
+      persisted += chunk.length;
     } catch (err) {
       throw new Error(
         `Failed to save transactions batch: ${
@@ -155,6 +160,8 @@ export async function saveTransactions(transactions: Transaction[]): Promise<voi
       );
     }
   }
+
+  return persisted;
 }
 
 /**


### PR DESCRIPTION
## Summary
- make saveTransactions report number of persisted transactions
- use saveTransactions in bank import route and return saved count
- update tests for new saveTransactions return value

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd4635e083318822f89f70568c8f