### PR TITLE
Enable ESM modules in Jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,8 +6,12 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
   transform: {
-    '^.+\\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+    '^.+\\\.[tj]sx?$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.test.json', useESM: true },
+    ],
   },
   transformIgnorePatterns: [
     "/node_modules/(?!lucide-react|d3-.*|recharts|embla-carousel-react)",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "module": "commonjs"
+    "module": "esnext"
   }
 }


### PR DESCRIPTION
## Summary
- treat TypeScript files as ESM in Jest
- compile test TypeScript as ES modules

## Testing
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b37727be548331bc19f7518db27aa4