### PR TITLE
chore: add placeholder checks

### DIFF
--- a/scripts/__tests__/check-placeholders.test.ts
+++ b/scripts/__tests__/check-placeholders.test.ts
@@ -1,4 +1,4 @@
-import {mkdtempSync, writeFileSync} from 'node:fs';
+import {copyFileSync, mkdtempSync, mkdirSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {spawnSync} from 'node:child_process';
@@ -27,5 +27,15 @@ describe('check-placeholders script', () => {
     const result = spawnSync('node', [script, dir]);
     expect(result.status).toBe(1);
     expect(result.stderr.toString()).toContain('...');
+  });
+
+  it('ignores the checker script itself', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'place-self-'));
+    const scriptsDir = join(dir, 'scripts');
+    mkdirSync(scriptsDir);
+    const target = join(scriptsDir, 'check-placeholders.mjs');
+    copyFileSync(script, target);
+    const result = spawnSync('node', [script, dir]);
+    expect(result.status).toBe(0);
   });
 });

--- a/scripts/check-placeholders.mjs
+++ b/scripts/check-placeholders.mjs
@@ -19,7 +19,8 @@ const args = [
   ':!node_modules',
   ':!package-lock.json',
   ':!pnpm-lock.yaml',
-  ':!yarn.lock'
+  ':!yarn.lock',
+  ':!scripts/check-placeholders.mjs'
 ];
 
 const result = spawnSync('git', args, {cwd: repoRoot, encoding: 'utf8'});


### PR DESCRIPTION
## Summary
- exclude placeholder checker script from own scan
- test ignoring checker script

## Testing
- `npm test` (fails: TypeError: Cannot redefine property: getQueuedTransactions)
- `npx jest scripts/__tests__/check-placeholders.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b38e4623ec8331965ca1bc62b3bb7b