### PR TITLE
feat: validate receipt image size

### DIFF
--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -120,3 +120,19 @@ describe('calculateCostOfLiving validation', () => {
   });
 });
 
+describe('analyzeReceipt validation', () => {
+  it('rejects receipt images larger than 1MB', async () => {
+    jest.resetModules();
+    setupSuccessMocks({ description: '', amount: 0, category: '' });
+    const { analyzeReceipt } = await import('@/ai/flows/analyze-receipt');
+
+    // Create a data URI with size > 1MB after decoding
+    const largeBase64 = Buffer.alloc(1024 * 1024 + 1).toString('base64');
+    const largeDataUri = `data:image/png;base64,${largeBase64}`;
+
+    await expect(
+      analyzeReceipt({ receiptImage: largeDataUri })
+    ).rejects.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary
- restrict `analyzeReceipt` flow to accept data URIs no larger than 1MB
- add test verifying oversized receipt images are rejected

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any, no-extra-semi)*

------
https://chatgpt.com/codex/tasks/task_e_68b366ea6a68833180376e6d1ec006ef