### PR TITLE
docs: clarify transaction persistence

### DIFF
--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -8,9 +8,8 @@ import { logger } from "@/lib/logger"
 /**
  * Generic transaction syncing endpoint.
  * Unlike `/api/bank/import`, this expects transactions that have already
- * been fetched from any source. The current implementation only validates
- * and reports how many transactions were received without persisting them.
- * TODO: Implement database persistence for received transactions.
+ * been fetched from any source. It validates each transaction, persists
+ * them via `saveTransactions`, and returns how many were saved.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),


### PR DESCRIPTION
## Summary
- update sync route comment to mention transactions are persisted via `saveTransactions`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in lucide-react)*
- `npm run lint` *(fails: lint errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b366e46ff0833181a101913d842c1c