### PR TITLE
feat: lazy init firebase in category service

### DIFF
--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -16,7 +16,6 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
-  initFirebase();
 });
 
 jest.mock("firebase/firestore", () => ({
@@ -29,6 +28,7 @@ jest.mock("firebase/firestore", () => ({
 
 describe("categoryService", () => {
   beforeEach(() => {
+    initFirebase();
     clearCategories();
     jest.clearAllMocks();
   });

--- a/src/lib/categoryService.ts
+++ b/src/lib/categoryService.ts
@@ -6,8 +6,6 @@ import { doc, getDocs, setDoc, deleteDoc, writeBatch } from "firebase/firestore"
 import { db, categoriesCollection, initFirebase } from "./firebase";
 import { logger } from "./logger";
 
-initFirebase();
-
 const STORAGE_KEY = "categories";
 
 // In non-browser environments (e.g. during testing) `localStorage` is not
@@ -44,6 +42,7 @@ function save(categories: string[]) {
 
 // Synchronize the local cache with Firestore in the background.
 async function syncFromServer() {
+  initFirebase();
   try {
     const snap = await getDocs(categoriesCollection);
     const list: string[] = [];
@@ -63,6 +62,7 @@ async function syncFromServer() {
  * the casing that will be preserved for display.
  */
 export function getCategories(): string[] {
+  initFirebase();
   if (typeof window !== "undefined") {
     void syncFromServer();
   }
@@ -87,6 +87,7 @@ export function getCategories(): string[] {
  * the background and failures are logged but do not interrupt the result.
  */
 export function addCategory(category: string): string[] {
+  initFirebase();
   const categories = getCategories();
   const trimmed = category.trim();
   const key = normalize(trimmed);
@@ -110,6 +111,7 @@ export function addCategory(category: string): string[] {
  * writes are performed in the background.
  */
 export function removeCategory(category: string): string[] {
+  initFirebase();
   const key = normalize(category);
   if (!isValidKey(key)) {
     logger.error("Invalid category name");
@@ -125,6 +127,7 @@ export function removeCategory(category: string): string[] {
 
 /** Clear all categories locally and in Firestore. */
 export function clearCategories() {
+  initFirebase();
   save([]);
   void (async () => {
     try {


### PR DESCRIPTION
## Summary
- lazily initialize Firebase in category service instead of at module load
- explicitly init Firebase in category service tests

## Testing
- `npm test src/__tests__/categoryService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b366f806588331b8424eea1f58d0b4