### PR TITLE
test: ensure array redaction and data uri handling

### DIFF
--- a/src/ai/__tests__/redaction.test.ts
+++ b/src/ai/__tests__/redaction.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment node
+ */
+import { sanitizeMiddleware } from '../sanitize-middleware'
+import { DATA_URI_REGEX } from '@/lib/data-uri'
+
+describe('redaction', () => {
+  it('redacts arrays of strings element-wise', () => {
+    const input = ['alice@example.com', 'bob@example.com']
+    const result = sanitizeMiddleware(input)
+
+    expect(result).toHaveLength(2)
+    result.forEach((value) => {
+      expect(value).toMatch(/^\[hash:[0-9a-f]{8}\]$/)
+    })
+
+    const stringified = JSON.stringify(result)
+    expect(stringified).not.toContain('alice@example.com')
+    expect(stringified).not.toContain('bob@example.com')
+  })
+
+  it('leaves data URIs matching DATA_URI_REGEX unmodified', () => {
+    const dataUri = 'data:image/png;base64,iVBORw0KGgo='
+    expect(DATA_URI_REGEX.test(dataUri)).toBe(true)
+
+    const result = sanitizeMiddleware(dataUri)
+    expect(result).toBe(dataUri)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests verifying arrays of strings are redacted element-wise
- ensure data URIs matching DATA_URI_REGEX are not altered

## Testing
- `npx jest src/ai/__tests__/redaction.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3773593e08331a7033060463fadfe