### PR TITLE
test: transpile lucide-react for Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/js-with-ts',
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   moduleNameMapper: {
@@ -7,9 +7,9 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
-    '^.+\\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
   },
   transformIgnorePatterns: [
-    "/node_modules/(?!lucide-react|d3-.*|recharts|embla-carousel-react)",
+    '/node_modules/(?!(lucide-react|d3-.*|recharts|embla-carousel-react)/)',
   ],
 };


### PR DESCRIPTION
## Summary
- use ts-jest's `js-with-ts` preset so Babel handles ESM deps
- ensure lucide-react and other ESM packages are not ignored by Jest transforms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b377ac3bf8833183a8c8268ff28083