### PR TITLE
Use shared Firebase auth in housekeeping

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -53,4 +53,4 @@ export function initFirebase() {
   return { app, auth, db, categoriesCollection };
 }
 
-export { app, auth, db, categoriesCollection };
+export { app, auth, db, categoriesCollection, getAuth };

--- a/src/lib/housekeeping.ts
+++ b/src/lib/housekeeping.ts
@@ -1,4 +1,4 @@
-import { getAuth } from "firebase/auth";
+import { getAuth } from "@/lib/firebase";
 import { logger } from "./logger";
 
 // Placeholder housekeeping service that cleans up outdated data.


### PR DESCRIPTION
## Summary
- import `getAuth` from internal Firebase wrapper
- re-export `getAuth` from Firebase module for reuse

## Testing
- `npm test src/__tests__/housekeeping-route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3771b1bb083318f7aef18470703af