### PR TITLE
refactor: replace explicit any types

### DIFF
--- a/src/__tests__/allowed-origins.test.ts
+++ b/src/__tests__/allowed-origins.test.ts
@@ -21,7 +21,9 @@ describe('getAllowedOrigins', () => {
 });
 
 describe('cors middleware', () => {
-  const allowed = getAllowedOrigins('http://allowed.com,/^https:\/\/sub\\.example\\.com$/')
+  const allowed = getAllowedOrigins(
+    String.raw`http://allowed.com,/^https://sub\.example\.com$/`
+  )
 
   it('rejects disallowed origins', () => {
     const req = new Request('http://localhost', { headers: { Origin: 'http://evil.com' } })

--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -2,7 +2,7 @@
 /** @jest-environment jsdom */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '../components/auth/auth-provider';
+import { useAuth } from '../components/auth/auth-provider';
 import { ClientProviders } from '@/components/layout/client-providers';
 
 let mockPathname = '/';

--- a/src/__tests__/carousel.test.tsx
+++ b/src/__tests__/carousel.test.tsx
@@ -9,7 +9,15 @@ jest.mock('lucide-react', () => ({
 
 const onMock = jest.fn();
 const offMock = jest.fn();
-let emblaApi: any;
+type MockEmblaApi = {
+  on: jest.Mock;
+  off: jest.Mock;
+  canScrollPrev: jest.Mock;
+  canScrollNext: jest.Mock;
+  scrollPrev: jest.Mock;
+  scrollNext: jest.Mock;
+};
+let emblaApi: MockEmblaApi;
 
 function mockUseEmbla() {
   emblaApi = {

--- a/src/__tests__/debt-calendar.test.tsx
+++ b/src/__tests__/debt-calendar.test.tsx
@@ -1,11 +1,12 @@
 
 /** @jest-environment jsdom */
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { webcrypto } from 'crypto';
 import DebtCalendar from '../components/debts/DebtCalendar';
 import { mockDebts } from '@/lib/data';
 import { ClientProviders } from '@/components/layout/client-providers';
+import type { Debt } from '@/lib/types';
 
 const pushMock = jest.fn();
 jest.mock('next/navigation', () => ({
@@ -33,7 +34,7 @@ jest.mock('firebase/firestore', () => ({
     cb({ docs: mockDebts.map(debt => ({ data: () => debt })) });
     return () => {};
   },
-  setDoc: jest.fn((_: unknown, debt: any) => {
+  setDoc: jest.fn((_: unknown, debt: Debt) => {
     const index = mockDebts.findIndex(d => d.id === debt.id);
     if (index === -1) {
       mockDebts.push(debt);
@@ -77,14 +78,6 @@ describe('DebtCalendar', () => {
   beforeEach(() => {
     localStorage.clear();
   });
-
-  function fillRequiredFields() {
-    fireEvent.change(screen.getByPlaceholderText('e.g., X1 Card'), { target: { value: 'Test Debt' } });
-    fireEvent.change(screen.getByPlaceholderText('5.5'), { target: { value: '5' } });
-    fireEvent.change(screen.getByPlaceholderText('5000'), { target: { value: '1000' } });
-    fireEvent.change(screen.getByPlaceholderText('3250'), { target: { value: '1000' } });
-    fireEvent.change(screen.getByPlaceholderText('150'), { target: { value: '100' } });
-  }
 
   test('renders calendar', () => {
     render(

--- a/src/__tests__/mapWorker.test.ts
+++ b/src/__tests__/mapWorker.test.ts
@@ -5,6 +5,7 @@ import { Worker } from "node:worker_threads"
 import fs from "node:fs"
 import path from "node:path"
 import ts from "typescript"
+import type { SquareMessage } from "../lib/mapWorker"
 
 function createWorker() {
   const filePath = path.resolve(__dirname, "../lib/mapWorker.ts")
@@ -31,7 +32,10 @@ describe("mapWorker", () => {
     const worker = createWorker()
     const result = await new Promise(resolve => {
       worker.once("message", resolve)
-      worker.postMessage({ type: "square", payload: [1, "a"] as any })
+      worker.postMessage({
+        type: "square",
+        payload: [1, "a"],
+      } as unknown as SquareMessage)
     })
     await worker.terminate()
     expect(result).toEqual({
@@ -44,7 +48,7 @@ describe("mapWorker", () => {
     const worker = createWorker()
     const result = await new Promise(resolve => {
       worker.once("message", resolve)
-      worker.postMessage({ type: "boom", payload: [] as any })
+      worker.postMessage({ type: "boom", payload: [] } as unknown as SquareMessage)
     })
     await worker.terminate()
     expect(result).toEqual({

--- a/src/__tests__/transactions-sync.test.ts
+++ b/src/__tests__/transactions-sync.test.ts
@@ -25,7 +25,7 @@ const baseTx = {
 
 describe("/api/transactions/sync persistence", () => {
   beforeEach(() => {
-    ;(saveTransactions as jest.Mock).mockClear()
+    (saveTransactions as jest.Mock).mockClear()
   })
 
   it("saves transactions via saveTransactions", async () => {
@@ -45,7 +45,7 @@ describe("/api/transactions/sync persistence", () => {
   })
 
   it("propagates persistence errors", async () => {
-    ;(saveTransactions as jest.Mock).mockRejectedValueOnce(
+    (saveTransactions as jest.Mock).mockRejectedValueOnce(
       Object.assign(new Error("db failed"), { status: 503 }),
     )
 

--- a/src/ai/sanitize-middleware.ts
+++ b/src/ai/sanitize-middleware.ts
@@ -8,7 +8,7 @@ function hashPlaceholder(value: string) {
   return `[hash:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 8)}]`
 }
 
-function sanitizeValue(value: any): any {
+function sanitizeValue(value: unknown): unknown {
   if (typeof value === 'string') {
     if (emailRegex.test(value) || phoneRegex.test(value) || accountRegex.test(value)) {
       return hashPlaceholder(value)
@@ -16,12 +16,12 @@ function sanitizeValue(value: any): any {
     return value
   }
   if (Array.isArray(value)) {
-    return value.map((v) => sanitizeValue(v))
+    return value.map(v => sanitizeValue(v))
   }
   if (value && typeof value === 'object') {
-    const result: any = {}
-    for (const key of Object.keys(value)) {
-      result[key] = sanitizeValue((value as any)[key])
+    const result: Record<string, unknown> = {}
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      result[key] = sanitizeValue((value as Record<string, unknown>)[key])
     }
     return result
   }
@@ -29,7 +29,7 @@ function sanitizeValue(value: any): any {
 }
 
 export function sanitizeMiddleware<T>(input: T): T {
-  return sanitizeValue(input)
+  return sanitizeValue(input) as T
 }
 
 export default sanitizeMiddleware


### PR DESCRIPTION
## Summary
- replace explicit `any` usage with dedicated types in tests and middleware
- clean up unused imports and unnecessary escapes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3772580608331b1f9e94678d48215