### PR TITLE
feat: add tax prep functions and UI

### DIFF
--- a/apps/web/src/app/tax-prep/page.tsx
+++ b/apps/web/src/app/tax-prep/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/app/src/lib/firebaseClient';
+import { apiTaxSummary, downloadTaxCsv } from '@/app/src/lib/taxClient';
+
+function currentYear() { return new Date().getFullYear(); }
+function fmt(n: number) { try { return n.toLocaleString(undefined, { style:'currency', currency:'USD' }); } catch { return `$${n.toFixed(2)}`; } }
+
+export default function TaxPrepPage() {
+  const [uid, setUid] = useState<string|null>(null);
+  const [year, setYear] = useState<number>(currentYear());
+  const [summary, setSummary] = useState<any|null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string|undefined>();
+
+  useEffect(()=> onAuthStateChanged(auth, u=> setUid(u?.uid ?? null)), []);
+  useEffect(()=> { if (uid) load(); }, [uid, year]);
+
+  async function load() {
+    setLoading(true); setError(undefined);
+    try { setSummary(await apiTaxSummary(year)); } catch (e:any) { setError(e.message); } finally { setLoading(false); }
+  }
+
+  if (!uid) return <div className="p-6"><p className="text-sm opacity-70">Please sign in.</p></div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex flex-wrap items-end gap-3">
+        <div>
+          <label className="block text-sm font-medium">Tax year</label>
+          <select className="border rounded p-2" value={year} onChange={e=> setYear(Number(e.target.value))}>
+            {Array.from({ length: 6 }).map((_,i)=> { const y = currentYear()-i; return <option key={y} value={y}>{y}</option>; })}
+          </select>
+        </div>
+        <button className="rounded bg-black text-white px-4 py-2" disabled={loading} onClick={load}>{loading? 'Refreshing…':'Refresh'}</button>
+        <button className="rounded border px-4 py-2" disabled={!summary || loading} onClick={()=> downloadTaxCsv(year)}>Download CSV</button>
+        {error && <span className="text-sm text-red-600">{error}</span>}
+      </div>
+
+      <div className="border rounded-xl overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50"><tr><th className="text-left p-2">Category</th><th className="text-right p-2">Total</th></tr></thead>
+          <tbody>
+            {summary?.categories?.map((c:string)=> (
+              <tr key={c} className="border-t">
+                <td className="p-2">{c}</td>
+                <td className="p-2 text-right">{fmt(summary?.totals?.[c] || 0)}</td>
+              </tr>
+            ))}
+            <tr className="border-t font-semibold"><td className="p-2">Grand total</td><td className="p-2 text-right">{fmt(summary?.grand_total || 0)}</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      {summary?.sample?.length ? (
+        <div className="border rounded-xl p-4">
+          <h3 className="font-medium mb-2">Sample itemization (first {summary.sample.length} of {summary.count})</h3>
+          <div className="overflow-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50"><tr><th className="text-left p-2">Date</th><th className="text-left p-2">Merchant</th><th className="text-left p-2">Category</th><th className="text-right p-2">Amount</th><th className="text-left p-2">Receipt</th></tr></thead>
+              <tbody>
+                {summary.sample.map((r:any)=> (
+                  <tr key={r.id} className="border-t">
+                    <td className="p-2 whitespace-nowrap">{r.date}</td>
+                    <td className="p-2">{r.merchant}</td>
+                    <td className="p-2">{r.nurse_category}</td>
+                    <td className="p-2 text-right">{fmt(r.amount)}</td>
+                    <td className="p-2">{r.has_receipt ? 'yes' : 'no'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
+
+      <p className="text-xs text-gray-500">Disclaimer: This report is informational and not tax advice. Deductibility varies by employment status and jurisdiction. Consult a qualified tax professional.</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/HeaderClient.tsx
+++ b/apps/web/src/components/HeaderClient.tsx
@@ -1,0 +1,10 @@
+'use client';
+import Link from 'next/link';
+
+export default function HeaderClient() {
+  return (
+    <nav>
+      <Link href="/tax-prep">Tax Prep</Link>
+    </nav>
+  );
+}

--- a/apps/web/src/lib/taxClient.ts
+++ b/apps/web/src/lib/taxClient.ts
@@ -1,0 +1,28 @@
+'use client';
+import { auth, FUNCTIONS_ORIGIN } from '@/app/src/lib/firebaseClient';
+
+async function idToken(): Promise<string> { const u = auth.currentUser; if (!u) throw new Error('Not authenticated'); return u.getIdToken(true); }
+
+export async function apiTaxSummary(year: number) {
+  const res = await fetch(`${FUNCTIONS_ORIGIN}/taxYearSummary`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${await idToken()}` },
+    body: JSON.stringify({ year }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return await res.json();
+}
+
+export async function downloadTaxCsv(year: number) {
+  const res = await fetch(`${FUNCTIONS_ORIGIN}/taxYearCsv?year=${year}`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${await idToken()}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = `nurse-tax-${year}.csv`;
+  document.body.appendChild(a); a.click(); a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,0 +1,1 @@
+export * from './tax';

--- a/packages/workers/src/tax.ts
+++ b/packages/workers/src/tax.ts
@@ -1,0 +1,136 @@
+/**
+ * Nurse Tax Prep (MVP)
+ * Summarize nurse-specific expense categories by tax year and export CSV.
+ * Disclaimer: This is not tax advice. Categories and deductibility depend on the user's facts.
+ */
+import { onRequest } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+import * as logger from 'firebase-functions/logger';
+
+if (!admin.apps.length) admin.initializeApp();
+const db = admin.firestore();
+
+const TAX_CATEGORIES: string[] = [
+  'ceus','licensure','meals_on_shift','equipment','parking','certifications','union_dues','travel_misc','lodging','mileage','agency_fees'
+];
+
+function yearRangeUTC(year: number) {
+  const start = new Date(Date.UTC(year, 0, 1, 0, 0, 0));
+  const end = new Date(Date.UTC(year + 1, 0, 1, 0, 0, 0));
+  return { start, end };
+}
+
+async function requireUser(req: any): Promise<string> {
+  const hdr = req.headers?.authorization || '';
+  const token = hdr.startsWith('Bearer ') ? hdr.slice(7) : '';
+  if (!token) throw new Error('Missing Authorization token');
+  const decoded = await admin.auth().verifyIdToken(token);
+  return decoded.uid;
+}
+
+function toUSD(n: number) { return Math.round(n * 100) / 100; }
+
+export const taxYearSummary = onRequest(async (req, res) => {
+  try {
+    const uid = await requireUser(req);
+    const year = Number(req.body?.year || req.query?.year || new Date().getUTCFullYear());
+    if (!Number.isInteger(year) || year < 2000 || year > 2100) throw new Error('invalid year');
+
+    const { start, end } = yearRangeUTC(year);
+    const snap = await db.collection('transactions')
+      .where('user_id', '==', uid)
+      .where('posted_at', '>=', start)
+      .where('posted_at', '<', end)
+      .get();
+
+    const byCat: Record<string, number> = {};
+    const items: any[] = [];
+
+    snap.forEach(d => {
+      const v = d.data() as any;
+      if (v.removed) return;
+      const cat = v.nurse_category || null;
+      if (!cat || !TAX_CATEGORIES.includes(cat)) return;
+      // Treat as expense if not linked to paystub (income). Use absolute amount to normalize.
+      const amt = Math.abs(Number(v.amount) || 0);
+      if (!amt) return;
+      byCat[cat] = (byCat[cat] || 0) + amt;
+      items.push({
+        id: d.id,
+        date: v.iso_date || (v.posted_at?.toDate ? v.posted_at.toDate().toISOString().slice(0,10) : ''),
+        merchant: v.merchant_name || v.raw_description || '',
+        nurse_category: cat,
+        amount: toUSD(amt),
+        notes: v.notes || null,
+        has_receipt: !!v.receipt_id,
+        receipt_id: v.receipt_id || null,
+      });
+    });
+
+    const totals = Object.fromEntries(Object.entries(byCat).map(([k,v]) => [k, toUSD(v)]));
+    const grand_total = toUSD(Object.values(byCat).reduce((s, n) => s + n, 0));
+
+    res.json({ year, categories: TAX_CATEGORIES, totals, grand_total, count: items.length, sample: items.slice(0, 50) });
+  } catch (e: any) {
+    logger.error('taxYearSummary error', e);
+    res.status(400).json({ error: e.message });
+  }
+});
+
+export const taxYearCsv = onRequest(async (req, res) => {
+  try {
+    const uid = await requireUser(req);
+    const year = Number(req.body?.year || req.query?.year || new Date().getUTCFullYear());
+    if (!Number.isInteger(year) || year < 2000 || year > 2100) throw new Error('invalid year');
+
+    const { start, end } = yearRangeUTC(year);
+    const snap = await db.collection('transactions')
+      .where('user_id', '==', uid)
+      .where('posted_at', '>=', start)
+      .where('posted_at', '<', end)
+      .get();
+
+    type Row = { date: string; merchant: string; category: string; amount: number; notes: string; receipt_id: string; tx_id: string };
+    const rows: Row[] = [];
+
+    snap.forEach(d => {
+      const v = d.data() as any;
+      if (v.removed) return;
+      const cat = v.nurse_category || null;
+      if (!cat || !TAX_CATEGORIES.includes(cat)) return;
+      const amt = Math.abs(Number(v.amount) || 0);
+      if (!amt) return;
+      const date = v.iso_date || (v.posted_at?.toDate ? v.posted_at.toDate().toISOString().slice(0,10) : '');
+      rows.push({
+        date,
+        merchant: (v.merchant_name || v.raw_description || '').replace(/\s+/g, ' ').trim(),
+        category: cat,
+        amount: toUSD(amt),
+        notes: (v.notes || '').replace(/\r?\n/g, ' '),
+        receipt_id: v.receipt_id || '',
+        tx_id: d.id,
+      });
+    });
+
+    // CSV header
+    const header = ['date','merchant','nurse_category','amount_usd','notes','receipt_id','transaction_id'];
+    const csvLines = [header.join(',')];
+    for (const r of rows) {
+      const cells = [r.date, r.merchant, r.category, r.amount.toFixed(2), r.notes, r.receipt_id, r.tx_id]
+        .map((c) => {
+          const s = String(c ?? '');
+          return (s.includes(',') || s.includes('"') || s.includes('\n')) ? '"' + s.replace(/"/g, '""') + '"' : s;
+        });
+      csvLines.push(cells.join(','));
+    }
+    const csv = csvLines.join('\n');
+
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', `attachment; filename="nurse-tax-${year}.csv"`);
+    res.status(200).send(csv);
+  } catch (e: any) {
+    logger.error('taxYearCsv error', e);
+    res.status(400).json({ error: e.message });
+  }
+});
+


### PR DESCRIPTION
## Summary
- add Firebase workers for tax year summaries and CSV export
- create client helpers and tax prep UI with CSV download
- add navigation link to tax prep page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b377cf75f88331bdf95f002c5e8098