### PR TITLE
test: transpile lucide-react for Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
-    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
   },
   transformIgnorePatterns: [
     '/node_modules/(?!(lucide-react|d3-.*|recharts|embla-carousel-react)/)',


### PR DESCRIPTION
## Summary
- allow ts-jest to handle JS and TS files so Babel transpiles ESM deps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37a62f1d083319d9dc5ad9a4691c2