### PR TITLE
Add housekeeping script and npm entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "nextn",
   "version": "0.1.0",
@@ -12,7 +11,8 @@
     "test": "jest",
     "pree2e": "node scripts/check-playwright-deps.js",
     "e2e": "npx playwright test",
-    "prepare": "husky"
+    "prepare": "husky",
+    "housekeeping": "node scripts/housekeeping.ts"
   },
   "dependencies": {
     "@genkit-ai/next": "^1.14.1",

--- a/scripts/housekeeping.ts
+++ b/scripts/housekeeping.ts
@@ -1,0 +1,18 @@
+import { archiveOldTransactions, cleanupDebts, backupData } from "../src/services/housekeeping";
+
+async function main() {
+  const cutoff = process.env.ARCHIVE_CUTOFF_DATE;
+  if (cutoff) {
+    await archiveOldTransactions(cutoff);
+  } else {
+    console.warn("ARCHIVE_CUTOFF_DATE not set, skipping transaction archiving");
+  }
+  await cleanupDebts();
+  await backupData();
+  console.info("Housekeeping complete");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/housekeeping.ts` to invoke housekeeping service functions
- expose `npm run housekeeping` to run the script

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(fails: several @typescript-eslint and no-extra-semi errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b366e8504c8331a90eb58924188122