### PR TITLE
Persist imported bank transactions

### DIFF
--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
-import { TransactionPayloadSchema } from "@/lib/transactions"
+import { TransactionPayloadSchema, saveTransactions } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
+import { logger } from "@/lib/logger"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -52,14 +53,18 @@ export async function POST(req: Request) {
   const { provider, transactions } = parsed.data
 
   try {
+    await saveTransactions(transactions)
     return NextResponse.json({
       provider,
       imported: transactions.length,
     })
-  } catch {
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    )
+  } catch (err) {
+    logger.error("Failed to persist transactions", err)
+    const message = err instanceof Error ? err.message : "Internal server error"
+    const status =
+      typeof err === "object" && err && "status" in err
+        ? (err as { status?: number }).status || 500
+        : 500
+    return NextResponse.json({ error: message }, { status })
   }
 }


### PR DESCRIPTION
## Summary
- persist bank imports by saving transactions before responding
- add error handling to report persistence failures

## Testing
- `npm test` (fails: SyntaxError: Cannot use import statement outside a module)
- `npm run lint` (fails: ESLint found unused variables and other issues)


------
https://chatgpt.com/codex/tasks/task_e_68b2df11191c833181e23a6dfd765105