### PR TITLE
docs: clarify transaction sync persistence

### DIFF
--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -7,10 +7,13 @@ import { logger } from "@/lib/logger"
 
 /**
  * Generic transaction syncing endpoint.
+ *
  * Unlike `/api/bank/import`, this expects transactions that have already
- * been fetched from any source. The current implementation only validates
- * and reports how many transactions were received without persisting them.
- * TODO: Implement database persistence for received transactions.
+ * been fetched from any source. Transactions are validated and persisted,
+ * and the response reports how many records were stored.
+ *
+ * Future enhancements could include deduplication and more detailed
+ * responses about newly created versus updated records.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),


### PR DESCRIPTION
## Summary
- update transaction sync route docs to remove stale note about persistence and outline potential future improvements

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in lucide-react)*
- `npm run lint` *(fails: eslint reported unused variables and no-explicit-any errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b366e1d5e48331bd1f4ee6bd0c1be6