### PR TITLE
Ensure service worker initializes without controller

### DIFF
--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -129,9 +129,10 @@ describe("Service worker registration", () => {
     })
   })
 
-  it("does not register when existing registration without controller", async () => {
+  it("updates existing registration when controller is missing", async () => {
     const register = jest.fn().mockResolvedValue(undefined)
-    const getRegistration = jest.fn().mockResolvedValue({})
+    const update = jest.fn().mockResolvedValue(undefined)
+    const getRegistration = jest.fn().mockResolvedValue({ update })
     Object.defineProperty(navigator, "serviceWorker", {
       value: {
         register,
@@ -149,6 +150,7 @@ describe("Service worker registration", () => {
 
     await act(async () => {})
 
+    expect(update).toHaveBeenCalled()
     expect(register).not.toHaveBeenCalled()
 
     const nav = navigator as Navigator & { serviceWorker?: ServiceWorkerContainer }

--- a/src/components/service-worker.tsx
+++ b/src/components/service-worker.tsx
@@ -101,9 +101,14 @@ export function ServiceWorker() {
           const existing = navigator.serviceWorker.getRegistration
             ? await navigator.serviceWorker.getRegistration()
             : undefined
-          if (!navigator.serviceWorker.controller && existing) {
-            // Service worker already registered, no need to register again
-          } else {
+
+          if (!navigator.serviceWorker.controller) {
+            if (existing) {
+              await existing.update()
+            } else {
+              await navigator.serviceWorker.register("/sw.js", { type: "module" })
+            }
+          } else if (!existing) {
             await navigator.serviceWorker.register("/sw.js", { type: "module" })
           }
         } catch (error) {


### PR DESCRIPTION
## Summary
- Update service worker registration to re-register or update when `navigator.serviceWorker.controller` is missing
- Add test covering first-load registration with existing registration

## Testing
- `npm test src/__tests__/service-worker.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b366ee56f48331b4eafda1a0893fa4