### PR TITLE
feat: enforce allowed origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,26 @@ Create a `.env.local` file by copying `.env.example` and populate it with the re
 | `RETENTION_DAYS` | Number of days to retain files before deletion (default: 30). |
 | `CRON_SECRET` | Shared secret expected in the `X-CRON-SECRET` header for housekeeping runs. |
 | `DEFAULT_TZ` | Optional IANA timezone used when synchronizing time with the network. Defaults to the system timezone. |
-| `ALLOWED_ORIGINS` | Comma-separated list of allowed request origins for CORS. Regex patterns may be wrapped in `/`. |
+| `ALLOWED_ORIGINS` | Comma-separated list of allowed request origins for CORS checks. Regex patterns may be wrapped in `/`. Requests from other origins receive HTTP 403. |
 | `LOG_LEVEL` | Minimum log level to output (`info`, `warn`, or `error`). Defaults to `info`. |
 
 Adjust the retention threshold by setting `RETENTION_DAYS` before running the service or updating the scheduled job configuration.
+
+### Configuring allowed origins
+
+Use the `ALLOWED_ORIGINS` variable to restrict which browser origins may call the API. The value is a comma-separated list of exact origins or regular expressions wrapped in `/`.
+
+Examples:
+
+```bash
+# Exact matches for two sites
+ALLOWED_ORIGINS=https://example.com,https://www.example.org
+
+# Allow any subdomain of example.com and one specific partner site
+ALLOWED_ORIGINS=/\\.example\\.com$/,https://partner.com
+```
+
+Requests with an `Origin` header that does not match any entry are rejected with HTTP 403.
 
 ## Internet time helper
 

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
 import { TransactionPayloadSchema } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
+import { isOriginAllowed } from "@/lib/allowed-origins"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -17,6 +18,9 @@ const bodySchema = z.object({
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
 export async function POST(req: Request) {
+  if (!isOriginAllowed(req.headers.get("origin"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
   try {
     await verifyFirebaseToken(req)
   } catch (err) {

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -4,6 +4,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
 import { TransactionPayloadSchema, saveTransactions } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
 import { logger } from "@/lib/logger"
+import { isOriginAllowed } from "@/lib/allowed-origins"
 
 /**
  * Generic transaction syncing endpoint.
@@ -19,6 +20,9 @@ const bodySchema = z.object({
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
 export async function POST(req: Request) {
+  if (!isOriginAllowed(req.headers.get("origin"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
   try {
     await verifyFirebaseToken(req)
   } catch (err) {

--- a/src/lib/allowed-origins.ts
+++ b/src/lib/allowed-origins.ts
@@ -29,3 +29,18 @@ export function getAllowedOrigins(env: string | undefined = process.env.ALLOWED_
 }
 
 export const allowedOrigins: AllowedOrigin[] = getAllowedOrigins();
+
+export function isOriginAllowed(
+  origin: string | null,
+  allowed: AllowedOrigin[] = allowedOrigins,
+): boolean {
+  if (!origin) return true;
+  try {
+    const normalized = new URL(origin).origin;
+    return allowed.some((item) =>
+      typeof item === "string" ? item === normalized : item.test(normalized),
+    );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- export `isOriginAllowed` helper
- gate API routes on allowed origins
- document `ALLOWED_ORIGINS` usage

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run lint` *(fails: no-unused-vars, no-explicit-any, no-extra-semi)*

------
https://chatgpt.com/codex/tasks/task_e_68b366df2bbc8331a8cbaf43f576a02c