### PR TITLE
feat: clean up expired storage files

### DIFF
--- a/src/__tests__/housekeeping-integration.test.ts
+++ b/src/__tests__/housekeeping-integration.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment node
+ */
+import { GET, resetRateLimit } from "@/app/api/cron/housekeeping/route";
+import { initFirebase } from "@/lib/firebase";
+import { logger } from "@/lib/logger";
+
+jest.mock("@/lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
+
+const listAll = jest.fn();
+const getMetadata = jest.fn();
+const deleteObject = jest.fn();
+
+jest.mock("firebase/storage", () => ({
+  getStorage: jest.fn(),
+  ref: jest.fn((_storage) => ({ fullPath: "" })),
+  listAll: (...args: unknown[]) => listAll(...args),
+  getMetadata: (...args: unknown[]) => getMetadata(...args),
+  deleteObject: (...args: unknown[]) => deleteObject(...args),
+}));
+
+jest.mock("firebase/auth", () => ({ getAuth: jest.fn() }));
+
+jest.mock("firebase/firestore", () => {
+  const store: { lastRun?: number } = {};
+  interface Tx {
+    get: () => Promise<{
+      exists: () => boolean;
+      data: () => { lastRun: number | undefined };
+    }>;
+    set: (ref: unknown, data: { lastRun: number }) => void;
+  }
+  return {
+    doc: () => ({}),
+    runTransaction: jest.fn(
+      async (_db: unknown, updateFn: (tx: Tx) => Promise<unknown>) => {
+        while (true) {
+          let write: { lastRun: number } | undefined;
+          const lastBefore = store.lastRun;
+          const tx: Tx = {
+            get: async () => ({
+              exists: () => store.lastRun !== undefined,
+              data: () => ({ lastRun: store.lastRun }),
+            }),
+            set: (_ref, data) => {
+              write = data;
+            },
+          };
+          const result = await updateFn(tx);
+          if (write && lastBefore !== store.lastRun) {
+            continue;
+          }
+          if (write) {
+            store.lastRun = write.lastRun;
+          }
+          return result;
+        }
+      }
+    ),
+    setDoc: jest.fn(async (_ref: unknown, data: { lastRun: number }) => {
+      store.lastRun = data.lastRun;
+    }),
+    __store: store,
+  };
+});
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
+}));
+
+const secret = "test-secret";
+const now = new Date("2024-02-02T00:00:00Z").getTime();
+let dateSpy: jest.SpyInstance<number, []>;
+
+describe("housekeeping integration", () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
+    process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = "test";
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = "test";
+    process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
+    process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
+    process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
+    initFirebase();
+  });
+
+  beforeEach(async () => {
+    process.env.CRON_SECRET = secret;
+    process.env.NEXT_PUBLIC_ENABLE_HOUSEKEEPING_LOG = "true";
+    process.env.RETENTION_DAYS = "1";
+    dateSpy = jest.spyOn(Date, "now").mockReturnValue(now);
+    listAll.mockResolvedValue({
+      items: [{ fullPath: "old.txt" }, { fullPath: "new.txt" }],
+    });
+    getMetadata.mockImplementation(async (item: { fullPath: string }) => {
+      if (item.fullPath === "old.txt") {
+        return { timeCreated: new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString() };
+      }
+      return { timeCreated: new Date(now - 12 * 60 * 60 * 1000).toISOString() };
+    });
+    deleteObject.mockClear();
+    (logger.info as jest.Mock).mockClear();
+    await resetRateLimit();
+  });
+
+  afterEach(() => {
+    dateSpy.mockRestore();
+  });
+
+  it("deletes expired files and logs actions", async () => {
+    const res = await GET(
+      new Request("http://localhost", { headers: { "x-cron-secret": secret } })
+    );
+    expect(res.status).toBe(200);
+    expect(deleteObject).toHaveBeenCalledTimes(1);
+    expect((deleteObject.mock.calls[0][0] as { fullPath: string }).fullPath).toBe(
+      "old.txt"
+    );
+    expect(logger.info).toHaveBeenCalledWith("Deleted expired file: old.txt");
+    expect(logger.info).toHaveBeenCalledWith(
+      "Housekeeping job executed: Firebase auth initialized; 1 file(s) deleted"
+    );
+  });
+});

--- a/src/lib/housekeeping.ts
+++ b/src/lib/housekeeping.ts
@@ -1,13 +1,42 @@
 import { getAuth } from "firebase/auth";
+import {
+  deleteObject,
+  getMetadata,
+  getStorage,
+  listAll,
+  ref,
+} from "firebase/storage";
 import { logger } from "./logger";
 
-// Placeholder housekeeping service that cleans up outdated data.
-// Replace with actual implementation as needed.
+// Cleans up outdated data from Firebase Storage.
 export async function runHousekeeping(): Promise<void> {
-  // Example: ensure auth SDK is initialized to avoid cold-start costs
-  // and perform cleanup tasks such as removing expired sessions.
+  // Ensure auth SDK is initialized to avoid cold-start costs
   getAuth();
+
+  const retentionDays = parseInt(process.env.RETENTION_DAYS || "30", 10);
+  const retentionMs = retentionDays * 24 * 60 * 60 * 1000;
+  const now = Date.now();
+
+  const storage = getStorage();
+  const rootRef = ref(storage);
+  const { items } = await listAll(rootRef);
+
+  let deleted = 0;
+  for (const item of items) {
+    const metadata = await getMetadata(item);
+    const created = new Date(metadata.timeCreated).getTime();
+    if (now - created > retentionMs) {
+      await deleteObject(item);
+      deleted++;
+      if (process.env.NEXT_PUBLIC_ENABLE_HOUSEKEEPING_LOG === "true") {
+        logger.info(`Deleted expired file: ${item.fullPath}`);
+      }
+    }
+  }
+
   if (process.env.NEXT_PUBLIC_ENABLE_HOUSEKEEPING_LOG === "true") {
-    logger.info("Housekeeping job executed: Firebase auth initialized");
+    logger.info(
+      `Housekeeping job executed: Firebase auth initialized; ${deleted} file(s) deleted`
+    );
   }
 }


### PR DESCRIPTION
## Summary
- remove expired files from Firebase Storage based on `RETENTION_DAYS`
- log cleanup actions and summary during housekeeping
- test housekeeping route and storage cleanup with cron secret

## Testing
- `npm test src/__tests__/housekeeping-route.test.ts`
- `npm test src/__tests__/housekeeping-integration.test.ts`
- `npm test` *(fails: Cannot use import statement outside a module in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b366f6f26c8331ad3ed781a7b90ea9