### PR TITLE
Use Node crypto randomUUID for transaction IDs

### DIFF
--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { collection, doc, writeBatch, getDocs } from "firebase/firestore";
+import { randomUUID } from "node:crypto";
 import { db, initFirebase } from "./firebase";
 import type { Transaction } from "./types";
 import { currencyCodeSchema } from "./currency";
@@ -108,7 +109,7 @@ export function validateTransactions(
     const parsedAmount = Number(amountString);
 
     const tx: Transaction = {
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       date: data.date,
       description: data.description,
       amount: parsedAmount,


### PR DESCRIPTION
## Summary
- import `randomUUID` from `node:crypto`
- use `randomUUID()` when generating transaction ids

## Testing
- `npm test`
- `npm run lint` *(fails: Unnecessary escape character and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b377854eac83318d23dfe7e19834d3