### PR TITLE
refactor debts firestore access

### DIFF
--- a/src/__tests__/use-debts.test.tsx
+++ b/src/__tests__/use-debts.test.tsx
@@ -10,8 +10,8 @@ import type {
 jest.mock("@/lib/logger", () => ({ logger: { error: jest.fn() } }));
 // Mock debts index module
 jest.mock("@/lib/debts", () => ({
-  debtsCollection: {},
-  debtDoc: (id: string) => ({ id })
+  getDebtsCollection: () => ({}),
+  getDebtDoc: (id: string) => ({ id }),
 }));
 
 const onSnapshotMock = jest.fn();

--- a/src/lib/debts/index.ts
+++ b/src/lib/debts/index.ts
@@ -1,5 +1,5 @@
 import { collection, doc, QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
-import { db, initFirebase } from "../firebase";
+import { getDb } from "../firebase";
 import type { Debt } from "../types";
 
 // Firestore data converter for `Debt` documents.
@@ -13,7 +13,10 @@ const debtConverter = {
   },
 };
 
-// `debts` collection reference using the converter.
-initFirebase();
-export const debtsCollection = collection(db, "debts").withConverter(debtConverter);
-export const debtDoc = (id: string) => doc(db, "debts", id).withConverter(debtConverter);
+export function getDebtsCollection() {
+  return collection(getDb(), "debts").withConverter(debtConverter);
+}
+
+export function getDebtDoc(id: string) {
+  return doc(getDb(), "debts", id).withConverter(debtConverter);
+}

--- a/src/lib/debts/use-debts.ts
+++ b/src/lib/debts/use-debts.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { onSnapshot, setDoc, deleteDoc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
 import type { Debt } from "../types";
-import { debtsCollection, debtDoc } from ".";
+import { getDebtsCollection, getDebtDoc } from ".";
 import { logger } from "../logger";
 
 // Hook to subscribe to debts collection and expose helpers for CRUD operations.
@@ -11,7 +11,7 @@ export function useDebts() {
 
   useEffect(() => {
     const unsub = onSnapshot(
-      debtsCollection,
+      getDebtsCollection(),
       snap => {
         const items = snap.docs.map(d => d.data());
         setDebts(items);
@@ -69,17 +69,17 @@ export function useDebts() {
 }
 
 export async function addOrUpdateDebt(next: Debt) {
-  await setDoc(debtDoc(next.id), next);
+  await setDoc(getDebtDoc(next.id), next);
 }
 
 export async function deleteDebt(id: string) {
-  await deleteDoc(debtDoc(id));
+  await deleteDoc(getDebtDoc(id));
 }
 
 export async function markPaid(dateISO: string, id: string) {
-  await updateDoc(debtDoc(id), { paidDates: arrayUnion(dateISO) });
+  await updateDoc(getDebtDoc(id), { paidDates: arrayUnion(dateISO) });
 }
 
 export async function unmarkPaid(dateISO: string, id: string) {
-  await updateDoc(debtDoc(id), { paidDates: arrayRemove(dateISO) });
+  await updateDoc(getDebtDoc(id), { paidDates: arrayRemove(dateISO) });
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -53,4 +53,8 @@ export function initFirebase() {
   return { app, auth, db, categoriesCollection };
 }
 
+export function getDb() {
+  return initFirebase().db;
+}
+
 export { app, auth, db, categoriesCollection };


### PR DESCRIPTION
## Summary
- add `getDb` helper to Firebase module
- expose `getDebtsCollection` and `getDebtDoc` functions that lazily fetch Firestore
- update debts hook and tests to use new accessors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b376ed8c3083318b16a3e761e649dc