### PR TITLE
test: transpile lucide-react for Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,8 +6,10 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  transform: {
-    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
   },
   transformIgnorePatterns: [
     '/node_modules/(?!(lucide-react|d3-.*|recharts|embla-carousel-react)/)',


### PR DESCRIPTION
## Summary
- configure ts-jest via globals so preset can keep Babel transform for JS modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37a5350648331ba9fda7378a64bc2