### PR TITLE
feat: add housekeeping script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ Values outside these patterns are ignored to prevent unsafe CSS injection.
 
 ## Housekeeping service
 
-The housekeeping service removes outdated files from Cloud Storage to manage costs and data retention.
+The housekeeping service archives old transactions, removes settled debts, and
+creates a backup snapshot of current data.
 
 ### Running locally
 1. Install dependencies with `npm install`.
 2. Provide the environment variables listed below.
 3. Start the service with `npm run housekeeping` or `node scripts/housekeeping.ts`.
+   - Pass `--cutoff=YYYY-MM-DD` to override the default archive cutoff date
+     derived from `RETENTION_DAYS` (30 days by default).
 
 ### Scheduled deployment
 - Deploy the service with `firebase deploy --only run.housekeeping`.
@@ -51,7 +54,7 @@ Create a `.env.local` file by copying `.env.example` and populate it with the re
 |----------|-------------|
 | `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase project containing the storage bucket. |
 | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Default Cloud Storage bucket for uploads. |
-| `RETENTION_DAYS` | Number of days to retain files before deletion (default: 30). |
+| `RETENTION_DAYS` | Days to retain transactions before archiving (default: 30). |
 | `CRON_SECRET` | Shared secret expected in the `X-CRON-SECRET` header for housekeeping runs. |
 | `DEFAULT_TZ` | Optional IANA timezone used when synchronizing time with the network. Defaults to the system timezone. |
 | `ALLOWED_ORIGINS` | Comma-separated list of allowed request origins for CORS. Regex patterns may be wrapped in `/`. |

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "pree2e": "node scripts/check-playwright-deps.js",
     "e2e": "npx playwright test",
-    "prepare": "husky"
+    "prepare": "husky",
+    "housekeeping": "node scripts/housekeeping.ts"
   },
   "dependencies": {
     "@genkit-ai/next": "^1.14.1",

--- a/scripts/housekeeping.ts
+++ b/scripts/housekeeping.ts
@@ -1,0 +1,12 @@
+import { runHousekeeping } from '../src/lib/housekeeping';
+
+async function main() {
+  const arg = process.argv.find((a) => a.startsWith('--cutoff='));
+  const cutoffDate = arg ? arg.split('=')[1] : undefined;
+  await runHousekeeping({ cutoffDate });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- expand housekeeping service to archive old transactions, cleanup debts and backup data
- add CLI script and npm command to run housekeeping
- document housekeeping usage and options

## Testing
- `npm test` *(fails: SyntaxError in lucide-react module)*
- `npm run lint` *(fails: ESLint errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b366ddeb50833194f341c909844a8b