### PR TITLE
feat: sanitize PII before model access

### DIFF
--- a/src/ai/flows/analyze-receipt.ts
+++ b/src/ai/flows/analyze-receipt.ts
@@ -9,7 +9,7 @@
  * - AnalyzeReceiptOutput - The return type for the analyzeReceipt function.
  */
 
-import {ai} from '@/ai/genkit';
+import { ai, piiMiddleware } from '@/ai/genkit';
 import {DATA_URI_REGEX} from '@/lib/data-uri';
 import {z} from 'genkit';
 
@@ -38,6 +38,7 @@ const prompt = ai.definePrompt({
   name: 'analyzeReceiptPrompt',
   input: {schema: AnalyzeReceiptInputSchema},
   output: {schema: AnalyzeReceiptOutputSchema},
+  use: [piiMiddleware],
   prompt: `You are an expert receipt scanner. Analyze the provided receipt image and extract the vendor name (for the description), the total amount, and suggest a relevant category for a nursing professional (e.g., Food, Uniforms, Supplies, Transport, Certifications, Other). The transaction type is always 'Expense'.
 
 Receipt Image: {{media url=receiptImage}}`,

--- a/src/ai/flows/analyze-spending-habits.ts
+++ b/src/ai/flows/analyze-spending-habits.ts
@@ -11,7 +11,7 @@
  * - AnalyzeSpendingHabitsOutput - The return type for the analyzeSpendingHabits function.
  */
 
-import {ai} from '@/ai/genkit';
+import { ai, piiMiddleware } from '@/ai/genkit';
 import {DATA_URI_REGEX} from '@/lib/data-uri';
 import {z} from 'genkit';
 
@@ -57,6 +57,7 @@ const prompt = ai.definePrompt({
   name: 'analyzeSpendingHabitsPrompt',
   input: {schema: AnalyzeSpendingHabitsInputSchema},
   output: {schema: AnalyzeSpendingHabitsOutputSchema},
+  use: [piiMiddleware],
   prompt: `You are a personal finance advisor for nursing professionals. Analyze the user's spending habits based on the provided financial documents, their personal description, and their stated financial goals.
 
 Crucially, you must consider the 'importance' ranking of each goal. Recommendations should prioritize achieving the goals the user has marked as most important.

--- a/src/ai/flows/calculate-cashflow.ts
+++ b/src/ai/flows/calculate-cashflow.ts
@@ -9,7 +9,7 @@
  * - CalculateCashflowOutput - The return type for the calculateCashflow function.
  */
 
-import {ai} from '@/ai/genkit';
+import { ai, piiMiddleware } from '@/ai/genkit';
 import {z} from 'genkit';
 
 const CalculateCashflowInputSchema = z.object({
@@ -51,6 +51,7 @@ const prompt = ai.definePrompt({
   name: 'calculateCashflowPrompt',
   input: {schema: CalculateCashflowInputSchema},
   output: {schema: CalculateCashflowOutputSchema},
+  use: [piiMiddleware],
   prompt: `You are a financial analyst. Based on the user's provided income, taxes, and deductions, calculate their gross and net monthly cashflow.
 
 Annual Income: {{{annualIncome}}}

--- a/src/ai/flows/spendingForecast.ts
+++ b/src/ai/flows/spendingForecast.ts
@@ -9,7 +9,7 @@
  * - SpendingForecastOutput - The return type for the predictSpending function.
  */
 
-import {ai} from '@/ai/genkit';
+import { ai, piiMiddleware } from '@/ai/genkit';
 import {z} from 'genkit';
 
 const TransactionSchema = z.object({
@@ -49,6 +49,7 @@ const prompt = ai.definePrompt({
   name: 'spendingForecastPrompt',
   input: {schema: SpendingForecastInputSchema},
   output: {schema: SpendingForecastOutputSchema},
+  use: [piiMiddleware],
   prompt: `You are a financial analyst. Review the user's past transactions and predict the total spending for the next three months.
 
 Transactions:

--- a/src/ai/flows/suggest-category.ts
+++ b/src/ai/flows/suggest-category.ts
@@ -1,7 +1,7 @@
 // This file uses server-side code.
 'use server';
 
-import { ai } from '@/ai/genkit';
+import { ai, piiMiddleware } from '@/ai/genkit';
 import { z } from 'genkit';
 
 import { classifyCategory } from '../train/category-model';
@@ -20,6 +20,7 @@ const prompt = ai.definePrompt({
   name: 'suggestCategoryPrompt',
   input: { schema: SuggestCategoryInputSchema },
   output: { schema: SuggestCategoryOutputSchema },
+  use: [piiMiddleware],
   prompt: `You are a financial assistant. Suggest a spending category for the following transaction description suitable for personal budgeting (e.g., Food, Transport, Utilities, Salary, Other).
 
 Description: {{description}}`,

--- a/src/ai/flows/suggest-debt-strategy.ts
+++ b/src/ai/flows/suggest-debt-strategy.ts
@@ -9,7 +9,7 @@
  * - SuggestDebtStrategyOutput - The return type for the suggestDebtStrategy function.
  */
 
-import {ai} from '@/ai/genkit';
+import { ai, piiMiddleware } from '@/ai/genkit';
 import {z} from 'genkit';
 import { RecurrenceValues } from '@/lib/types';
 
@@ -48,6 +48,7 @@ const prompt = ai.definePrompt({
   name: 'suggestDebtStrategyPrompt',
   input: {schema: SuggestDebtStrategyInputSchema},
   output: {schema: SuggestDebtStrategyOutputSchema},
+  use: [piiMiddleware],
   prompt: `You are an expert financial advisor specializing in debt management for healthcare professionals like nurses. Analyze the following list of debts and recommend the best payoff strategy.
 
 Your primary goal is to help the user save the most money on interest, so you should lean towards the 'avalanche' method (highest interest rate first) unless there is a very small debt that could be paid off quickly for a psychological win (the 'snowball' method).

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,5 +1,40 @@
-import {genkit} from 'genkit';
-import {googleAI} from '@genkit-ai/googleai';
+import { genkit, type ModelMiddleware } from 'genkit';
+import { googleAI } from '@genkit-ai/googleai';
+import crypto from 'crypto';
+
+/**
+ * Regex patterns for detecting common forms of PII.
+ */
+const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const PHONE_REGEX = /\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}\b/g;
+// Rough pattern for long sequences of digits such as account numbers or cards.
+const ACCOUNT_REGEX = /\b\d{12,19}\b/g;
+
+function hash(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * Middleware that hashes sensitive information in request messages
+ * before they are sent to the model.
+ */
+export const piiMiddleware: ModelMiddleware = async (req, next) => {
+  const messages = req.messages.map((message) => ({
+    ...message,
+    content: message.content.map((part) => {
+      if (part.text) {
+        const text = part.text
+          .replace(EMAIL_REGEX, (m) => hash(m))
+          .replace(PHONE_REGEX, (m) => hash(m))
+          .replace(ACCOUNT_REGEX, (m) => hash(m));
+        return { ...part, text };
+      }
+      return part;
+    }),
+  }));
+
+  return next({ ...req, messages });
+};
 
 const model = process.env.GENKIT_MODEL || 'googleai/gemini-2.5-flash';
 
@@ -7,3 +42,5 @@ export const ai = genkit({
   plugins: [googleAI()],
   model,
 });
+
+export { piiMiddleware };


### PR DESCRIPTION
## Summary
- add PII-sanitizing middleware that hashes emails, phone numbers, and account numbers before model requests
- enforce middleware across all AI flow prompts

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module in lucide-react)*
- `npm run lint` *(fails: lint errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b366e9c3dc8331895572d868e5a868