### PR TITLE
feat: enforce cron secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Create a `.env.local` file by copying `.env.example` and populate it with the re
 | `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase project containing the storage bucket. |
 | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Default Cloud Storage bucket for uploads. |
 | `RETENTION_DAYS` | Number of days to retain files before deletion (default: 30). |
-| `CRON_SECRET` | Shared secret expected in the `X-CRON-SECRET` header for housekeeping runs. |
+| `CRON_SECRET` | **Required.** Shared secret expected in the `X-CRON-SECRET` header for housekeeping runs. The service logs a fatal error at startup if unset. |
 | `DEFAULT_TZ` | Optional IANA timezone used when synchronizing time with the network. Defaults to the system timezone. |
 | `ALLOWED_ORIGINS` | Comma-separated list of allowed request origins for CORS. Regex patterns may be wrapped in `/`. |
 | `LOG_LEVEL` | Minimum log level to output (`info`, `warn`, or `error`). Defaults to `info`. |

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -1,7 +1,6 @@
 /**
  * @jest-environment node
  */
-import { GET, resetRateLimit } from "@/app/api/cron/housekeeping/route";
 import { runHousekeeping } from "@/lib/housekeeping";
 import { getCurrentTime } from "@/lib/internet-time";
 
@@ -16,14 +15,22 @@ jest.mock("@/lib/internet-time", () => ({
 jest.mock("@/lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
 import { initFirebase } from "@/lib/firebase";
 
-beforeAll(() => {
+const secret = "test-secret";
+let GET: typeof import("@/app/api/cron/housekeeping/route").GET;
+let resetRateLimit: typeof import("@/app/api/cron/housekeeping/route").resetRateLimit;
+
+beforeAll(async () => {
   process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
   process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = "test";
   process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = "test";
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
+  process.env.CRON_SECRET = secret;
   initFirebase();
+  const mod = await import("@/app/api/cron/housekeeping/route");
+  GET = mod.GET;
+  resetRateLimit = mod.resetRateLimit;
 });
 
 jest.mock("firebase/firestore", () => {
@@ -74,8 +81,6 @@ jest.mock("firebase/firestore", () => {
 });
 
 describe("/api/cron/housekeeping", () => {
-  const secret = "test-secret";
-
   beforeEach(async () => {
     process.env.CRON_SECRET = secret;
     await resetRateLimit();

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -7,6 +7,11 @@ import { logger } from "@/lib/logger";
 
 const HEADER_NAME = "x-cron-secret";
 const WINDOW_MS = 60_000; // 1 minute
+if (!process.env.CRON_SECRET) {
+  const message = "CRON_SECRET environment variable is required";
+  logger.error(message);
+  throw new Error(message);
+}
 initFirebase();
 const STATE_DOC = doc(db, "cron", "housekeeping");
 


### PR DESCRIPTION
## Summary
- ensure housekeeping route fails fast if `CRON_SECRET` env var is missing
- document `CRON_SECRET` requirement in README
- align unit test with new startup check

## Testing
- `npm run lint` (fails: auth-provider.test.tsx unused variable, carousel.test.tsx unexpected any, debt-calendar.test.tsx unused var, mapWorker.test.ts unexpected any, transactions-sync.test.ts unnecessary semicolons)
- `npm test` (fails: Jest can't parse `lucide-react` ESM in auth-provider.test.tsx and debt-calendar.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68b366e6ef208331b7c1ef7583848629