### PR TITLE
feat: add prompt redaction middleware

### DIFF
--- a/src/__tests__/genkit-redact.test.ts
+++ b/src/__tests__/genkit-redact.test.ts
@@ -1,0 +1,25 @@
+jest.mock('genkit', () => ({ genkit: jest.fn(() => ({})) }));
+jest.mock(
+  '@genkit-ai/googleai',
+  () => {
+    const model = jest.fn((_name: string, opts: any) => ({ name: _name, ...opts }));
+    const plugin = jest.fn();
+    return { googleAI: Object.assign(plugin, { model }) };
+  },
+  { virtual: true }
+);
+
+import { genkit } from 'genkit';
+import { googleAI } from '@genkit-ai/googleai';
+import { redactMiddleware } from '@/ai/redact';
+
+describe('genkit client', () => {
+  it('injects redaction middleware', () => {
+    require('@/ai/genkit');
+    expect((googleAI as any).model).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ use: [redactMiddleware] })
+    );
+    expect((genkit as any).mock.calls[0][0]).toBeDefined();
+  });
+});

--- a/src/__tests__/redact.test.ts
+++ b/src/__tests__/redact.test.ts
@@ -1,0 +1,28 @@
+import { redactMiddleware } from '@/ai/redact';
+
+describe('redactMiddleware', () => {
+  const run = async (text: string) => {
+    const req: any = {
+      messages: [{ role: 'user', content: [{ text }] }],
+    };
+    const next = jest.fn(async (r) => r);
+    await redactMiddleware(req, next);
+    return next.mock.calls[0][0].messages[0].content[0].text;
+  };
+
+  it('removes email addresses', async () => {
+    const result = await run('Contact me at test@example.com');
+    expect(result).not.toContain('test@example.com');
+  });
+
+  it('removes phone numbers', async () => {
+    const result = await run('Call me at (555) 123-4567');
+    expect(result).not.toContain('555');
+    expect(result).not.toContain('123-4567');
+  });
+
+  it('removes account identifiers', async () => {
+    const result = await run('My account id is acct_ABC123');
+    expect(result).not.toContain('acct_ABC123');
+  });
+});

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,9 +1,10 @@
-import {genkit} from 'genkit';
-import {googleAI} from '@genkit-ai/googleai';
+import { genkit } from 'genkit';
+import { googleAI } from '@genkit-ai/googleai';
+import { redactMiddleware } from './redact';
 
-const model = process.env.GENKIT_MODEL || 'googleai/gemini-2.5-flash';
+const modelName = process.env.GENKIT_MODEL || 'googleai/gemini-2.5-flash';
 
 export const ai = genkit({
   plugins: [googleAI()],
-  model,
+  model: googleAI.model(modelName, { use: [redactMiddleware] }),
 });

--- a/src/ai/redact.ts
+++ b/src/ai/redact.ts
@@ -1,0 +1,28 @@
+import type { ModelMiddleware } from '@genkit-ai/ai/model';
+
+const emailRegex = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+const phoneRegex = /(?:\+?\d{1,2}[\s-]?)?(?:\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}\b/g;
+const accountRegex = /\b(?:acct|account)(?:[\s:_-]*id)?[\s:_-]*[A-Za-z0-9]+\b/gi;
+
+function redactText(text: string): string {
+  return text
+    .replace(emailRegex, '[REDACTED]')
+    .replace(phoneRegex, '[REDACTED]')
+    .replace(accountRegex, '[REDACTED]');
+}
+
+export const redactMiddleware: ModelMiddleware = async (req, next) => {
+  const messages = req.messages.map((message) => ({
+    ...message,
+    content: message.content.map((part) => {
+      if (part.text) {
+        return { ...part, text: redactText(part.text) };
+      }
+      return part;
+    }),
+  }));
+
+  return next({ ...req, messages });
+};
+
+export default redactMiddleware;


### PR DESCRIPTION
## Summary
- add middleware that strips emails, phone numbers, and account IDs from prompts
- plug middleware into the Genkit client
- test redaction and client integration

## Testing
- `npm test src/__tests__/redact.test.ts src/__tests__/genkit-redact.test.ts`
- `npm test` *(fails: Cannot use import statement outside a module in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b366eedcc0833197b5b0e57277e3c4