### PR TITLE
Transpile ESM dependencies in Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,25 @@
-module.exports = {
-  preset: 'ts-jest',
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+/** @type {import('jest').Config} */
+const customJestConfig = {
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  transform: {
-    '^.+\\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
-  },
-  transformIgnorePatterns: [
-    '/node_modules/(?!(lucide-react|d3-.*|recharts|embla-carousel-react)/)',
-  ],
-  extensionsToTreatAsEsm: ['.jsx', '.ts', '.tsx'],
+};
+
+module.exports = async () => {
+  const jestConfig = await createJestConfig(customJestConfig)();
+  jestConfig.transformIgnorePatterns = [
+    '/node_modules/(?!lucide-react|d3-.*|recharts|embla-carousel-react)',
+    '^.+\\.module\\.(css|sass|scss)$',
+  ];
+  jestConfig.extensionsToTreatAsEsm = ['.jsx', '.ts', '.tsx'];
+  return jestConfig;
 };


### PR DESCRIPTION
## Summary
- Adjust Jest transformIgnorePatterns to include ESM packages like lucide-react
- Treat TS/JSX files as ES modules for proper ESM dependency handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b377732b388331bc2f9a8149f3aa53