### PR TITLE
chore: add placeholder checks

### DIFF
--- a/scripts/__tests__/check-placeholders.test.ts
+++ b/scripts/__tests__/check-placeholders.test.ts
@@ -1,0 +1,31 @@
+import {mkdtempSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {spawnSync} from 'node:child_process';
+
+const script = join(__dirname, '..', 'check-placeholders.mjs');
+
+describe('check-placeholders script', () => {
+  it('passes when no placeholders are present', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'place-ok-'));
+    writeFileSync(join(dir, 'index.js'), 'const a = 1;\n');
+    const result = spawnSync('node', [script, dir]);
+    expect(result.status).toBe(0);
+  });
+
+  it('fails on TODO markers', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'place-todo-'));
+    writeFileSync(join(dir, 'index.js'), '// TODO: fix\n');
+    const result = spawnSync('node', [script, dir]);
+    expect(result.status).toBe(1);
+    expect(result.stderr.toString()).toContain('TODO');
+  });
+
+  it('fails on stand-alone ellipses', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'place-dots-'));
+    writeFileSync(join(dir, 'index.js'), '...\n');
+    const result = spawnSync('node', [script, dir]);
+    expect(result.status).toBe(1);
+    expect(result.stderr.toString()).toContain('...');
+  });
+});

--- a/scripts/check-placeholders.mjs
+++ b/scripts/check-placeholders.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import {spawnSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import {dirname, resolve} from 'node:path';
+
+const repoRoot = process.argv[2]
+  ? resolve(process.argv[2])
+  : resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const pattern = '(^|\\s)\\.\\.\\.(\\s|$)|TODO';
+
+const args = [
+  'grep',
+  '--no-index',
+  '-nP',
+  pattern,
+  '--',
+  '.',
+  ':!node_modules',
+  ':!package-lock.json',
+  ':!pnpm-lock.yaml',
+  ':!yarn.lock'
+];
+
+const result = spawnSync('git', args, {cwd: repoRoot, encoding: 'utf8'});
+
+if (result.status === 0 && result.stdout.trim().length > 0) {
+  console.error('Placeholder markers found:\n' + result.stdout);
+  process.exit(1);
+} else if (result.status === 1) {
+  // No matches found
+  process.exit(0);
+} else {
+  console.error(result.stderr.toString());
+  process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
## Summary
- add script to detect TODO or standalone ellipses
- cover placeholder checker with tests

## Testing
- `npm test` *(fails: ServiceWorker handles queued transaction retrieval errors gracefully; Test suite failed to run - Cannot access 'dataStore' before initialization)*
- `npx jest scripts/__tests__/check-placeholders.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b38baeadd48331979f7e74efe6308b