### PR TITLE
Expand cost-of-living dataset and calculations

### DIFF
--- a/docs/cost-of-living-data.md
+++ b/docs/cost-of-living-data.md
@@ -1,0 +1,23 @@
+# Cost of Living Dataset
+
+This project derives metropolitan cost-of-living multipliers from the [Bureau of Economic Analysis (BEA) Regional Price Parities](https://www.bea.gov/data/prices-inflation/regional-price-parities-rpps).
+
+## Updating the dataset
+
+Run the update script annually after BEA releases new RPP figures:
+
+```bash
+npx ts-node scripts/update-cost-of-living.ts
+```
+
+The script downloads the latest BEA data and regenerates `src/data/costOfLivingYYYY.ts` with RPP multipliers for every U.S. metropolitan statistical area.
+
+## Using the data
+
+Import the generated dataset and look up a metro's multiplier to adjust baseline living costs:
+
+```ts
+import { costOfLiving2024 } from '@/data/costOfLiving2024';
+const seattle = costOfLiving2024.metros['Seattle-Tacoma-Bellevue, WA (Metropolitan Statistical Area)'];
+console.log(seattle.rpp);
+```

--- a/src/ai/flows/__tests__/cost-of-living.test.ts
+++ b/src/ai/flows/__tests__/cost-of-living.test.ts
@@ -1,17 +1,25 @@
 import { calculateCostOfLiving } from '@/ai/flows/cost-of-living';
 
 describe('calculateCostOfLiving', () => {
-  it('computes California household costs', () => {
-    const result = calculateCostOfLiving({ region: 'California', adults: 2, children: 1 });
-    expect(result.annual.total).toBeCloseTo(124700);
-    expect(result.monthly.total).toBeCloseTo(10391.67, 2);
-    expect(result.annual.categories.housing).toBeCloseTo(60000);
+  it('computes Abilene household costs', () => {
+    const result = calculateCostOfLiving({
+      metro: 'Abilene, TX (Metropolitan Statistical Area)',
+      adults: 2,
+      children: 1,
+    });
+    expect(result.annual.total).toBeCloseTo(98384.66, 1);
+    expect(result.monthly.total).toBeCloseTo(8198.72, 2);
+    expect(result.annual.categories.housing).toBeCloseTo(44924.5, 1);
   });
 
-  it('computes Texas household costs', () => {
-    const result = calculateCostOfLiving({ region: 'Texas', adults: 1, children: 2 });
-    expect(result.annual.total).toBeCloseTo(83400);
-    expect(result.monthly.total).toBeCloseTo(6950);
-    expect(result.annual.categories.groceries).toBeCloseTo(10800);
+  it('computes San Francisco household costs', () => {
+    const result = calculateCostOfLiving({
+      metro: 'San Francisco-Oakland-Berkeley, CA (Metropolitan Statistical Area)',
+      adults: 1,
+      children: 2,
+    });
+    expect(result.annual.total).toBeCloseTo(106402.5, 1);
+    expect(result.monthly.total).toBeCloseTo(8866.88, 2);
+    expect(result.annual.categories.groceries).toBeCloseTo(14187, 0);
   });
 });

--- a/src/ai/flows/__tests__/validation.test.ts
+++ b/src/ai/flows/__tests__/validation.test.ts
@@ -1,4 +1,4 @@
-import type { Region } from '@/data/costOfLiving2024';
+import type { MetroArea } from '@/data/costOfLiving2024';
 
 interface Schema<T = unknown> {
   parse: (value: unknown) => T;
@@ -104,19 +104,23 @@ describe('calculateCostOfLiving validation', () => {
   it('rejects non-positive adult count', async () => {
     const { calculateCostOfLiving } = await import('@/ai/flows/cost-of-living');
     expect(() =>
-      calculateCostOfLiving({ region: 'California', adults: 0, children: 0 })
+      calculateCostOfLiving({
+        metro: 'Abilene, TX (Metropolitan Statistical Area)',
+        adults: 0,
+        children: 0,
+      })
     ).toThrow();
   });
 
-  it('rejects unknown region', async () => {
+  it('rejects unknown metro', async () => {
     const { calculateCostOfLiving } = await import('@/ai/flows/cost-of-living');
     expect(() =>
       calculateCostOfLiving({
-        region: 'Atlantis' as unknown as Region,
+        metro: 'Atlantis' as unknown as MetroArea,
         adults: 1,
         children: 0,
       })
-    ).toThrow('Unknown region');
+    ).toThrow('Unknown metro');
   });
 });
 

--- a/src/ai/flows/cost-of-living.ts
+++ b/src/ai/flows/cost-of-living.ts
@@ -1,7 +1,16 @@
-import { costOfLiving2024, Region, RegionCost } from '@/data/costOfLiving2024';
+import { costOfLiving2024, MetroArea } from '@/data/costOfLiving2024';
+
+export interface RegionCost {
+  housing: number;
+  groceries: number;
+  utilities: number;
+  transportation: number;
+  healthcare: number;
+  miscellaneous: number;
+}
 
 export interface CalculateCostOfLivingInput {
-  region: Region;
+  metro: MetroArea;
   adults: number;
   children: number;
 }
@@ -10,6 +19,15 @@ export interface CostOfLivingBreakdown {
   monthly: { total: number; categories: RegionCost };
   annual: { total: number; categories: RegionCost };
 }
+
+const BASELINE_COSTS: RegionCost = {
+  housing: 20000,
+  groceries: 5000,
+  utilities: 3000,
+  transportation: 6000,
+  healthcare: 5000,
+  miscellaneous: 4000,
+};
 
 const CHILD_MULTIPLIERS: Record<keyof RegionCost, number> = {
   housing: 0.5,
@@ -20,18 +38,19 @@ const CHILD_MULTIPLIERS: Record<keyof RegionCost, number> = {
   miscellaneous: 0.5,
 };
 
-export function calculateCostOfLiving({ region, adults, children }: CalculateCostOfLivingInput): CostOfLivingBreakdown {
+export function calculateCostOfLiving({ metro, adults, children }: CalculateCostOfLivingInput): CostOfLivingBreakdown {
   if (adults <= 0 || children < 0) {
     throw new Error('Invalid household composition');
   }
-  const base = costOfLiving2024.regions[region];
-  if (!base) {
-    throw new Error(`Unknown region: ${region}`);
+  const metroInfo = costOfLiving2024.metros[metro];
+  if (!metroInfo) {
+    throw new Error(`Unknown metro: ${metro}`);
   }
 
-  const annualCategories = Object.keys(base).reduce((acc, key) => {
+  const annualCategories = Object.keys(BASELINE_COSTS).reduce((acc, key) => {
     const k = key as keyof RegionCost;
-    const amount = base[k] * adults + base[k] * CHILD_MULTIPLIERS[k] * children;
+    const base = BASELINE_COSTS[k] * metroInfo.rpp;
+    const amount = base * adults + base * CHILD_MULTIPLIERS[k] * children;
     acc[k] = amount;
     return acc;
   }, {} as RegionCost);

--- a/src/app/cost-of-living/page.tsx
+++ b/src/app/cost-of-living/page.tsx
@@ -16,8 +16,8 @@ import {
 } from '@/components/ui/select';
 
 export default function CostOfLivingPage() {
-  const regions = Object.keys(costOfLiving2024.regions);
-  const [region, setRegion] = useState(regions[0]);
+  const metros = Object.keys(costOfLiving2024.metros);
+  const [metro, setMetro] = useState(metros[0]);
   const [adults, setAdults] = useState(1);
   const [children, setChildren] = useState(0);
   const [result, setResult] = useState<CostOfLivingBreakdown | null>(null);
@@ -25,7 +25,7 @@ export default function CostOfLivingPage() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const breakdown = calculateCostOfLiving({
-      region: region as keyof typeof costOfLiving2024.regions,
+      metro: metro as keyof typeof costOfLiving2024.metros,
       adults,
       children,
     });
@@ -37,7 +37,7 @@ export default function CostOfLivingPage() {
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Cost of Living</h1>
         <p className="text-muted-foreground">
-          Estimate household expenses by region.
+          Estimate household expenses by metro area.
         </p>
       </div>
       <Card>
@@ -47,15 +47,15 @@ export default function CostOfLivingPage() {
         <CardContent>
           <form onSubmit={handleSubmit} className="grid gap-4 sm:grid-cols-3">
             <div className="space-y-2">
-              <Label htmlFor="region">Region</Label>
-              <Select value={region} onValueChange={setRegion}>
-                <SelectTrigger id="region">
-                  <SelectValue placeholder="Select region" />
+              <Label htmlFor="metro">Metro Area</Label>
+              <Select value={metro} onValueChange={setMetro}>
+                <SelectTrigger id="metro">
+                  <SelectValue placeholder="Select metro" />
                 </SelectTrigger>
                 <SelectContent>
-                  {regions.map((r) => (
-                    <SelectItem key={r} value={r}>
-                      {r}
+                  {metros.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      {m}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/data/costOfLiving2024.ts
+++ b/src/data/costOfLiving2024.ts
@@ -1,39 +1,1168 @@
-export interface RegionCost {
-  housing: number;
-  groceries: number;
-  utilities: number;
-  transportation: number;
-  healthcare: number;
-  miscellaneous: number;
-}
-
-export interface CostOfLivingDataset {
-  baseYear: number;
-  source: string;
-  regions: Record<string, RegionCost>;
-}
-
-export const costOfLiving2024: CostOfLivingDataset = {
+export interface MetroCost { rpp: number; }
+export interface CostOfLivingDataset { baseYear: number; source: string; metros: Record<string, MetroCost>; }
+export const costOfLiving2024 : CostOfLivingDataset = {
   baseYear: 2025,
-  source: 'BEA Regional Price Parities 2024',
-  regions: {
-    California: {
-      housing: 24000,
-      groceries: 5000,
-      utilities: 3000,
-      transportation: 7000,
-      healthcare: 6000,
-      miscellaneous: 4000,
-    },
-    Texas: {
-      housing: 18000,
-      groceries: 4500,
-      utilities: 2800,
-      transportation: 6000,
-      healthcare: 5000,
-      miscellaneous: 3500,
-    },
+  source: 'BEA Regional Price Parities 2023',
+  metros: {
+  "United States": {
+    "rpp": 1
   },
+  "United States (Nonmetropolitan Portion)": {
+    "rpp": 0.8822199999999999
+  },
+  "Abilene, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.89849
+  },
+  "Akron, OH (Metropolitan Statistical Area)": {
+    "rpp": 0.9282699999999999
+  },
+  "Albany, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.86405
+  },
+  "Albany-Lebanon, OR (Metropolitan Statistical Area)": {
+    "rpp": 1.04609
+  },
+  "Albany-Schenectady-Troy, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.97583
+  },
+  "Albuquerque, NM (Metropolitan Statistical Area)": {
+    "rpp": 0.92958
+  },
+  "Alexandria, LA (Metropolitan Statistical Area)": {
+    "rpp": 0.8621800000000001
+  },
+  "Allentown-Bethlehem-Easton, PA-NJ (Metropolitan Statistical Area)": {
+    "rpp": 0.98441
+  },
+  "Altoona, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.8825
+  },
+  "Amarillo, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.9081199999999999
+  },
+  "Ames, IA (Metropolitan Statistical Area)": {
+    "rpp": 0.9141800000000001
+  },
+  "Anchorage, AK (Metropolitan Statistical Area)": {
+    "rpp": 1.04547
+  },
+  "Ann Arbor, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.97968
+  },
+  "Anniston-Oxford, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.8721800000000001
+  },
+  "Appleton, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.93597
+  },
+  "Asheville, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.9612900000000001
+  },
+  "Athens-Clarke County, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.93278
+  },
+  "Atlanta-Sandy Springs-Alpharetta, GA (Metropolitan Statistical Area)": {
+    "rpp": 1.00933
+  },
+  "Atlantic City-Hammonton, NJ (Metropolitan Statistical Area)": {
+    "rpp": 0.9717
+  },
+  "Auburn-Opelika, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.88857
+  },
+  "Augusta-Richmond County, GA-SC (Metropolitan Statistical Area)": {
+    "rpp": 0.9103
+  },
+  "Austin-Round Rock-Georgetown, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.9762000000000001
+  },
+  "Bakersfield, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.02247
+  },
+  "Baltimore-Columbia-Towson, MD (Metropolitan Statistical Area)": {
+    "rpp": 1.02672
+  },
+  "Bangor, ME (Metropolitan Statistical Area)": {
+    "rpp": 0.9146599999999999
+  },
+  "Barnstable Town, MA (Metropolitan Statistical Area)": {
+    "rpp": 1.05815
+  },
+  "Baton Rouge, LA (Metropolitan Statistical Area)": {
+    "rpp": 0.90802
+  },
+  "Battle Creek, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.88228
+  },
+  "Bay City, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.90565
+  },
+  "Beaumont-Port Arthur, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.90238
+  },
+  "Beckley, WV (Metropolitan Statistical Area)": {
+    "rpp": 0.89644
+  },
+  "Bellingham, WA (Metropolitan Statistical Area)": {
+    "rpp": 1.04139
+  },
+  "Bend, OR (Metropolitan Statistical Area)": {
+    "rpp": 1.0581
+  },
+  "Billings, MT (Metropolitan Statistical Area)": {
+    "rpp": 0.89613
+  },
+  "Binghamton, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.9163
+  },
+  "Birmingham-Hoover, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.92569
+  },
+  "Bismarck, ND (Metropolitan Statistical Area)": {
+    "rpp": 0.8964799999999999
+  },
+  "Blacksburg-Christiansburg, VA (Metropolitan Statistical Area)": {
+    "rpp": 0.90657
+  },
+  "Bloomington, IL (Metropolitan Statistical Area)": {
+    "rpp": 0.92002
+  },
+  "Bloomington, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.93372
+  },
+  "Bloomsburg-Berwick, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9034
+  },
+  "Boise City, ID (Metropolitan Statistical Area)": {
+    "rpp": 0.93427
+  },
+  "Boston-Cambridge-Newton, MA-NH (Metropolitan Statistical Area)": {
+    "rpp": 1.11574
+  },
+  "Boulder, CO (Metropolitan Statistical Area)": {
+    "rpp": 0.99851
+  },
+  "Bowling Green, KY (Metropolitan Statistical Area)": {
+    "rpp": 0.9051699999999999
+  },
+  "Bremerton-Silverdale-Port Orchard, WA (Metropolitan Statistical Area)": {
+    "rpp": 1.07541
+  },
+  "Bridgeport-Stamford-Norwalk, CT (Metropolitan Statistical Area)": {
+    "rpp": 1.0648600000000001
+  },
+  "Brownsville-Harlingen, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.8518300000000001
+  },
+  "Brunswick, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.8970999999999999
+  },
+  "Buffalo-Cheektowaga, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.94393
+  },
+  "Burlington, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.9274800000000001
+  },
+  "Burlington-South Burlington, VT (Metropolitan Statistical Area)": {
+    "rpp": 1.0004
+  },
+  "California-Lexington Park, MD (Metropolitan Statistical Area)": {
+    "rpp": 1.00247
+  },
+  "Canton-Massillon, OH (Metropolitan Statistical Area)": {
+    "rpp": 0.88539
+  },
+  "Cape Coral-Fort Myers, FL (Metropolitan Statistical Area)": {
+    "rpp": 1.02565
+  },
+  "Cape Girardeau, MO-IL (Metropolitan Statistical Area)": {
+    "rpp": 0.86324
+  },
+  "Carbondale-Marion, IL (Metropolitan Statistical Area)": {
+    "rpp": 0.8724299999999999
+  },
+  "Carson City, NV (Metropolitan Statistical Area)": {
+    "rpp": 0.94056
+  },
+  "Casper, WY (Metropolitan Statistical Area)": {
+    "rpp": 0.91833
+  },
+  "Cedar Rapids, IA (Metropolitan Statistical Area)": {
+    "rpp": 0.89959
+  },
+  "Chambersburg-Waynesboro, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9392499999999999
+  },
+  "Champaign-Urbana, IL (Metropolitan Statistical Area)": {
+    "rpp": 0.90826
+  },
+  "Charleston, WV (Metropolitan Statistical Area)": {
+    "rpp": 0.88389
+  },
+  "Charleston-North Charleston, SC (Metropolitan Statistical Area)": {
+    "rpp": 1.00639
+  },
+  "Charlotte-Concord-Gastonia, NC-SC (Metropolitan Statistical Area)": {
+    "rpp": 0.96979
+  },
+  "Charlottesville, VA (Metropolitan Statistical Area)": {
+    "rpp": 0.9859300000000001
+  },
+  "Chattanooga, TN-GA (Metropolitan Statistical Area)": {
+    "rpp": 0.92794
+  },
+  "Cheyenne, WY (Metropolitan Statistical Area)": {
+    "rpp": 0.9093000000000001
+  },
+  "Chicago-Naperville-Elgin, IL-IN-WI (Metropolitan Statistical Area)": {
+    "rpp": 1.02557
+  },
+  "Chico, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.04616
+  },
+  "Cincinnati, OH-KY-IN (Metropolitan Statistical Area)": {
+    "rpp": 0.9410200000000001
+  },
+  "Clarksville, TN-KY (Metropolitan Statistical Area)": {
+    "rpp": 0.92148
+  },
+  "Cleveland, TN (Metropolitan Statistical Area)": {
+    "rpp": 0.90876
+  },
+  "Cleveland-Elyria, OH (Metropolitan Statistical Area)": {
+    "rpp": 0.93045
+  },
+  "Coeur d'Alene, ID (Metropolitan Statistical Area)": {
+    "rpp": 0.96883
+  },
+  "College Station-Bryan, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.90701
+  },
+  "Colorado Springs, CO (Metropolitan Statistical Area)": {
+    "rpp": 0.9741
+  },
+  "Columbia, MO (Metropolitan Statistical Area)": {
+    "rpp": 0.8928
+  },
+  "Columbia, SC (Metropolitan Statistical Area)": {
+    "rpp": 0.92925
+  },
+  "Columbus, GA-AL (Metropolitan Statistical Area)": {
+    "rpp": 0.8879600000000001
+  },
+  "Columbus, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.9031199999999999
+  },
+  "Columbus, OH (Metropolitan Statistical Area)": {
+    "rpp": 0.94516
+  },
+  "Corpus Christi, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.91306
+  },
+  "Corvallis, OR (Metropolitan Statistical Area)": {
+    "rpp": 1.06358
+  },
+  "Crestview-Fort Walton Beach-Destin, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.9799
+  },
+  "Cumberland, MD-WV (Metropolitan Statistical Area)": {
+    "rpp": 0.8582
+  },
+  "Dallas-Fort Worth-Arlington, TX (Metropolitan Statistical Area)": {
+    "rpp": 1.0329300000000001
+  },
+  "Dalton, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.90276
+  },
+  "Danville, IL (Metropolitan Statistical Area)": {
+    "rpp": 0.86824
+  },
+  "Daphne-Fairhope-Foley, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.94726
+  },
+  "Davenport-Moline-Rock Island, IA-IL (Metropolitan Statistical Area)": {
+    "rpp": 0.89274
+  },
+  "Dayton-Kettering, OH (Metropolitan Statistical Area)": {
+    "rpp": 0.92289
+  },
+  "Decatur, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.90096
+  },
+  "Decatur, IL (Metropolitan Statistical Area)": {
+    "rpp": 0.86604
+  },
+  "Deltona-Daytona Beach-Ormond Beach, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.9874200000000001
+  },
+  "Denver-Aurora-Lakewood, CO (Metropolitan Statistical Area)": {
+    "rpp": 1.0549
+  },
+  "Des Moines-West Des Moines, IA (Metropolitan Statistical Area)": {
+    "rpp": 0.92659
+  },
+  "Detroit-Warren-Dearborn, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.98007
+  },
+  "Dothan, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.88318
+  },
+  "Dover, DE (Metropolitan Statistical Area)": {
+    "rpp": 0.91652
+  },
+  "Dubuque, IA (Metropolitan Statistical Area)": {
+    "rpp": 0.89056
+  },
+  "Duluth, MN-WI (Metropolitan Statistical Area)": {
+    "rpp": 0.8698
+  },
+  "Durham-Chapel Hill, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.96638
+  },
+  "East Stroudsburg, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9565600000000001
+  },
+  "Eau Claire, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.91405
+  },
+  "El Centro, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.0008
+  },
+  "Elizabethtown-Fort Knox, KY (Metropolitan Statistical Area)": {
+    "rpp": 0.89386
+  },
+  "Elkhart-Goshen, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.9257299999999999
+  },
+  "Elmira, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.9220099999999999
+  },
+  "El Paso, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.90241
+  },
+  "Enid, OK (Metropolitan Statistical Area) *": {
+    "rpp": 0.86142
+  },
+  "Erie, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9151600000000001
+  },
+  "Eugene-Springfield, OR (Metropolitan Statistical Area)": {
+    "rpp": 1.03481
+  },
+  "Evansville, IN-KY (Metropolitan Statistical Area)": {
+    "rpp": 0.89763
+  },
+  "Fairbanks, AK (Metropolitan Statistical Area)": {
+    "rpp": 0.99362
+  },
+  "Fargo, ND-MN (Metropolitan Statistical Area)": {
+    "rpp": 0.8941
+  },
+  "Farmington, NM (Metropolitan Statistical Area)": {
+    "rpp": 0.8652
+  },
+  "Fayetteville, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.91385
+  },
+  "Fayetteville-Springdale-Rogers, AR (Metropolitan Statistical Area)": {
+    "rpp": 0.90957
+  },
+  "Flagstaff, AZ (Metropolitan Statistical Area)": {
+    "rpp": 0.9127
+  },
+  "Flint, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.89833
+  },
+  "Florence, SC (Metropolitan Statistical Area)": {
+    "rpp": 0.87997
+  },
+  "Florence-Muscle Shoals, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.8561799999999999
+  },
+  "Fond du Lac, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.92837
+  },
+  "Fort Collins, CO (Metropolitan Statistical Area)": {
+    "rpp": 0.9661799999999999
+  },
+  "Fort Smith, AR-OK (Metropolitan Statistical Area)": {
+    "rpp": 0.8506199999999999
+  },
+  "Fort Wayne, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.8998
+  },
+  "Fresno, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.03988
+  },
+  "Gadsden, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.8702
+  },
+  "Gainesville, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.96895
+  },
+  "Gainesville, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.96097
+  },
+  "Gettysburg, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9272400000000001
+  },
+  "Glens Falls, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.9355100000000001
+  },
+  "Goldsboro, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.8973099999999999
+  },
+  "Grand Forks, ND-MN (Metropolitan Statistical Area)": {
+    "rpp": 0.8619499999999999
+  },
+  "Grand Island, NE (Metropolitan Statistical Area)": {
+    "rpp": 0.87262
+  },
+  "Grand Junction, CO (Metropolitan Statistical Area)": {
+    "rpp": 0.92131
+  },
+  "Grand Rapids-Kentwood, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.9518899999999999
+  },
+  "Grants Pass, OR (Metropolitan Statistical Area)": {
+    "rpp": 1.00709
+  },
+  "Great Falls, MT (Metropolitan Statistical Area)": {
+    "rpp": 0.92596
+  },
+  "Greeley, CO (Metropolitan Statistical Area)": {
+    "rpp": 0.95987
+  },
+  "Green Bay, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.9206399999999999
+  },
+  "Greensboro-High Point, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.9268000000000001
+  },
+  "Greenville, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.9161199999999999
+  },
+  "Greenville-Anderson, SC (Metropolitan Statistical Area)": {
+    "rpp": 0.92778
+  },
+  "Gulfport-Biloxi, MS (Metropolitan Statistical Area)": {
+    "rpp": 0.89345
+  },
+  "Hagerstown-Martinsburg, MD-WV (Metropolitan Statistical Area)": {
+    "rpp": 0.9514900000000001
+  },
+  "Hammond, LA (Metropolitan Statistical Area)": {
+    "rpp": 0.8751000000000001
+  },
+  "Hanford-Corcoran, CA (Metropolitan Statistical Area)": {
+    "rpp": 0.9841500000000001
+  },
+  "Harrisburg-Carlisle, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.96525
+  },
+  "Harrisonburg, VA (Metropolitan Statistical Area)": {
+    "rpp": 0.93218
+  },
+  "Hartford-East Hartford-Middletown, CT (Metropolitan Statistical Area)": {
+    "rpp": 1.02568
+  },
+  "Hattiesburg, MS (Metropolitan Statistical Area)": {
+    "rpp": 0.89303
+  },
+  "Hickory-Lenoir-Morganton, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.8922100000000001
+  },
+  "Hilton Head Island-Bluffton, SC (Metropolitan Statistical Area)": {
+    "rpp": 0.95654
+  },
+  "Hinesville, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.93888
+  },
+  "Homosassa Springs, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.9543300000000001
+  },
+  "Hot Springs, AR (Metropolitan Statistical Area)": {
+    "rpp": 0.85801
+  },
+  "Houma-Thibodaux, LA (Metropolitan Statistical Area)": {
+    "rpp": 0.88583
+  },
+  "Houston-The Woodlands-Sugar Land, TX (Metropolitan Statistical Area)": {
+    "rpp": 1.0022
+  },
+  "Huntington-Ashland, WV-KY-OH (Metropolitan Statistical Area)": {
+    "rpp": 0.88435
+  },
+  "Huntsville, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.9439700000000001
+  },
+  "Idaho Falls, ID (Metropolitan Statistical Area)": {
+    "rpp": 0.8994599999999999
+  },
+  "Indianapolis-Carmel-Anderson, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.9457800000000001
+  },
+  "Iowa City, IA (Metropolitan Statistical Area)": {
+    "rpp": 0.9183
+  },
+  "Ithaca, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.9892400000000001
+  },
+  "Jackson, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.92732
+  },
+  "Jackson, MS (Metropolitan Statistical Area)": {
+    "rpp": 0.90671
+  },
+  "Jackson, TN (Metropolitan Statistical Area)": {
+    "rpp": 0.8727800000000001
+  },
+  "Jacksonville, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.9921599999999999
+  },
+  "Jacksonville, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.91584
+  },
+  "Janesville-Beloit, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.91393
+  },
+  "Jefferson City, MO (Metropolitan Statistical Area)": {
+    "rpp": 0.87681
+  },
+  "Johnson City, TN (Metropolitan Statistical Area)": {
+    "rpp": 0.88872
+  },
+  "Johnstown, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.88064
+  },
+  "Jonesboro, AR (Metropolitan Statistical Area)": {
+    "rpp": 0.8568600000000001
+  },
+  "Joplin, MO (Metropolitan Statistical Area)": {
+    "rpp": 0.8564799999999999
+  },
+  "Kahului-Wailuku-Lahaina, HI (Metropolitan Statistical Area)": {
+    "rpp": 1.0628
+  },
+  "Kalamazoo-Portage, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.93979
+  },
+  "Kankakee, IL (Metropolitan Statistical Area)": {
+    "rpp": 0.9230700000000001
+  },
+  "Kansas City, MO-KS (Metropolitan Statistical Area)": {
+    "rpp": 0.93266
+  },
+  "Kennewick-Richland, WA (Metropolitan Statistical Area)": {
+    "rpp": 0.98988
+  },
+  "Killeen-Temple, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.9176099999999999
+  },
+  "Kingsport-Bristol, TN-VA (Metropolitan Statistical Area)": {
+    "rpp": 0.85354
+  },
+  "Kingston, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.9897
+  },
+  "Knoxville, TN (Metropolitan Statistical Area)": {
+    "rpp": 0.9277299999999999
+  },
+  "Kokomo, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.89666
+  },
+  "La Crosse-Onalaska, WI-MN (Metropolitan Statistical Area)": {
+    "rpp": 0.91291
+  },
+  "Lafayette, LA (Metropolitan Statistical Area)": {
+    "rpp": 0.8701000000000001
+  },
+  "Lafayette-West Lafayette, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.91524
+  },
+  "Lake Charles, LA (Metropolitan Statistical Area)": {
+    "rpp": 0.86749
+  },
+  "Lake Havasu City-Kingman, AZ (Metropolitan Statistical Area)": {
+    "rpp": 0.8989499999999999
+  },
+  "Lakeland-Winter Haven, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.9737399999999999
+  },
+  "Lancaster, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9630500000000001
+  },
+  "Lansing-East Lansing, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.9284600000000001
+  },
+  "Laredo, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.87786
+  },
+  "Las Cruces, NM (Metropolitan Statistical Area)": {
+    "rpp": 0.8934799999999999
+  },
+  "Las Vegas-Henderson-Paradise, NV (Metropolitan Statistical Area)": {
+    "rpp": 0.9740099999999999
+  },
+  "Lawrence, KS (Metropolitan Statistical Area)": {
+    "rpp": 0.9098900000000001
+  },
+  "Lawton, OK (Metropolitan Statistical Area)": {
+    "rpp": 0.87627
+  },
+  "Lebanon, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9533
+  },
+  "Lewiston, ID-WA (Metropolitan Statistical Area)": {
+    "rpp": 0.8720300000000001
+  },
+  "Lewiston-Auburn, ME (Metropolitan Statistical Area)": {
+    "rpp": 1.00109
+  },
+  "Lexington-Fayette, KY (Metropolitan Statistical Area)": {
+    "rpp": 0.9311
+  },
+  "Lima, OH (Metropolitan Statistical Area)": {
+    "rpp": 0.8758499999999999
+  },
+  "Lincoln, NE (Metropolitan Statistical Area)": {
+    "rpp": 0.9195
+  },
+  "Little Rock-North Little Rock-Conway, AR (Metropolitan Statistical Area)": {
+    "rpp": 0.8909199999999999
+  },
+  "Logan, UT-ID (Metropolitan Statistical Area)": {
+    "rpp": 0.9291200000000001
+  },
+  "Longview, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.88417
+  },
+  "Longview, WA (Metropolitan Statistical Area)": {
+    "rpp": 0.99411
+  },
+  "Los Angeles-Long Beach-Anaheim, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.15455
+  },
+  "Louisville/Jefferson County, KY-IN (Metropolitan Statistical Area)": {
+    "rpp": 0.94018
+  },
+  "Lubbock, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.90869
+  },
+  "Lynchburg, VA (Metropolitan Statistical Area)": {
+    "rpp": 0.9028400000000001
+  },
+  "Macon-Bibb County, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.90039
+  },
+  "Madera, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.02948
+  },
+  "Madison, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.95786
+  },
+  "Manchester-Nashua, NH (Metropolitan Statistical Area)": {
+    "rpp": 1.05074
+  },
+  "Manhattan, KS (Metropolitan Statistical Area)": {
+    "rpp": 0.9025799999999999
+  },
+  "Mankato, MN (Metropolitan Statistical Area)": {
+    "rpp": 0.87637
+  },
+  "Mansfield, OH (Metropolitan Statistical Area)": {
+    "rpp": 0.86616
+  },
+  "McAllen-Edinburg-Mission, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.85555
+  },
+  "Medford, OR (Metropolitan Statistical Area)": {
+    "rpp": 1.03349
+  },
+  "Memphis, TN-MS-AR (Metropolitan Statistical Area)": {
+    "rpp": 0.92427
+  },
+  "Merced, CA (Metropolitan Statistical Area)": {
+    "rpp": 0.99517
+  },
+  "Miami-Fort Lauderdale-Pompano Beach, FL (Metropolitan Statistical Area)": {
+    "rpp": 1.11824
+  },
+  "Michigan City-La Porte, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.92071
+  },
+  "Midland, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.90565
+  },
+  "Midland, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.94761
+  },
+  "Milwaukee-Waukesha, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.95536
+  },
+  "Minneapolis-St. Paul-Bloomington, MN-WI (Metropolitan Statistical Area)": {
+    "rpp": 1.04509
+  },
+  "Missoula, MT (Metropolitan Statistical Area)": {
+    "rpp": 0.93107
+  },
+  "Mobile, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.8941800000000001
+  },
+  "Modesto, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.04962
+  },
+  "Monroe, LA (Metropolitan Statistical Area)": {
+    "rpp": 0.83601
+  },
+  "Monroe, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.93214
+  },
+  "Montgomery, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.9075700000000001
+  },
+  "Morgantown, WV (Metropolitan Statistical Area)": {
+    "rpp": 0.9227500000000001
+  },
+  "Morristown, TN (Metropolitan Statistical Area)": {
+    "rpp": 0.87712
+  },
+  "Mount Vernon-Anacortes, WA (Metropolitan Statistical Area)": {
+    "rpp": 1.06018
+  },
+  "Muncie, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.88802
+  },
+  "Muskegon, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.91683
+  },
+  "Myrtle Beach-Conway-North Myrtle Beach, SC-NC (Metropolitan Statistical Area)": {
+    "rpp": 0.92818
+  },
+  "Napa, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.1177
+  },
+  "Naples-Marco Island, FL (Metropolitan Statistical Area)": {
+    "rpp": 1.05811
+  },
+  "Nashville-Davidson--Murfreesboro--Franklin, TN (Metropolitan Statistical Area)": {
+    "rpp": 0.9743
+  },
+  "New Bern, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.89945
+  },
+  "New Haven-Milford, CT (Metropolitan Statistical Area)": {
+    "rpp": 1.03502
+  },
+  "New Orleans-Metairie, LA (Metropolitan Statistical Area)": {
+    "rpp": 0.91146
+  },
+  "New York-Newark-Jersey City, NY-NJ-PA (Metropolitan Statistical Area)": {
+    "rpp": 1.12473
+  },
+  "Niles, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.8967700000000001
+  },
+  "North Port-Sarasota-Bradenton, FL (Metropolitan Statistical Area)": {
+    "rpp": 1.03635
+  },
+  "Norwich-New London, CT (Metropolitan Statistical Area)": {
+    "rpp": 1.0042
+  },
+  "Ocala, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.95506
+  },
+  "Ocean City, NJ (Metropolitan Statistical Area)": {
+    "rpp": 1.01471
+  },
+  "Odessa, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.9205599999999999
+  },
+  "Ogden-Clearfield, UT (Metropolitan Statistical Area)": {
+    "rpp": 0.95132
+  },
+  "Oklahoma City, OK (Metropolitan Statistical Area)": {
+    "rpp": 0.9097799999999999
+  },
+  "Olympia-Lacey-Tumwater, WA (Metropolitan Statistical Area)": {
+    "rpp": 1.06477
+  },
+  "Omaha-Council Bluffs, NE-IA (Metropolitan Statistical Area)": {
+    "rpp": 0.9251900000000001
+  },
+  "Orlando-Kissimmee-Sanford, FL (Metropolitan Statistical Area)": {
+    "rpp": 1.01109
+  },
+  "Oshkosh-Neenah, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.90692
+  },
+  "Owensboro, KY (Metropolitan Statistical Area)": {
+    "rpp": 0.90034
+  },
+  "Oxnard-Thousand Oaks-Ventura, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.1347
+  },
+  "Palm Bay-Melbourne-Titusville, FL (Metropolitan Statistical Area)": {
+    "rpp": 1.0083799999999998
+  },
+  "Panama City, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.9798
+  },
+  "Parkersburg-Vienna, WV (Metropolitan Statistical Area)": {
+    "rpp": 0.8821899999999999
+  },
+  "Pensacola-Ferry Pass-Brent, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.9556
+  },
+  "Peoria, IL (Metropolitan Statistical Area)": {
+    "rpp": 0.88617
+  },
+  "Philadelphia-Camden-Wilmington, PA-NJ-DE-MD (Metropolitan Statistical Area)": {
+    "rpp": 1.03547
+  },
+  "Phoenix-Mesa-Chandler, AZ (Metropolitan Statistical Area)": {
+    "rpp": 1.05524
+  },
+  "Pine Bluff, AR (Metropolitan Statistical Area)": {
+    "rpp": 0.80325
+  },
+  "Pittsburgh, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9444199999999999
+  },
+  "Pittsfield, MA (Metropolitan Statistical Area)": {
+    "rpp": 0.92967
+  },
+  "Pocatello, ID (Metropolitan Statistical Area)": {
+    "rpp": 0.87752
+  },
+  "Portland-South Portland, ME (Metropolitan Statistical Area)": {
+    "rpp": 1.0359699999999998
+  },
+  "Portland-Vancouver-Hillsboro, OR-WA (Metropolitan Statistical Area)": {
+    "rpp": 1.06615
+  },
+  "Port St. Lucie, FL (Metropolitan Statistical Area)": {
+    "rpp": 1.01675
+  },
+  "Poughkeepsie-Newburgh-Middletown, NY (Metropolitan Statistical Area) *": {
+    "rpp": 1.09728
+  },
+  "Prescott Valley-Prescott, AZ (Metropolitan Statistical Area)": {
+    "rpp": 0.95026
+  },
+  "Providence-Warwick, RI-MA (Metropolitan Statistical Area)": {
+    "rpp": 1.0086199999999999
+  },
+  "Provo-Orem, UT (Metropolitan Statistical Area)": {
+    "rpp": 0.9502299999999999
+  },
+  "Pueblo, CO (Metropolitan Statistical Area)": {
+    "rpp": 0.9239700000000001
+  },
+  "Punta Gorda, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.98437
+  },
+  "Racine, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.95038
+  },
+  "Raleigh-Cary, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.97989
+  },
+  "Rapid City, SD (Metropolitan Statistical Area)": {
+    "rpp": 0.90315
+  },
+  "Reading, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9601900000000001
+  },
+  "Redding, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.02836
+  },
+  "Reno, NV (Metropolitan Statistical Area)": {
+    "rpp": 0.9744799999999999
+  },
+  "Richmond, VA (Metropolitan Statistical Area)": {
+    "rpp": 0.97988
+  },
+  "Riverside-San Bernardino-Ontario, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.07929
+  },
+  "Roanoke, VA (Metropolitan Statistical Area)": {
+    "rpp": 0.90944
+  },
+  "Rochester, MN (Metropolitan Statistical Area)": {
+    "rpp": 0.9311400000000001
+  },
+  "Rochester, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.97667
+  },
+  "Rockford, IL (Metropolitan Statistical Area)": {
+    "rpp": 0.90067
+  },
+  "Rocky Mount, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.88237
+  },
+  "Rome, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.90223
+  },
+  "Sacramento-Roseville-Folsom, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.08888
+  },
+  "Saginaw, MI (Metropolitan Statistical Area)": {
+    "rpp": 0.8926000000000001
+  },
+  "St. Cloud, MN (Metropolitan Statistical Area)": {
+    "rpp": 0.89333
+  },
+  "St. George, UT (Metropolitan Statistical Area)": {
+    "rpp": 0.96063
+  },
+  "St. Joseph, MO-KS (Metropolitan Statistical Area)": {
+    "rpp": 0.87803
+  },
+  "St. Louis, MO-IL (Metropolitan Statistical Area)": {
+    "rpp": 0.96312
+  },
+  "Salem, OR (Metropolitan Statistical Area)": {
+    "rpp": 1.0241
+  },
+  "Salinas, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.12988
+  },
+  "Salisbury, MD-DE (Metropolitan Statistical Area)": {
+    "rpp": 0.9512
+  },
+  "Salt Lake City, UT (Metropolitan Statistical Area)": {
+    "rpp": 0.96404
+  },
+  "San Angelo, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.90869
+  },
+  "San Antonio-New Braunfels, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.93727
+  },
+  "San Diego-Chula Vista-Carlsbad, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.11491
+  },
+  "San Francisco-Oakland-Berkeley, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.18225
+  },
+  "San Jose-Sunnyvale-Santa Clara, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.12867
+  },
+  "San Luis Obispo-Paso Robles, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.10819
+  },
+  "Santa Cruz-Watsonville, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.1259000000000001
+  },
+  "Santa Fe, NM (Metropolitan Statistical Area)": {
+    "rpp": 0.9337000000000001
+  },
+  "Santa Maria-Santa Barbara, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.1348799999999999
+  },
+  "Santa Rosa-Petaluma, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.10084
+  },
+  "Savannah, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.95569
+  },
+  "Scranton--Wilkes-Barre, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9296800000000001
+  },
+  "Seattle-Tacoma-Bellevue, WA (Metropolitan Statistical Area)": {
+    "rpp": 1.12991
+  },
+  "Sebastian-Vero Beach, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.96919
+  },
+  "Sebring-Avon Park, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.91278
+  },
+  "Sheboygan, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.90765
+  },
+  "Sherman-Denison, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.91804
+  },
+  "Shreveport-Bossier City, LA (Metropolitan Statistical Area)": {
+    "rpp": 0.87128
+  },
+  "Sierra Vista-Douglas, AZ (Metropolitan Statistical Area)": {
+    "rpp": 0.86678
+  },
+  "Sioux City, IA-NE-SD (Metropolitan Statistical Area)": {
+    "rpp": 0.8814799999999999
+  },
+  "Sioux Falls, SD (Metropolitan Statistical Area)": {
+    "rpp": 0.9028100000000001
+  },
+  "South Bend-Mishawaka, IN-MI (Metropolitan Statistical Area)": {
+    "rpp": 0.91415
+  },
+  "Spartanburg, SC (Metropolitan Statistical Area)": {
+    "rpp": 0.90648
+  },
+  "Spokane-Spokane Valley, WA (Metropolitan Statistical Area)": {
+    "rpp": 1.01031
+  },
+  "Springfield, IL (Metropolitan Statistical Area)": {
+    "rpp": 0.90549
+  },
+  "Springfield, MA (Metropolitan Statistical Area)": {
+    "rpp": 0.98422
+  },
+  "Springfield, MO (Metropolitan Statistical Area)": {
+    "rpp": 0.8927200000000001
+  },
+  "Springfield, OH (Metropolitan Statistical Area)": {
+    "rpp": 0.8866700000000001
+  },
+  "State College, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.9322400000000001
+  },
+  "Staunton, VA (Metropolitan Statistical Area)": {
+    "rpp": 0.9259499999999999
+  },
+  "Stockton, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.0742
+  },
+  "Sumter, SC (Metropolitan Statistical Area)": {
+    "rpp": 0.8625
+  },
+  "Syracuse, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.95174
+  },
+  "Tallahassee, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.9528
+  },
+  "Tampa-St. Petersburg-Clearwater, FL (Metropolitan Statistical Area)": {
+    "rpp": 1.03433
+  },
+  "Terre Haute, IN (Metropolitan Statistical Area)": {
+    "rpp": 0.88224
+  },
+  "Texarkana, TX-AR (Metropolitan Statistical Area)": {
+    "rpp": 0.8530800000000001
+  },
+  "The Villages, FL (Metropolitan Statistical Area)": {
+    "rpp": 0.94292
+  },
+  "Toledo, OH (Metropolitan Statistical Area)": {
+    "rpp": 0.90354
+  },
+  "Topeka, KS (Metropolitan Statistical Area)": {
+    "rpp": 0.85887
+  },
+  "Trenton-Princeton, NJ (Metropolitan Statistical Area)": {
+    "rpp": 1.0207
+  },
+  "Tucson, AZ (Metropolitan Statistical Area)": {
+    "rpp": 0.9434600000000001
+  },
+  "Tulsa, OK (Metropolitan Statistical Area)": {
+    "rpp": 0.8947499999999999
+  },
+  "Tuscaloosa, AL (Metropolitan Statistical Area)": {
+    "rpp": 0.89967
+  },
+  "Twin Falls, ID (Metropolitan Statistical Area) *": {
+    "rpp": 0.8858400000000001
+  },
+  "Tyler, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.9238599999999999
+  },
+  "Urban Honolulu, HI (Metropolitan Statistical Area)": {
+    "rpp": 1.10246
+  },
+  "Utica-Rome, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.9226000000000001
+  },
+  "Valdosta, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.86712
+  },
+  "Vallejo, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.092
+  },
+  "Victoria, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.90631
+  },
+  "Vineland-Bridgeton, NJ (Metropolitan Statistical Area)": {
+    "rpp": 0.93745
+  },
+  "Virginia Beach-Norfolk-Newport News, VA-NC (Metropolitan Statistical Area)": {
+    "rpp": 0.9736
+  },
+  "Visalia, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.01318
+  },
+  "Waco, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.90786
+  },
+  "Walla Walla, WA (Metropolitan Statistical Area)": {
+    "rpp": 0.9803400000000001
+  },
+  "Warner Robins, GA (Metropolitan Statistical Area)": {
+    "rpp": 0.91569
+  },
+  "Washington-Arlington-Alexandria, DC-VA-MD-WV (Metropolitan Statistical Area)": {
+    "rpp": 1.08641
+  },
+  "Waterloo-Cedar Falls, IA (Metropolitan Statistical Area)": {
+    "rpp": 0.8798600000000001
+  },
+  "Watertown-Fort Drum, NY (Metropolitan Statistical Area)": {
+    "rpp": 0.90518
+  },
+  "Wausau-Weston, WI (Metropolitan Statistical Area)": {
+    "rpp": 0.90133
+  },
+  "Weirton-Steubenville, WV-OH (Metropolitan Statistical Area)": {
+    "rpp": 0.88764
+  },
+  "Wenatchee, WA (Metropolitan Statistical Area)": {
+    "rpp": 1.0201900000000002
+  },
+  "Wheeling, WV-OH (Metropolitan Statistical Area)": {
+    "rpp": 0.88991
+  },
+  "Wichita, KS (Metropolitan Statistical Area)": {
+    "rpp": 0.89481
+  },
+  "Wichita Falls, TX (Metropolitan Statistical Area)": {
+    "rpp": 0.88914
+  },
+  "Williamsport, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.92686
+  },
+  "Wilmington, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.9714700000000001
+  },
+  "Winchester, VA-WV (Metropolitan Statistical Area)": {
+    "rpp": 0.94344
+  },
+  "Winston-Salem, NC (Metropolitan Statistical Area)": {
+    "rpp": 0.9140600000000001
+  },
+  "Worcester, MA-CT (Metropolitan Statistical Area)": {
+    "rpp": 1.0201500000000001
+  },
+  "Yakima, WA (Metropolitan Statistical Area)": {
+    "rpp": 0.98008
+  },
+  "York-Hanover, PA (Metropolitan Statistical Area)": {
+    "rpp": 0.96642
+  },
+  "Youngstown-Warren-Boardman, OH-PA (Metropolitan Statistical Area)": {
+    "rpp": 0.86008
+  },
+  "Yuba City, CA (Metropolitan Statistical Area)": {
+    "rpp": 1.03638
+  },
+  "Yuma, AZ (Metropolitan Statistical Area)": {
+    "rpp": 0.87477
+  }
+}
 } as const;
 
-export type Region = keyof typeof costOfLiving2024.regions;
+export type MetroArea = keyof typeof costOfLiving2024.metros;


### PR DESCRIPTION
## Summary
- add script to fetch BEA RPP data and generate metro cost-of-living dataset
- replace cost-of-living calculations to use metro RPP multipliers
- document dataset update process and adjust UI to select metro areas

## Testing
- `npx jest src/ai/flows/__tests__/cost-of-living.test.ts src/ai/flows/__tests__/validation.test.ts src/data/__tests__/cost-of-living-dataset.test.ts`
- `npm test` *(fails: Jest encountered an unexpected token in lucide-react ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b366ef767483319bdcaed7e45d9df7