### PR TITLE
test: add sanitize middleware tests

### DIFF
--- a/src/ai/__tests__/sanitize-middleware.test.ts
+++ b/src/ai/__tests__/sanitize-middleware.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment node
+ */
+import { sanitizeMiddleware } from '../sanitize-middleware'
+
+describe('sanitizeMiddleware', () => {
+  it('hashes emails, phone numbers, and nested account numbers', () => {
+    const input = {
+      email: 'alice@example.com',
+      phone: '555-123-4567',
+      nested: {
+        account: { number: '9876543210' },
+      },
+    }
+
+    const result = sanitizeMiddleware(input)
+    const stringified = JSON.stringify(result)
+
+    expect(result.email).toMatch(/^\[hash:[0-9a-f]{8}\]$/)
+    expect(result.phone).toMatch(/^\[hash:[0-9a-f]{8}\]$/)
+    expect(result.nested.account.number).toMatch(/^\[hash:[0-9a-f]{8}\]$/)
+
+    expect(stringified).not.toContain('alice@example.com')
+    expect(stringified).not.toContain('555-123-4567')
+    expect(stringified).not.toContain('9876543210')
+  })
+})
+

--- a/src/ai/sanitize-middleware.ts
+++ b/src/ai/sanitize-middleware.ts
@@ -1,0 +1,36 @@
+import crypto from 'crypto'
+
+const emailRegex = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/
+const phoneRegex = /(?:\+?\d{1,2}\s?)?(?:\(?\d{3}\)?[\s.-]?)?\d{3}[\s.-]?\d{4}/
+const accountRegex = /\b\d{6,}\b/
+
+function hashPlaceholder(value: string) {
+  return `[hash:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 8)}]`
+}
+
+function sanitizeValue(value: any): any {
+  if (typeof value === 'string') {
+    if (emailRegex.test(value) || phoneRegex.test(value) || accountRegex.test(value)) {
+      return hashPlaceholder(value)
+    }
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => sanitizeValue(v))
+  }
+  if (value && typeof value === 'object') {
+    const result: any = {}
+    for (const key of Object.keys(value)) {
+      result[key] = sanitizeValue((value as any)[key])
+    }
+    return result
+  }
+  return value
+}
+
+export function sanitizeMiddleware<T>(input: T): T {
+  return sanitizeValue(input)
+}
+
+export default sanitizeMiddleware
+


### PR DESCRIPTION
## Summary
- add middleware that hashes emails, phone numbers, and account numbers
- test that sanitizeMiddleware replaces PII with hashed placeholders

## Testing
- `npm test -- src/ai/__tests__/sanitize-middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b369262c908331b40d3bd60671f92a