### PR TITLE
test: fix Firestore mock in debt calendar test

### DIFF
--- a/src/__tests__/debt-calendar.test.tsx
+++ b/src/__tests__/debt-calendar.test.tsx
@@ -26,8 +26,8 @@ jest.mock('@/components/service-worker', () => ({
 let snapshotCallback: ((snapshot: { docs: Array<{ data: () => unknown }> }) => void) | null = null;
 jest.mock('firebase/firestore', () => ({
   getFirestore: jest.fn(),
-  collection: jest.fn(() => ({ withConverter: jest.fn(() => ({})) })),
-  doc: jest.fn(() => ({ withConverter: jest.fn(() => ({})) })),
+  collection: jest.fn(() => ({ withConverter: () => ({}) })),
+  doc: jest.fn(() => ({ withConverter: () => ({}) })),
   onSnapshot: (_: unknown, cb: (snapshot: { docs: Array<{ data: () => unknown }> }) => void) => {
     snapshotCallback = cb;
     cb({ docs: mockDebts.map(debt => ({ data: () => debt })) });


### PR DESCRIPTION
## Summary
- ensure Firestore's `collection` and `doc` mocks expose a no-op `withConverter`

## Testing
- `npm test -- src/__tests__/debt-calendar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b376ec2b2883319fc4f75db14d8404