### PR TITLE
fix jest transform for lucide-react

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
-    '^.+\\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+    '^.+\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
   },
   transformIgnorePatterns: [
     "/node_modules/(?!lucide-react|d3-.*|recharts|embla-carousel-react)",


### PR DESCRIPTION
## Summary
- transpile `.js` and `.tsx` files in Jest so lucide-react and other packages are processed

## Testing
- `npm test src/__tests__/auth-provider.test.tsx` *(fails: window.matchMedia is not a function)*
- `npm test src/__tests__/debt-calendar.test.tsx` *(fails: invariant expected app router to be mounted)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd26fbdc8331acf1013d01dc20ac