### PR TITLE
docs: clarify transaction sync persistence

### DIFF
--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -8,9 +8,9 @@ import { logger } from "@/lib/logger"
 /**
  * Generic transaction syncing endpoint.
  * Unlike `/api/bank/import`, this expects transactions that have already
- * been fetched from any source. The current implementation only validates
- * and reports how many transactions were received without persisting them.
- * TODO: Implement database persistence for received transactions.
+ * been fetched from any source.
+ * Persists the received transactions to Firestore via `saveTransactions`
+ * and reports how many were processed.
  */
 const bodySchema = z.object({
   transactions: z.array(TransactionPayloadSchema),


### PR DESCRIPTION
## Summary
- clarify that the transaction sync handler stores data in Firestore via `saveTransactions`

## Testing
- `npm test` *(fails: SyntaxError in lucide-react during auth-provider.test.tsx and debt-calendar.test.tsx)*
- `npm run lint` *(fails: ESLint errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b366ecb76483318c4d2ab12ef83700