### PR TITLE
feat: add budgets and goals features

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,15 @@
+{
+  "indexes": [
+    { "collectionGroup": "budgets", "queryScope": "COLLECTION", "fields": [
+      { "fieldPath": "user_id", "order": "ASCENDING" },
+      { "fieldPath": "month", "order": "DESCENDING" }
+    ]},
+    { "collectionGroup": "summaries", "queryScope": "COLLECTION", "fields": [
+      { "fieldPath": "user_id", "order": "ASCENDING" },
+      { "fieldPath": "month", "order": "DESCENDING" }
+    ]},
+    { "collectionGroup": "goals", "queryScope": "COLLECTION", "fields": [ { "fieldPath": "user_id", "order": "ASCENDING" } ] },
+    { "collectionGroup": "goal_contributions", "queryScope": "COLLECTION", "fields": [ { "fieldPath": "user_id", "order": "ASCENDING" }, { "fieldPath": "goal_id", "order": "ASCENDING" } ] }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,13 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isSignedIn() { return request.auth != null; }
+    function isOwner(userId) { return request.auth != null && request.auth.uid == userId; }
+
+    // owner-only collections add:
+    match /{colName}/{docId} where colName in ['summaries','goal_contributions'] {
+      allow read, write: if isOwner(resource.data.user_id);
+      allow create: if isSignedIn() && request.resource.data.user_id == request.auth.uid;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "embla-carousel-react": "^8.6.0",
         "firebase": "^11.9.1",
         "firebase-admin": "^13.4.0",
+        "firebase-functions": "^6.4.0",
         "framer-motion": "^12.23.12",
         "genkit": "^1.14.1",
         "idb": "^7.1.1",
@@ -7603,6 +7604,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -12110,6 +12120,28 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/firebase-functions": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.4.0.tgz",
+      "integrity": "sha512-Q/LGhJrmJEhT0dbV60J4hCkVSeOM6/r7xJS/ccmkXzTWMjo+UPAYX9zlQmGlEjotstZ0U9GtQSJSgbB2Z+TJDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.5",
+        "@types/express": "^4.17.21",
+        "cors": "^2.8.5",
+        "express": "^4.21.0",
+        "protobufjs": "^7.2.2"
+      },
+      "bin": {
+        "firebase-functions": "lib/bin/firebase-functions.js"
+      },
+      "engines": {
+        "node": ">=14.10.0"
+      },
+      "peerDependencies": {
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
       }
     },
     "node_modules/firebase/node_modules/@firebase/auth": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "nextn",
   "version": "0.1.0",
@@ -45,6 +44,7 @@
     "embla-carousel-react": "^8.6.0",
     "firebase": "^11.9.1",
     "firebase-admin": "^13.4.0",
+    "firebase-functions": "^6.4.0",
     "framer-motion": "^12.23.12",
     "genkit": "^1.14.1",
     "idb": "^7.1.1",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@studio/domain",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "src/zod.ts",
+  "dependencies": {
+    "zod": "^3.24.2"
+  }
+}

--- a/packages/domain/src/zod.ts
+++ b/packages/domain/src/zod.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+// Budget envelope and main schemas
+export const BudgetEnvelopeSchema = z.object({
+  category: z.string(),
+  planned: z.number(),
+  carryover: z.boolean().optional(),
+});
+
+export const BudgetSchema = z.object({
+  user_id: z.string(),
+  month: z.string().regex(/^\d{4}-\d{2}$/),
+  envelopes: z.array(BudgetEnvelopeSchema),
+  locked: z.boolean().optional(),
+  created_at: z.any().optional(),
+});
+export type BudgetDoc = z.infer<typeof BudgetSchema>;
+
+export const GoalSchema = z.object({
+  user_id: z.string(),
+  name: z.string(),
+  target_amount: z.number().positive(),
+  target_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  funding_strategy: z.string().optional(),
+  created_at: z.any().optional(),
+});
+export type GoalDoc = z.infer<typeof GoalSchema>;
+
+// Spend summaries capture aggregated monthly totals
+export const SpendSummarySchema = z.object({
+  user_id: z.string(),
+  month: z.string().regex(/^\d{4}-\d{2}$/),
+  totals_by_category: z.record(z.number()).default({}),
+  total_spent: z.number().default(0),
+  total_income: z.number().default(0),
+  tx_count: z.number().default(0),
+  updated_at: z.any().optional(),
+});
+export type SpendSummaryDoc = z.infer<typeof SpendSummarySchema>;
+
+// Goal contributions track manual deposits towards a goal
+export const GoalContributionSchema = z.object({
+  user_id: z.string(),
+  goal_id: z.string(),
+  amount: z.number().positive(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  note: z.string().optional(),
+  created_at: z.any().optional(),
+});
+export type GoalContributionDoc = z.infer<typeof GoalContributionSchema>;
+

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@studio/workers",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "firebase-admin": "^13.4.0",
+    "firebase-functions": "^5.0.0"
+  }
+}

--- a/packages/workers/src/budgets.ts
+++ b/packages/workers/src/budgets.ts
@@ -1,0 +1,26 @@
+import { onRequest } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+
+if (!admin.apps.length) admin.initializeApp();
+const db = admin.firestore();
+
+async function requireUser(req: any): Promise<string> {
+  const hdr = req.headers?.authorization || '';
+  const token = hdr.startsWith('Bearer ') ? hdr.slice(7) : '';
+  if (!token) throw new Error('Missing Authorization token');
+  const decoded = await admin.auth().verifyIdToken(token);
+  return decoded.uid;
+}
+
+export const upsertBudget = onRequest(async (req, res) => {
+  try {
+    const uid = await requireUser(req);
+    const { month, envelopes, locked } = req.body || {};
+    if (!month || !/^\d{4}-\d{2}$/.test(month)) throw new Error('month YYYY-MM required');
+    if (!Array.isArray(envelopes)) throw new Error('envelopes[] required');
+
+    const id = `${uid}_${month}`;
+    await db.collection('budgets').doc(id).set({ user_id: uid, month, envelopes, locked: !!locked }, { merge: true });
+    res.json({ ok: true });
+  } catch (e: any) { res.status(400).json({ error: e.message }); }
+});

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,0 +1,2 @@
+export * from './summary';
+export * from './budgets';

--- a/packages/workers/src/summary.ts
+++ b/packages/workers/src/summary.ts
@@ -1,0 +1,77 @@
+import { onRequest } from 'firebase-functions/v2/https';
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import * as admin from 'firebase-admin';
+import * as logger from 'firebase-functions/logger';
+
+if (!admin.apps.length) admin.initializeApp();
+const db = admin.firestore();
+
+function ym(d: Date) {
+  const y = d.getUTCFullYear();
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  return `${y}-${m}`;
+}
+function monthRange(month: string) {
+  const [y, m] = month.split('-').map(Number);
+  const start = new Date(Date.UTC(y, m - 1, 1));
+  const end = new Date(Date.UTC(y, m, 1));
+  return { start, end };
+}
+async function requireUser(req: any): Promise<string> {
+  const hdr = req.headers?.authorization || '';
+  const token = hdr.startsWith('Bearer ') ? hdr.slice(7) : '';
+  if (!token) throw new Error('Missing Authorization token');
+  const decoded = await admin.auth().verifyIdToken(token);
+  return decoded.uid;
+}
+
+export async function recompute(uid: string, month: string) {
+  const { start, end } = monthRange(month);
+  const q = db.collection('transactions')
+    .where('user_id', '==', uid)
+    .where('posted_at', '>=', start)
+    .where('posted_at', '<', end);
+  const snap = await q.get();
+  const byCat: Record<string, number> = {};
+  let spent = 0; let income = 0; let count = 0;
+  snap.forEach((d) => {
+    const v = d.data() as any;
+    const amt = Math.abs(Number(v.amount) || 0);
+    const isIncome = !!v.paystub_id; // MVP heuristic
+    if (isIncome) income += amt; else { const c = v.nurse_category || 'uncategorized'; byCat[c] = (byCat[c] || 0) + amt; spent += amt; }
+    count++;
+  });
+  const id = `${uid}_${month}`;
+  await db.collection('summaries').doc(id).set({
+    user_id: uid, month, totals_by_category: byCat, total_spent: spent, total_income: income, tx_count: count,
+    updated_at: admin.firestore.FieldValue.serverTimestamp(),
+  }, { merge: true });
+  return { tx: count, spent, income, categories: Object.keys(byCat).length };
+}
+
+export const recomputeMonthSummary = onRequest(async (req, res) => {
+  try {
+    const uid = await requireUser(req);
+    const month = String(req.body?.month || req.query?.month || ym(new Date()));
+    const result = await recompute(uid, month);
+    res.json({ month, ...result });
+  } catch (e: any) { logger.error('recomputeMonthSummary', e); res.status(400).json({ error: e.message }); }
+});
+
+export const onTxWriteUpdateSummary = onDocumentWritten('transactions/{txId}', async (event) => {
+  try {
+    const before = event.data?.before.data() as any | undefined;
+    const after = event.data?.after.data() as any | undefined;
+    const months = new Set<string>();
+    const uid = (after?.user_id) || (before?.user_id);
+    if (!uid) return;
+    const pick = (v: any | undefined) => {
+      if (!v?.posted_at) return null;
+      const d = v.posted_at.toDate ? v.posted_at.toDate() : new Date(v.posted_at);
+      return ym(d);
+    };
+    const m1 = pick(before); const m2 = pick(after);
+    if (m1) months.add(m1); if (m2) months.add(m2);
+    for (const m of months) await recompute(uid, m);
+  } catch (e) { logger.error('onTxWriteUpdateSummary', e); }
+});

--- a/src/app/budgets/page.tsx
+++ b/src/app/budgets/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+import BudgetEditor from '@/components/BudgetEditor';
+export default function BudgetsPage(){
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-semibold">Budgets</h1>
+      <BudgetEditor />
+    </div>
+  );
+}

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -1,67 +1,10 @@
-"use client"
-
-import { useEffect, useState } from "react";
-import type { Goal } from "@/lib/types";
-import { GoalCard } from "@/components/goals/goal-card";
-import { AddGoalDialog } from "@/components/goals/add-goal-dialog";
-import { collection, addDoc, getDocs, updateDoc, deleteDoc, doc } from "firebase/firestore";
-import { db, initFirebase } from "@/lib/firebase";
-
-initFirebase();
-
-export default function GoalsPage() {
-  const [goals, setGoals] = useState<Goal[]>([]);
-
-  useEffect(() => {
-    const fetchGoals = async () => {
-      const snap = await getDocs(collection(db, "goals"));
-      const data = snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Goal, "id">) })) as Goal[];
-      setGoals(data);
-    };
-    fetchGoals();
-  }, []);
-
-  const handleSaveGoal = async (goal: Goal) => {
-    if (goal.id) {
-      await updateDoc(doc(db, "goals", goal.id), {
-        name: goal.name,
-        targetAmount: goal.targetAmount,
-        currentAmount: goal.currentAmount,
-        deadline: goal.deadline,
-        importance: goal.importance,
-      });
-      setGoals(prev => prev.map(g => g.id === goal.id ? goal : g));
-    } else {
-      const docRef = await addDoc(collection(db, "goals"), {
-        name: goal.name,
-        targetAmount: goal.targetAmount,
-        currentAmount: goal.currentAmount,
-        deadline: goal.deadline,
-        importance: goal.importance,
-      });
-      setGoals(prev => [{ ...goal, id: docRef.id }, ...prev]);
-    }
-  };
-
-  const handleDeleteGoal = async (id: string) => {
-    await deleteDoc(doc(db, "goals", id));
-    setGoals(prev => prev.filter(g => g.id !== id));
-  };
-
+'use client';
+import Goals from '@/components/Goals';
+export default function GoalsPage(){
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-            <h1 className="text-3xl font-bold tracking-tight">Financial Goals</h1>
-            <p className="text-muted-foreground">Set and track your financial goals to stay motivated.</p>
-        </div>
-        <AddGoalDialog onSave={handleSaveGoal} />
-      </div>
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {goals.map(goal => (
-          <GoalCard key={goal.id} goal={goal} onDelete={handleDeleteGoal} onUpdate={handleSaveGoal} />
-        ))}
-      </div>
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-semibold">Goals</h1>
+      <Goals />
     </div>
   );
 }

--- a/src/components/BudgetEditor.tsx
+++ b/src/components/BudgetEditor.tsx
@@ -1,0 +1,95 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { auth, db, initFirebase } from '@/lib/firebase';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { saveBudget, Envelope } from '@/lib/budgetsClient';
+
+initFirebase();
+
+const NurseCats = [
+  'scrubs','ceus','licensure','agency_fees','housing_stipend_overage','mileage','lodging','per_diem','union_dues','equipment','parking','meals_on_shift','certifications','travel_misc','uncategorized'
+];
+
+function nowMonth() { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}`; }
+function fmt(n: number) { try { return n.toLocaleString(undefined, { style:'currency', currency:'USD' }); } catch { return `$${n.toFixed(2)}`; } }
+
+export default function BudgetEditor() {
+  const [month, setMonth] = useState(nowMonth());
+  const [uid, setUid] = useState<string | null>(null);
+  const [envelopes, setEnvelopes] = useState<Envelope[]>(NurseCats.map(c=> ({ category: c, planned: 0 })));
+  const [locked, setLocked] = useState(false);
+  type Summary = { totals_by_category?: Record<string, number>; total_income?: number } | null;
+  const [summary, setSummary] = useState<Summary>(null);
+  const [msg, setMsg] = useState<string>('');
+
+  useEffect(()=> auth.onAuthStateChanged(u=> setUid(u?.uid ?? null)),[]);
+
+  // Load budget & summary for selected month
+  useEffect(()=>{
+    if (!uid) return;
+    const bid = `${uid}_${month}`;
+    const unsubB = onSnapshot(doc(db, 'budgets', bid), snap => {
+        if (snap.exists()) {
+          const v = snap.data() as { envelopes?: Envelope[]; locked?: boolean };
+          setEnvelopes(v.envelopes || []);
+          setLocked(!!v.locked);
+        } else {
+          setEnvelopes(NurseCats.map(c=> ({ category: c, planned: 0 })));
+          setLocked(false);
+        }
+      });
+    const unsubS = onSnapshot(doc(db, 'summaries', bid), snap => setSummary(snap.exists()? snap.data(): null));
+    return () => { unsubB(); unsubS(); };
+  }, [uid, month]);
+
+  function setPlanned(i: number, val: number) {
+    setEnvelopes(prev => prev.map((e, idx)=> idx===i ? { ...e, planned: isNaN(val)?0:val } : e));
+  }
+
+  async function onSave() {
+    try { await saveBudget(month, envelopes, locked); setMsg('Saved'); setTimeout(()=> setMsg(''), 1500); } catch (e){ setMsg((e as Error).message);} }
+
+  const spentByCat: Record<string, number> = summary?.totals_by_category || {};
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-end gap-3">
+        <div>
+          <label className="block text-sm font-medium">Month</label>
+          <input type="month" value={month} onChange={e=> setMonth(e.target.value)} className="border rounded p-2" />
+        </div>
+        <label className="inline-flex items-center gap-2 text-sm"><input type="checkbox" checked={locked} onChange={e=> setLocked(e.target.checked)} /> Lock budget</label>
+        <button className="rounded bg-black text-white px-4 py-2" onClick={onSave}>Save</button>
+        {msg && <span className="text-sm">{msg}</span>}
+      </div>
+
+      <div className="border rounded overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50"><tr><th className="text-left p-2">Category</th><th className="text-right p-2">Planned</th><th className="text-right p-2">Spent MTD</th><th className="text-right p-2">Remaining</th></tr></thead>
+          <tbody>
+            {envelopes.map((e, i) => {
+              const spent = spentByCat[e.category] || 0;
+              const remaining = Math.max(0, (e.planned || 0) - spent);
+              return (
+                <tr key={e.category} className="border-t">
+                  <td className="p-2">{e.category}</td>
+                  <td className="p-2 text-right">
+                    <input type="number" step="0.01" disabled={locked} value={e.planned} onChange={e2=> setPlanned(i, Number(e2.target.value))} className="max-w-[120px] border rounded p-1 text-right" />
+                  </td>
+                  <td className="p-2 text-right">{fmt(spent)}</td>
+                  <td className="p-2 text-right">{fmt(remaining)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="grid md:grid-cols-3 gap-4">
+        <div className="border rounded p-3"><div className="text-sm opacity-70">Total planned</div><div className="text-2xl font-semibold">{fmt(envelopes.reduce((s,e)=> s + (e.planned||0), 0))}</div></div>
+        <div className="border rounded p-3"><div className="text-sm opacity-70">Total spent (MTD)</div><div className="text-2xl font-semibold">{fmt(Object.values(spentByCat).reduce((s,n)=> s + (n as number), 0))}</div></div>
+        <div className="border rounded p-3"><div className="text-sm opacity-70">Income (MTD)</div><div className="text-2xl font-semibold">{fmt(summary?.total_income || 0)}</div></div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Goals.tsx
+++ b/src/components/Goals.tsx
@@ -1,0 +1,83 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { auth, db, initFirebase } from '@/lib/firebase';
+import { addDoc, collection, onSnapshot, orderBy, query, serverTimestamp, where } from 'firebase/firestore';
+
+initFirebase();
+
+function ymdd(d = new Date()) { return d.toISOString().slice(0,10); }
+
+export default function Goals() {
+  type Goal = { id: string; name: string; target_amount: number; target_date: string };
+  const [uid, setUid] = useState<string|null>(null);
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [name, setName] = useState('');
+  const [target, setTarget] = useState<number>(1000);
+  const [date, setDate] = useState<string>(new Date(new Date().getFullYear(), new Date().getMonth()+3, 1).toISOString().slice(0,10));
+  const [selected, setSelected] = useState<Goal|null>(null);
+  const [contrib, setContrib] = useState<number>(50);
+  const [msg, setMsg] = useState('');
+
+  useEffect(()=> auth.onAuthStateChanged(u=> setUid(u?.uid ?? null)), []);
+  useEffect(()=>{
+    if (!uid) return;
+    const q = query(collection(db, 'goals'), where('user_id','==',uid), orderBy('target_date','asc'));
+    return onSnapshot(q, snap => setGoals(snap.docs.map(d=> ({ id: d.id, ...(d.data() as Omit<Goal,'id'>) }))));
+  }, [uid]);
+
+  async function createGoal() {
+    if (!uid) return;
+    await addDoc(collection(db, 'goals'), { user_id: uid, name, target_amount: target, target_date: date, funding_strategy: 'monthly', created_at: serverTimestamp() });
+    setName(''); setTarget(1000);
+  }
+
+  async function addContribution() {
+    if (!uid || !selected) return;
+    await addDoc(collection(db, 'goal_contributions'), { user_id: uid, goal_id: selected.id, amount: contrib, date: ymdd(), created_at: serverTimestamp() });
+    setMsg('Added'); setTimeout(()=> setMsg(''), 1000);
+  }
+
+  return (
+    <div className="grid md:grid-cols-3 gap-6">
+      <div className="md:col-span-1 border rounded-xl p-4 space-y-3">
+        <h3 className="font-medium">Create goal</h3>
+        <label className="block text-sm">Name</label>
+        <input className="border rounded p-2 w-full" value={name} onChange={e=> setName(e.target.value)} />
+        <label className="block text-sm mt-2">Target amount</label>
+        <input type="number" className="border rounded p-2 w-full" value={target} onChange={e=> setTarget(Number(e.target.value))} />
+        <label className="block text-sm mt-2">Target date</label>
+        <input type="date" className="border rounded p-2 w-full" value={date} onChange={e=> setDate(e.target.value)} />
+        <button className="rounded bg-black text-white px-4 py-2 mt-3" onClick={createGoal}>Create</button>
+      </div>
+
+      <div className="md:col-span-2 border rounded-xl p-4">
+        <h3 className="font-medium mb-2">Your goals</h3>
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50"><tr><th className="text-left p-2">Name</th><th className="text-right p-2">Target</th><th className="text-left p-2">Date</th><th className="text-right p-2">Actions</th></tr></thead>
+          <tbody>
+            {goals.map(g => (
+              <tr key={g.id} className="border-t">
+                <td className="p-2">{g.name}</td>
+                <td className="p-2 text-right">{g.target_amount?.toLocaleString(undefined,{style:'currency',currency:'USD'})}</td>
+                <td className="p-2">{g.target_date}</td>
+                <td className="p-2 text-right"><button className="underline" onClick={()=> setSelected(g)}>Contribute</button></td>
+              </tr>
+            ))}
+            {goals.length===0 && <tr><td className="p-2" colSpan={4}>No goals yet.</td></tr>}
+          </tbody>
+        </table>
+
+        {selected && (
+          <div className="mt-4 border-t pt-4">
+            <h4 className="font-medium">Contribute to {selected.name}</h4>
+            <div className="flex items-end gap-3">
+              <input type="number" className="border rounded p-2" value={contrib} onChange={e=> setContrib(Number(e.target.value))} />
+              <button className="rounded border px-4 py-2" onClick={addContribution}>Add contribution</button>
+              {msg && <span className="text-sm">{msg}</span>}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -91,6 +91,12 @@ export default function AppHeader() {
               Debts
             </Link>
             <Link
+              href="/budgets"
+              className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground"
+            >
+              Budgets
+            </Link>
+            <Link
               href="/goals"
               className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground"
             >

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Settings,
   CreditCard,
   Wallet,
+  CircleDollarSign,
 } from "lucide-react"
 import { NurseFinAILogo } from "@/components/icons"
 import { cn } from "@/lib/utils"
@@ -27,6 +28,7 @@ const navItems = [
   { href: "/dashboard", icon: LayoutDashboard, label: "Dashboard" },
   { href: "/transactions", icon: ArrowLeftRight, label: "Transactions" },
   { href: "/debts", icon: CreditCard, label: "Debts" },
+  { href: "/budgets", icon: CircleDollarSign, label: "Budgets" },
   { href: "/goals", icon: Target, label: "Goals" },
   { href: "/cashflow", icon: Wallet, label: "Cashflow" },
   { href: "/insights", icon: Sparkles, label: "AI Insights" },

--- a/src/lib/budgetsClient.ts
+++ b/src/lib/budgetsClient.ts
@@ -1,0 +1,13 @@
+'use client';
+import { auth, db, initFirebase } from '@/lib/firebase';
+import { doc, setDoc } from 'firebase/firestore';
+
+initFirebase();
+
+export type Envelope = { category: string; planned: number; carryover?: boolean };
+
+export async function saveBudget(month: string, envelopes: Envelope[], locked: boolean) {
+  const uid = auth.currentUser?.uid; if (!uid) throw new Error('Not signed in');
+  const id = `${uid}_${month}`;
+  await setDoc(doc(db, 'budgets', id), { user_id: uid, month, envelopes, locked }, { merge: true });
+}


### PR DESCRIPTION
## Summary
- add zod schemas for budgets, goals, spend summaries, and goal contributions
- implement cloud functions for month summaries and budget upserts
- expose budgeting and goal management UIs with navigation links

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in lucide-react)*
- `npm run lint` *(fails: lint errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b3671fa668833180e9fbcffb34c7a2