### PR TITLE
feat: restrict API origins

### DIFF
--- a/src/__tests__/allowed-origins.test.ts
+++ b/src/__tests__/allowed-origins.test.ts
@@ -1,4 +1,4 @@
-import { getAllowedOrigins } from '@/lib/allowed-origins';
+import { getAllowedOrigins, isAllowedOrigin } from '@/lib/allowed-origins';
 
 describe('getAllowedOrigins', () => {
   it('parses strings and regex and ignores malformed entries', () => {
@@ -14,3 +14,17 @@ describe('getAllowedOrigins', () => {
     expect(origins[1]).toBeInstanceOf(RegExp);
   });
 });
+
+describe('isAllowedOrigin', () => {
+  it('allows exact string matches', () => {
+    const origins = getAllowedOrigins('https://example.com')
+    expect(isAllowedOrigin('https://example.com', origins)).toBe(true)
+    expect(isAllowedOrigin('https://evil.com', origins)).toBe(false)
+  })
+
+  it('matches regex patterns', () => {
+    const origins = getAllowedOrigins(String.raw`/^https:\/\/.*\.example\.com$/`)
+    expect(isAllowedOrigin('https://foo.example.com', origins)).toBe(true)
+    expect(isAllowedOrigin('https://bar.test.com', origins)).toBe(false)
+  })
+})

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import { verifyFirebaseToken } from "@/lib/server-auth"
 import { TransactionPayloadSchema } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
+import { isAllowedOrigin } from "@/lib/allowed-origins"
 
 /**
  * Imports transactions from a banking provider (e.g., Plaid, Finicity).
@@ -17,6 +18,9 @@ const bodySchema = z.object({
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
 export async function POST(req: Request) {
+  if (!isAllowedOrigin(req.headers.get("origin"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
   try {
     await verifyFirebaseToken(req)
   } catch (err) {

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -4,6 +4,7 @@ import { verifyFirebaseToken } from "@/lib/server-auth"
 import { TransactionPayloadSchema, saveTransactions } from "@/lib/transactions"
 import { PayloadTooLargeError, readBodyWithLimit } from "@/lib/http"
 import { logger } from "@/lib/logger"
+import { isAllowedOrigin } from "@/lib/allowed-origins"
 
 /**
  * Generic transaction syncing endpoint.
@@ -19,6 +20,9 @@ const bodySchema = z.object({
 const MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
 export async function POST(req: Request) {
+  if (!isAllowedOrigin(req.headers.get("origin"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
   try {
     await verifyFirebaseToken(req)
   } catch (err) {

--- a/src/lib/allowed-origins.ts
+++ b/src/lib/allowed-origins.ts
@@ -29,3 +29,14 @@ export function getAllowedOrigins(env: string | undefined = process.env.ALLOWED_
 }
 
 export const allowedOrigins: AllowedOrigin[] = getAllowedOrigins();
+
+export function isAllowedOrigin(
+  origin: string | null,
+  origins: AllowedOrigin[] = allowedOrigins,
+): boolean {
+  if (origins.length === 0) return true
+  if (!origin) return false
+  return origins.some((item) =>
+    typeof item === "string" ? item === origin : item.test(origin),
+  )
+}


### PR DESCRIPTION
## Summary
- add helper to parse and check allowed origins
- reject API requests from disallowed origins
- test exact and regex origin matching

## Testing
- `npm test` *(fails: Cannot use import statement outside a module in lucide-react)*
- `npx jest src/__tests__/allowed-origins.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b366f5d6c08331b37db3284260d2ad