### PR TITLE
refactor: lazy Firestore init in category service

### DIFF
--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -3,11 +3,9 @@ import { setDoc, deleteDoc } from "firebase/firestore";
 import { logger } from "@/lib/logger";
 
 jest.mock("@/lib/firebase", () => ({
-  db: {},
-  categoriesCollection: {},
-  initFirebase: jest.fn(),
+  getDb: jest.fn(() => ({})),
+  getCategoriesCollection: jest.fn(() => ({})),
 }));
-import { initFirebase } from "@/lib/firebase";
 
 beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "test";
@@ -16,7 +14,6 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = "test";
   process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = "test";
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = "test";
-  initFirebase();
 });
 
 jest.mock("firebase/firestore", () => ({

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -53,4 +53,12 @@ export function initFirebase() {
   return { app, auth, db, categoriesCollection };
 }
 
+export function getDb() {
+  return initFirebase().db;
+}
+
+export function getCategoriesCollection() {
+  return initFirebase().categoriesCollection;
+}
+
 export { app, auth, db, categoriesCollection };


### PR DESCRIPTION
## Summary
- refactor categoryService to obtain Firestore instances via getters inside each operation
- add `getDb` and `getCategoriesCollection` helpers in firebase module
- adjust categoryService tests for new lazy initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b376ee14f48331822173d34af45510