### PR TITLE
Use consistent CRON_SECRET header casing

### DIFF
--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -89,7 +89,7 @@ describe("/api/cron/housekeeping", () => {
     expect(res1.status).toBe(401);
 
     const req2 = new Request("http://localhost", {
-      headers: { "x-cron-secret": "wrong" },
+      headers: { "X-CRON-SECRET": "wrong" },
     });
     const res2 = await GET(req2);
     expect(res2.status).toBe(401);
@@ -98,7 +98,7 @@ describe("/api/cron/housekeeping", () => {
 
   it("runs housekeeping with valid secret and enforces rate limit", async () => {
     const req = new Request("http://localhost", {
-      headers: { "x-cron-secret": secret },
+      headers: { "X-CRON-SECRET": secret },
     });
     const res1 = await GET(req);
     expect(res1.status).toBe(200);
@@ -111,7 +111,7 @@ describe("/api/cron/housekeeping", () => {
 
   it("prevents concurrent invocations", async () => {
     const req = new Request("http://localhost", {
-      headers: { "x-cron-secret": secret },
+      headers: { "X-CRON-SECRET": secret },
     });
 
     const [res1, res2] = await Promise.all([GET(req), GET(req)]);

--- a/src/app/api/cron/housekeeping/route.ts
+++ b/src/app/api/cron/housekeeping/route.ts
@@ -5,7 +5,7 @@ import { getCurrentTime } from "@/lib/internet-time";
 import { doc, runTransaction, setDoc } from "firebase/firestore";
 import { logger } from "@/lib/logger";
 
-const HEADER_NAME = "x-cron-secret";
+const HEADER_NAME = "X-CRON-SECRET";
 const WINDOW_MS = 60_000; // 1 minute
 initFirebase();
 const STATE_DOC = doc(db, "cron", "housekeeping");


### PR DESCRIPTION
## Summary
- Align housekeeping endpoint with documentation by expecting `X-CRON-SECRET`
- Update housekeeping route tests to send `X-CRON-SECRET`

## Testing
- `npm test src/__tests__/housekeeping-route.test.ts`
- `npm test` *(fails: Cannot use import statement outside a module in lucide-react)*
- `npm run lint` *(fails: ESLint errors such as 'AuthProvider' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b36935b9348331821a07e6845a38f8