### PR TITLE
Commit Firestore transaction batches concurrently

### DIFF
--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -139,21 +139,24 @@ export function validateTransactions(
 export async function saveTransactions(transactions: Transaction[]): Promise<void> {
   const colRef = collection(db, "transactions");
   const chunks = chunkTransactions(transactions);
+  const commitPromises: Promise<void>[] = [];
+
   for (const chunk of chunks) {
     const batch = writeBatch(db);
     chunk.forEach((tx) => {
       batch.set(doc(colRef, tx.id), tx);
     });
+    commitPromises.push(batch.commit());
+  }
 
-    try {
-      await batch.commit();
-    } catch (err) {
-      throw new Error(
-        `Failed to save transactions batch: ${
-          err instanceof Error ? err.message : String(err)
-        }`
-      );
-    }
+  try {
+    await Promise.all(commitPromises);
+  } catch (err) {
+    throw new Error(
+      `Failed to save transactions batch: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Save transactions in parallel by collecting batch commit promises
- Commit all batches at once with `Promise.all` for improved concurrency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37785f830833185352552c1d6a8e6