### PR TITLE
refactor: tidy tests and types

### DIFF
--- a/src/__tests__/allowed-origins.test.ts
+++ b/src/__tests__/allowed-origins.test.ts
@@ -21,7 +21,9 @@ describe('getAllowedOrigins', () => {
 });
 
 describe('cors middleware', () => {
-  const allowed = getAllowedOrigins('http://allowed.com,/^https:\/\/sub\\.example\\.com$/')
+  const allowed = getAllowedOrigins(
+    'http://allowed.com,' + String.raw`/^https://sub\.example\.com$/`,
+  )
 
   it('rejects disallowed origins', () => {
     const req = new Request('http://localhost', { headers: { Origin: 'http://evil.com' } })

--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -2,7 +2,7 @@
 /** @jest-environment jsdom */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '../components/auth/auth-provider';
+import { useAuth } from '../components/auth/auth-provider';
 import { ClientProviders } from '@/components/layout/client-providers';
 
 let mockPathname = '/';

--- a/src/__tests__/carousel.test.tsx
+++ b/src/__tests__/carousel.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Carousel } from '@/components/ui/carousel';
+import type { UseEmblaCarouselType } from 'embla-carousel-react';
 
 jest.mock('lucide-react', () => ({
   ArrowLeft: () => null,
@@ -9,7 +10,7 @@ jest.mock('lucide-react', () => ({
 
 const onMock = jest.fn();
 const offMock = jest.fn();
-let emblaApi: any;
+let emblaApi: UseEmblaCarouselType[1];
 
 function mockUseEmbla() {
   emblaApi = {

--- a/src/__tests__/debt-calendar.test.tsx
+++ b/src/__tests__/debt-calendar.test.tsx
@@ -1,11 +1,12 @@
 
 /** @jest-environment jsdom */
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { webcrypto } from 'crypto';
 import DebtCalendar from '../components/debts/DebtCalendar';
 import { mockDebts } from '@/lib/data';
 import { ClientProviders } from '@/components/layout/client-providers';
+import type { Debt } from '@/lib/types';
 
 const pushMock = jest.fn();
 jest.mock('next/navigation', () => ({
@@ -33,7 +34,7 @@ jest.mock('firebase/firestore', () => ({
     cb({ docs: mockDebts.map(debt => ({ data: () => debt })) });
     return () => {};
   },
-  setDoc: jest.fn((_: unknown, debt: any) => {
+  setDoc: jest.fn((_: unknown, debt: Debt) => {
     const index = mockDebts.findIndex(d => d.id === debt.id);
     if (index === -1) {
       mockDebts.push(debt);
@@ -78,13 +79,6 @@ describe('DebtCalendar', () => {
     localStorage.clear();
   });
 
-  function fillRequiredFields() {
-    fireEvent.change(screen.getByPlaceholderText('e.g., X1 Card'), { target: { value: 'Test Debt' } });
-    fireEvent.change(screen.getByPlaceholderText('5.5'), { target: { value: '5' } });
-    fireEvent.change(screen.getByPlaceholderText('5000'), { target: { value: '1000' } });
-    fireEvent.change(screen.getByPlaceholderText('3250'), { target: { value: '1000' } });
-    fireEvent.change(screen.getByPlaceholderText('150'), { target: { value: '100' } });
-  }
 
   test('renders calendar', () => {
     render(

--- a/src/__tests__/mapWorker.test.ts
+++ b/src/__tests__/mapWorker.test.ts
@@ -31,7 +31,10 @@ describe("mapWorker", () => {
     const worker = createWorker()
     const result = await new Promise(resolve => {
       worker.once("message", resolve)
-      worker.postMessage({ type: "square", payload: [1, "a"] as any })
+      worker.postMessage({
+        type: "square",
+        payload: [1, "a"] as unknown as number[],
+      })
     })
     await worker.terminate()
     expect(result).toEqual({
@@ -44,7 +47,10 @@ describe("mapWorker", () => {
     const worker = createWorker()
     const result = await new Promise(resolve => {
       worker.once("message", resolve)
-      worker.postMessage({ type: "boom", payload: [] as any })
+      worker.postMessage({
+        type: "boom",
+        payload: [] as unknown as number[],
+      })
     })
     await worker.terminate()
     expect(result).toEqual({

--- a/src/__tests__/transactions-sync.test.ts
+++ b/src/__tests__/transactions-sync.test.ts
@@ -25,7 +25,7 @@ const baseTx = {
 
 describe("/api/transactions/sync persistence", () => {
   beforeEach(() => {
-    ;(saveTransactions as jest.Mock).mockClear()
+    (saveTransactions as jest.Mock).mockClear()
   })
 
   it("saves transactions via saveTransactions", async () => {
@@ -45,7 +45,7 @@ describe("/api/transactions/sync persistence", () => {
   })
 
   it("propagates persistence errors", async () => {
-    ;(saveTransactions as jest.Mock).mockRejectedValueOnce(
+    (saveTransactions as jest.Mock).mockRejectedValueOnce(
       Object.assign(new Error("db failed"), { status: 503 }),
     )
 

--- a/src/ai/sanitize-middleware.ts
+++ b/src/ai/sanitize-middleware.ts
@@ -8,22 +8,24 @@ function hashPlaceholder(value: string) {
   return `[hash:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 8)}]`
 }
 
-function sanitizeValue(value: any): any {
+function sanitizeValue<T>(value: T): T {
   if (typeof value === 'string') {
     if (emailRegex.test(value) || phoneRegex.test(value) || accountRegex.test(value)) {
-      return hashPlaceholder(value)
+      return hashPlaceholder(value) as unknown as T
     }
     return value
   }
   if (Array.isArray(value)) {
-    return value.map((v) => sanitizeValue(v))
+    return value.map(v => sanitizeValue(v)) as unknown as T
   }
   if (value && typeof value === 'object') {
-    const result: any = {}
-    for (const key of Object.keys(value)) {
-      result[key] = sanitizeValue((value as any)[key])
+    const result: Record<string, unknown> = {}
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      result[key] = sanitizeValue(
+        (value as Record<string, unknown>)[key],
+      )
     }
-    return result
+    return result as T
   }
   return value
 }


### PR DESCRIPTION
## Summary
- streamline auth provider test by removing unused AuthProvider
- tighten test typings and clean up stray semicolons and imports
- replace `any` in sanitize middleware with generics

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b377740dc08331933fc79486c8c2f5