### PR TITLE
test: stub lucide icons with proxy

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -2,7 +2,19 @@ import '@testing-library/jest-dom'
 import { jest } from '@jest/globals'
 import { TextEncoder, TextDecoder } from 'node:util'
 
-jest.mock('lucide-react', () => ({ __esModule: true, default: {} }))
+jest.mock(
+  'lucide-react',
+  () =>
+    new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          if (prop === '__esModule') return true
+          return () => null
+        },
+      },
+    ),
+)
 
 Object.assign(globalThis as any, { TextEncoder, TextDecoder })
 


### PR DESCRIPTION
## Summary
- mock lucide-react with proxy to return functional stubs for icon exports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3794bef4483318901f7d2f3230515