### PR TITLE
Reject oversized receipt images

### DIFF
--- a/src/ai/flows/__tests__/analyze-receipt.test.ts
+++ b/src/ai/flows/__tests__/analyze-receipt.test.ts
@@ -1,0 +1,24 @@
+jest.mock('@/ai/genkit', () => ({
+  ai: {
+    definePrompt: jest.fn(),
+    defineFlow: jest.fn(),
+  },
+}));
+
+import { AnalyzeReceiptInputSchema } from '@/ai/flows/analyze-receipt';
+
+describe('AnalyzeReceiptInputSchema', () => {
+  it('rejects data URIs larger than 1MB', () => {
+    const oversizedBuffer = Buffer.alloc(1024 * 1024 + 1);
+    const dataUri = `data:image/png;base64,${oversizedBuffer.toString('base64')}`;
+    const result = AnalyzeReceiptInputSchema.safeParse({ receiptImage: dataUri });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts data URIs up to 1MB', () => {
+    const validBuffer = Buffer.alloc(1024 * 1024);
+    const dataUri = `data:image/png;base64,${validBuffer.toString('base64')}`;
+    const result = AnalyzeReceiptInputSchema.safeParse({ receiptImage: dataUri });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -13,10 +13,21 @@ import {ai} from '@/ai/genkit';
 import {DATA_URI_REGEX} from '@/lib/data-uri';
 import {z} from 'genkit';
 
+const MAX_IMAGE_SIZE_BYTES = 1024 * 1024; // 1MB
+
 export const AnalyzeReceiptInputSchema = z.object({
   receiptImage: z
     .string()
     .regex(DATA_URI_REGEX)
+    .refine(dataUri => {
+      const base64Data = dataUri.split(',')[1];
+      try {
+        const buffer = Buffer.from(base64Data, 'base64');
+        return buffer.byteLength <= MAX_IMAGE_SIZE_BYTES;
+      } catch {
+        return false;
+      }
+    }, {message: 'Receipt image exceeds maximum size of 1MB'})
     .describe(
       "An image of a receipt, as a data URI that must include a MIME type and use Base64 encoding. Expected format: 'data:<mimetype>;base64,<encoded_data>'."
     ),


### PR DESCRIPTION
## Summary
- enforce 1MB decoded size limit for receipt data URIs
- add tests covering oversized and valid receipt images

## Testing
- `npm test` *(fails: Cannot use import statement outside a module in lucide-react for auth-provider.test.tsx and debt-calendar.test.tsx)*
- `npm test src/ai/flows/__tests__/analyze-receipt.test.ts`
- `npm run lint` *(fails: eslint errors in existing test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b2df15a5988331b365ab452f7865f3