### PR TITLE
chore: add Node engines requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This is a NextJS starter in Firebase Studio.
 This project uses npm as the canonical package manager. Use npm for all dependency management tasks.
 To get started, take a look at src/app/page.tsx.
 
+Requires Node.js 20. Use a Node.js version greater than or equal to 20 but less than 21.
+
 ## Development
 - `npm run dev` – start the development server.
 - On Cloud Workstations, run `PORT=6000 npm run dev` to match the reserved domain.

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,9 @@
         "tailwindcss": "^3.4.1",
         "ts-jest": "^29.4.1",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20 <21"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "name": "nextn",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20 <21"
+  },
   "scripts": {
     "preinstall": "node scripts/ensure-npm.js",
     "dev": "next dev -p ${PORT:-9000}",


### PR DESCRIPTION
## Summary
- enforce Node.js 20 via `engines` in `package.json`
- document Node.js 20 requirement in README

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b366f66cb083318a2480a49d7f17eb