### PR TITLE
test: stub lucide-react for jest

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom'
 import { jest } from '@jest/globals'
 import { TextEncoder, TextDecoder } from 'node:util'
 
+// Stub all icons from lucide-react to empty components
 jest.mock(
   'lucide-react',
   () =>


### PR DESCRIPTION
## Summary
- mock lucide-react in Jest setup to avoid ESM syntax errors during tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b37736bc508331923d26a236a2d0b7