### PR TITLE
Add Firestore security rules and CI deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: actions/checkout@v4
       - run: npm ci
       - run: npm run build
+      - run: npm install -g firebase-tools
+      - run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_NURSEFINAI }}' > $HOME/serviceAccount.json
+      - run: firebase deploy --only firestore:rules --project nursefinai --non-interactive
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: $HOME/serviceAccount.json
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules restricting users to their own documents
- reference Firestore rules in firebase.json
- deploy Firestore rules in CI via firebase-tools

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(fails: ESLint errors in tests)*
- `firebase --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b366e25cac8331a995e9e1e1a08c89