### PR TITLE
Persist bank import transactions

### DIFF
--- a/src/__tests__/bank-import.test.ts
+++ b/src/__tests__/bank-import.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/transactions", () => {
+  const actual = jest.requireActual("@/lib/transactions")
+  return {
+    ...actual,
+    saveTransactions: jest.fn().mockResolvedValue(undefined),
+  }
+})
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn() },
+}))
+
+import { POST as bankImport } from "@/app/api/bank/import/route"
+import { saveTransactions } from "@/lib/transactions"
+import { logger } from "@/lib/logger"
+
+const baseTx = {
+  id: "1",
+  date: "2024-01-01",
+  description: "Test",
+  amount: 1,
+  currency: "USD",
+  type: "Income" as const,
+  category: "Misc",
+}
+
+describe("/api/bank/import persistence", () => {
+  beforeEach(() => {
+    ;(saveTransactions as jest.Mock).mockClear()
+    ;(logger.error as jest.Mock).mockClear()
+  })
+
+  it("saves transactions and returns provider", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ provider: "plaid", transactions: [baseTx] }),
+    })
+
+    const res = await bankImport(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data).toEqual({ provider: "plaid", imported: 1 })
+    expect(saveTransactions).toHaveBeenCalledTimes(1)
+    expect(saveTransactions).toHaveBeenCalledWith([baseTx])
+  })
+
+  it("logs and propagates persistence errors", async () => {
+    ;(saveTransactions as jest.Mock).mockRejectedValueOnce(
+      Object.assign(new Error("db failed"), { status: 503 }),
+    )
+
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify({ provider: "finicity", transactions: [baseTx] }),
+    })
+
+    const res = await bankImport(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(503)
+    expect(data).toEqual({ error: "db failed" })
+    expect(logger.error).toHaveBeenCalledTimes(1)
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed to import transactions for provider finicity",
+      expect.any(Error),
+    )
+  })
+})

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
-import { TransactionPayloadSchema } from "@/lib/transactions"
+import { TransactionPayloadSchema, saveTransactions } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
+import { logger } from "@/lib/logger"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -52,14 +53,19 @@ export async function POST(req: Request) {
   const { provider, transactions } = parsed.data
 
   try {
+    await saveTransactions(transactions)
     return NextResponse.json({
       provider,
       imported: transactions.length,
     })
-  } catch {
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    )
+  } catch (err) {
+    logger.error(`Failed to import transactions for provider ${provider}`, err)
+    const message =
+      err instanceof Error ? err.message : "Internal server error"
+    const status =
+      typeof err === "object" && err && "status" in err
+        ? (err as { status?: number }).status || 500
+        : 500
+    return NextResponse.json({ error: message }, { status })
   }
 }


### PR DESCRIPTION
## Summary
- Persist validated bank-import transactions using `saveTransactions`
- Log provider-specific failures for easier debugging
- Test provider-specific persistence and error logging

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module for lucide-react in auth-provider/debt-calendar tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b366f520488331a6ee4af100aebaca