### PR TITLE
docs: document transaction persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ memory for one hour to avoid unnecessary network requests. Use
 `convertCurrency(amount, from, to)` uses these rates to convert between
 currencies.
 
+## Transaction syncing API
+
+`POST /api/transactions/sync` accepts an array of transactions that have
+already been fetched from any provider. The endpoint verifies the Firebase
+token, validates each transaction, persists them via `saveTransactions`, and
+responds with the number of transactions received.
+
 ## Upgrading Next.js
 
 This project pins Next.js to a specific version. When upgrading, follow the steps in [docs/next-upgrade.md](docs/next-upgrade.md) to review releases, update the version, and verify the changes.

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -8,9 +8,8 @@ import { logger } from "@/lib/logger"
 /**
  * Generic transaction syncing endpoint.
  * Unlike `/api/bank/import`, this expects transactions that have already
- * been fetched from any source. The current implementation only validates
- * and reports how many transactions were received without persisting them.
- * TODO: Implement database persistence for received transactions.
+ * been fetched from any source. The endpoint validates each transaction,
+ * persists them to the database, and reports how many were received.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),


### PR DESCRIPTION
## Summary
- clarify that `/api/transactions/sync` validates and persists incoming transactions
- document the transaction syncing endpoint in the README

## Testing
- ⚠️ `npm test` (fails: Cannot use import statement outside a module in lucide-react)
- ✅ `npx jest src/__tests__/transactions-sync.test.ts`
- ⚠️ `npm run lint` (fails: lint errors in several test files)
- ✅ `npx eslint src/app/api/transactions/sync/route.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2ddc5af6c8331996c3594e5399ff9