### PR TITLE
feat: enhance HTML sanitization middleware

### DIFF
--- a/src/ai/sanitize-middleware.ts
+++ b/src/ai/sanitize-middleware.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto'
 import sanitizeHtml from 'sanitize-html'
+import type { IOptions } from 'sanitize-html'
 
 const emailRegex = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/
 const phoneRegex = /(?:\+?\d{1,2}\s?)?(?:\(?\d{3}\)?[\s.-]?)?\d{3}[\s.-]?\d{4}/
@@ -9,11 +10,13 @@ function hashPlaceholder(value: string) {
   return `[hash:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 8)}]`
 }
 
+const sanitizeOptions: IOptions = {
+  allowedTags: [],
+  allowedAttributes: {},
+}
+
 function sanitizeString(value: string): string {
-  const cleaned = sanitizeHtml(value, {
-    allowedTags: [],
-    allowedAttributes: {},
-  })
+  const cleaned = sanitizeHtml(value, sanitizeOptions)
   if (emailRegex.test(cleaned) || phoneRegex.test(cleaned) || accountRegex.test(cleaned)) {
     return hashPlaceholder(cleaned)
   }


### PR DESCRIPTION
## Summary
- extract reusable `sanitize-html` options object
- import `IOptions` type for clearer typings

## Testing
- `npm test`
- `npx eslint src/ai/sanitize-middleware.ts src/ai/__tests__/sanitize-middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b37b315384833190ff064f0a5322ad