### PR TITLE
chore: switch jest config to next

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,15 +1,25 @@
-module.exports = {
-  preset: 'ts-jest',
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+/** @type {import('jest').Config} */
+const customJestConfig = {
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  transform: {
-    '^.+\\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
-  },
-  transformIgnorePatterns: [
-    "/node_modules/(?!lucide-react|d3-.*|recharts|embla-carousel-react)",
-  ],
 };
+
+module.exports = async () => {
+  const jestConfig = await createJestConfig(customJestConfig)();
+  jestConfig.transformIgnorePatterns = [
+    '/node_modules/(?!lucide-react|d3-.*|recharts|embla-carousel-react)',
+    '^.+\\.module\\.(css|sass|scss)$',
+  ];
+  return jestConfig;
+};
+


### PR DESCRIPTION
## Summary
- adopt Next.js-aware jest config via `next/jest`
- whitelist lucide-react and other ESM packages for transformation

## Testing
- `npm test` *(fails: getQueuedTransactions redefinition, dataStore before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68b3777d27ec8331b4771f3073e5c40e