### PR TITLE
chore: centralize lucide-react jest mock

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -2,6 +2,12 @@ import '@testing-library/jest-dom'
 import { jest } from '@jest/globals'
 import { TextEncoder, TextDecoder } from 'node:util'
 
+// Stub all icons from lucide-react to empty components
+jest.mock(
+  'lucide-react',
+  () => new Proxy({}, { get: () => () => null })
+)
+
 Object.assign(globalThis as any, { TextEncoder, TextDecoder })
 
 

--- a/src/__tests__/add-transaction-dialog.test.tsx
+++ b/src/__tests__/add-transaction-dialog.test.tsx
@@ -12,7 +12,6 @@ const suggestCategoryMock = jest.fn();
 jest.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: toastMock }),
 }));
-jest.mock('lucide-react', () => ({ PlusCircle: () => null }));
 jest.mock('@/components/ui/dialog', () => {
   const Mock = ({ children }: React.PropsWithChildren) => <div>{children}</div>;
   return {

--- a/src/__tests__/carousel.test.tsx
+++ b/src/__tests__/carousel.test.tsx
@@ -2,11 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Carousel } from '@/components/ui/carousel';
 
-jest.mock('lucide-react', () => ({
-  ArrowLeft: () => null,
-  ArrowRight: () => null,
-}));
-
 const onMock = jest.fn();
 const offMock = jest.fn();
 let emblaApi: any;

--- a/src/__tests__/debt-calendar.test.tsx
+++ b/src/__tests__/debt-calendar.test.tsx
@@ -14,7 +14,6 @@ jest.mock('next/navigation', () => ({
 }));
 
 // Mock UI components to avoid Radix and other dependencies
-jest.mock('lucide-react', () => ({ X: () => null }));
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
   usePathname: () => '/',

--- a/src/__tests__/transactions-table.test.tsx
+++ b/src/__tests__/transactions-table.test.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TransactionsTable } from '@/components/transactions/transactions-table';
-jest.mock('lucide-react', () => ({ Repeat: () => null }));
 
 type Tx = {
   id: string;


### PR DESCRIPTION
## Summary
- add global lucide-react stub in jest setup
- remove redundant lucide-react mocks from tests

## Testing
- `npm run lint` *(fails: Unnecessary escape character, unused vars, unexpected any, etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b377a5af88833192a770773e76c8ef