### PR TITLE
refactor: use getDb for firebase init

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -18,15 +18,15 @@ const firebaseConfigSchema = z.object({
   NEXT_PUBLIC_FIREBASE_APP_ID: z.string().min(1),
 });
 
-let app: ReturnType<typeof initializeApp>;
-let auth: ReturnType<typeof getAuth>;
-let db: ReturnType<typeof getFirestore>;
-let categoriesCollection: ReturnType<typeof collection>;
+let app: ReturnType<typeof initializeApp> | undefined;
+let auth: ReturnType<typeof getAuth> | undefined;
+let db: ReturnType<typeof getFirestore> | undefined;
+let categoriesCollection: ReturnType<typeof collection> | undefined;
 
 
 export function initFirebase() {
   if (app) {
-    return { app, auth, db, categoriesCollection };
+    return { app, auth, db: db!, categoriesCollection: categoriesCollection! };
   }
 
   const envParseResult = firebaseConfigSchema.safeParse(process.env);
@@ -53,4 +53,11 @@ export function initFirebase() {
   return { app, auth, db, categoriesCollection };
 }
 
-export { app, auth, db, categoriesCollection };
+export function getDb(): ReturnType<typeof getFirestore> {
+  if (!db) {
+    initFirebase();
+  }
+  return db!;
+}
+
+export { app, auth, db, categoriesCollection, getDb };

--- a/src/services/housekeeping.ts
+++ b/src/services/housekeeping.ts
@@ -11,12 +11,12 @@ import {
   writeBatch,
   QueryDocumentSnapshot,
 } from "firebase/firestore";
-import { db, initFirebase } from "../lib/firebase";
+import { getDb } from "../lib/firebase";
 import type { Transaction, Debt, Goal } from "../lib/types";
 import { getCurrentTime } from "../lib/internet-time";
 import { logger } from "../lib/logger";
 
-initFirebase();
+const db = getDb();
 
 /**
  * Moves transactions older than the provided cutoff date to an archive collection


### PR DESCRIPTION
## Summary
- add getDb helper for lazy Firebase initialization
- use getDb in housekeeping service instead of calling initFirebase directly

## Testing
- `npm test src/__tests__/housekeeping.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3771bce088331934a01879e1a0bba