### PR TITLE
test: enforce cron secret env

### DIFF
--- a/src/__tests__/housekeeping-route-env.test.ts
+++ b/src/__tests__/housekeeping-route-env.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment node
+ */
+
+describe("housekeeping route environment", () => {
+  it("throws if CRON_SECRET is not set", async () => {
+    const original = process.env.CRON_SECRET;
+    delete process.env.CRON_SECRET;
+    jest.resetModules();
+
+    await expect(
+      import("@/app/api/cron/housekeeping/route")
+    ).rejects.toThrow("CRON_SECRET environment variable is not set");
+
+    if (original === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = original;
+    }
+    jest.resetModules();
+  });
+});

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -5,6 +5,10 @@ import { getCurrentTime } from "@/lib/internet-time";
 import { doc, runTransaction, setDoc } from "firebase/firestore";
 import { logger } from "@/lib/logger";
 
+if (!process.env.CRON_SECRET) {
+  throw new Error("CRON_SECRET environment variable is not set");
+}
+
 const HEADER_NAME = "x-cron-secret";
 const WINDOW_MS = 60_000; // 1 minute
 initFirebase();


### PR DESCRIPTION
## Summary
- ensure housekeeping cron route fails to load if CRON_SECRET is unset
- dynamically import housekeeping route in tests after setting CRON_SECRET
- add test verifying import throws without CRON_SECRET

## Testing
- `npm test src/__tests__/housekeeping-route-env.test.ts src/__tests__/housekeeping-route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3693391648331bef56ce43a182534