### PR TITLE
Add payroll tax calculations and tests

### DIFF
--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -52,8 +52,8 @@ describe('taxEstimation validation', () => {
       location: 'NY',
       filingStatus: 'single',
     });
-    expect(result.estimatedTax).toBeCloseTo(9214, 0);
-    expect(result.taxRate).toBeCloseTo(11.52, 2);
+    expect(result.estimatedTax).toBeCloseTo(15334, 0);
+    expect(result.taxRate).toBeCloseTo(19.17, 2);
   });
 });
 

--- a/src/ai/flows/tax-estimation.ts
+++ b/src/ai/flows/tax-estimation.ts
@@ -10,7 +10,7 @@
  */
 
 import {z} from 'genkit';
-import {calculateIncomeTax} from '@/lib/taxes';
+import {calculateTaxes} from '@/lib/taxes';
 
 const TaxEstimationInputSchema = z.object({
   income: z
@@ -47,14 +47,15 @@ export type TaxEstimationOutput = z.infer<typeof TaxEstimationOutputSchema>;
 
 export async function estimateTax(input: TaxEstimationInput): Promise<TaxEstimationOutput> {
   const parsed = TaxEstimationInputSchema.parse(input);
-  const {tax, breakdown} = calculateIncomeTax(
+  const {incomeTax, payrollTaxes, breakdown} = calculateTaxes(
     parsed.income,
     parsed.deductions,
     parsed.filingStatus
   );
-  const taxRate = parsed.income === 0 ? 0 : (tax / parsed.income) * 100;
+  const totalTax = incomeTax + payrollTaxes.total;
+  const taxRate = parsed.income === 0 ? 0 : (totalTax / parsed.income) * 100;
   return TaxEstimationOutputSchema.parse({
-    estimatedTax: tax,
+    estimatedTax: totalTax,
     taxRate,
     breakdown,
   });

--- a/src/lib/__tests__/taxes.test.ts
+++ b/src/lib/__tests__/taxes.test.ts
@@ -1,0 +1,29 @@
+import { calculatePayrollTaxes, SOCIAL_SECURITY_WAGE_BASE } from '@/lib/taxes';
+
+describe('calculatePayrollTaxes', () => {
+  it('computes payroll taxes below the Social Security wage base', () => {
+    const wages = 50_000;
+    const payroll = calculatePayrollTaxes(wages, 'single');
+    const expectedSocialSecurity = wages * 0.062;
+    const expectedMedicare = wages * 0.0145;
+    expect(payroll.socialSecurity).toBeCloseTo(expectedSocialSecurity, 2);
+    expect(payroll.medicare).toBeCloseTo(expectedMedicare, 2);
+    expect(payroll.additionalMedicare).toBe(0);
+    expect(payroll.total).toBeCloseTo(expectedSocialSecurity + expectedMedicare, 2);
+  });
+
+  it('caps Social Security tax and applies additional Medicare surtax', () => {
+    const wages = 250_000;
+    const payroll = calculatePayrollTaxes(wages, 'single');
+    const expectedSocialSecurity = SOCIAL_SECURITY_WAGE_BASE * 0.062;
+    const expectedMedicare = wages * 0.0145;
+    const expectedAdditional = (wages - 200_000) * 0.009;
+    expect(payroll.socialSecurity).toBeCloseTo(expectedSocialSecurity, 2);
+    expect(payroll.medicare).toBeCloseTo(expectedMedicare, 2);
+    expect(payroll.additionalMedicare).toBeCloseTo(expectedAdditional, 2);
+    expect(payroll.total).toBeCloseTo(
+      expectedSocialSecurity + expectedMedicare + expectedAdditional,
+      2,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Social Security and Medicare tax calculations including surtax
- expose unified tax API returning income and payroll taxes
- cover payroll calculations with unit tests and update tax flow validation

## Testing
- `npm test` *(fails: Cannot use import statement outside a module in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b366f094848331b96e1b6fd9e06fed