### PR TITLE
feat: add CORS middleware

### DIFF
--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
 import { TransactionPayloadSchema } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
+import { handleCors, withCors } from "@/lib/cors"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -17,11 +18,17 @@ const bodySchema = z.object({
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
 export async function POST(req: Request) {
+  const cors = handleCors(req)
+  if (cors) return cors
+
   try {
     await verifyFirebaseToken(req)
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unauthorized"
-    return NextResponse.json({ error: message }, { status: 401 })
+    return withCors(
+      req,
+      NextResponse.json({ error: message }, { status: 401 }),
+    )
   }
 
   let text: string
@@ -29,7 +36,10 @@ export async function POST(req: Request) {
     text = await readBodyWithLimit(req, MAX_BODY_SIZE)
   } catch (err) {
     if (err instanceof PayloadTooLargeError) {
-      return NextResponse.json({ error: err.message }, { status: err.status })
+      return withCors(
+        req,
+        NextResponse.json({ error: err.message }, { status: err.status }),
+      )
     }
     throw err
   }
@@ -38,28 +48,40 @@ export async function POST(req: Request) {
   try {
     json = JSON.parse(text)
   } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+    return withCors(
+      req,
+      NextResponse.json({ error: "Invalid JSON" }, { status: 400 }),
+    )
   }
 
   const parsed = bodySchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Invalid payload", details: parsed.error.flatten() },
-      { status: 400 },
+    return withCors(
+      req,
+      NextResponse.json(
+        { error: "Invalid payload", details: parsed.error.flatten() },
+        { status: 400 },
+      ),
     )
   }
 
   const { provider, transactions } = parsed.data
 
   try {
-    return NextResponse.json({
-      provider,
-      imported: transactions.length,
-    })
+    return withCors(
+      req,
+      NextResponse.json({
+        provider,
+        imported: transactions.length,
+      }),
+    )
   } catch {
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
+    return withCors(
+      req,
+      NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      ),
     )
   }
 }

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -4,6 +4,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
 import { TransactionPayloadSchema, saveTransactions } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
 import { logger } from "@/lib/logger"
+import { handleCors, withCors } from "@/lib/cors"
 
 /**
  * Generic transaction syncing endpoint.
@@ -19,11 +20,17 @@ const bodySchema = z.object({
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
 export async function POST(req: Request) {
+  const cors = handleCors(req)
+  if (cors) return cors
+
   try {
     await verifyFirebaseToken(req)
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unauthorized"
-    return NextResponse.json({ error: message }, { status: 401 })
+    return withCors(
+      req,
+      NextResponse.json({ error: message }, { status: 401 }),
+    )
   }
 
   let text: string
@@ -31,7 +38,10 @@ export async function POST(req: Request) {
     text = await readBodyWithLimit(req, MAX_BODY_SIZE)
   } catch (err) {
     if (err instanceof PayloadTooLargeError) {
-      return NextResponse.json({ error: err.message }, { status: err.status })
+      return withCors(
+        req,
+        NextResponse.json({ error: err.message }, { status: err.status }),
+      )
     }
     throw err
   }
@@ -40,14 +50,20 @@ export async function POST(req: Request) {
   try {
     json = JSON.parse(text)
   } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+    return withCors(
+      req,
+      NextResponse.json({ error: "Invalid JSON" }, { status: 400 }),
+    )
   }
 
   const parsed = bodySchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Invalid payload", details: parsed.error.flatten() },
-      { status: 400 },
+    return withCors(
+      req,
+      NextResponse.json(
+        { error: "Invalid payload", details: parsed.error.flatten() },
+        { status: 400 },
+      ),
     )
   }
 
@@ -55,7 +71,10 @@ export async function POST(req: Request) {
 
   try {
     await saveTransactions(transactions)
-    return NextResponse.json({ received: transactions.length })
+    return withCors(
+      req,
+      NextResponse.json({ received: transactions.length }),
+    )
   } catch (err) {
     logger.error("Failed to persist transactions", err)
     const message =
@@ -64,6 +83,9 @@ export async function POST(req: Request) {
       typeof err === "object" && err && "status" in err
         ? (err as { status?: number }).status || 500
         : 500
-    return NextResponse.json({ error: message }, { status })
+    return withCors(
+      req,
+      NextResponse.json({ error: message }, { status }),
+    )
   }
 }

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { AllowedOrigin, allowedOrigins } from "./allowed-origins";
+
+function isAllowed(origin: string, allowed: AllowedOrigin[]): boolean {
+  return allowed.some((o) =>
+    typeof o === "string" ? o === origin : o.test(origin),
+  );
+}
+
+export function handleCors(
+  req: Request,
+  allowed: AllowedOrigin[] = allowedOrigins,
+): Response | undefined {
+  const origin = req.headers.get("Origin");
+
+  if (req.method === "OPTIONS") {
+    if (!origin || !isAllowed(origin, allowed)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    const headers = new Headers({
+      "Access-Control-Allow-Origin": origin,
+      "Access-Control-Allow-Methods":
+        req.headers.get("Access-Control-Request-Method") || "",
+      "Access-Control-Allow-Headers":
+        req.headers.get("Access-Control-Request-Headers") || "",
+      Vary: "Origin",
+    });
+    return new Response(null, { status: 204, headers });
+  }
+
+  if (origin && !isAllowed(origin, allowed)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return undefined;
+}
+
+export function withCors(
+  req: Request,
+  res: Response,
+  allowed: AllowedOrigin[] = allowedOrigins,
+): Response {
+  const origin = req.headers.get("Origin");
+  if (origin && isAllowed(origin, allowed)) {
+    res.headers.set("Access-Control-Allow-Origin", origin);
+    const vary = res.headers.get("Vary");
+    if (!vary) {
+      res.headers.set("Vary", "Origin");
+    } else if (!vary.split(",").map((v) => v.trim()).includes("Origin")) {
+      res.headers.set("Vary", `${vary}, Origin`);
+    }
+  }
+  return res;
+}
+
+export { isAllowed as isOriginAllowed };
+


### PR DESCRIPTION
## Summary
- implement CORS helpers to validate Origin headers against allowed list
- apply middleware to API routes and test CORS behaviour

## Testing
- `npm test src/__tests__/allowed-origins.test.ts src/__tests__/api-validation.test.ts src/__tests__/transactions-sync.test.ts src/__tests__/housekeeping-route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b366edabac8331b8601b2b3ad5feef