### PR TITLE
fix: correct firebase client import

### DIFF
--- a/apps/web/src/app/tax-prep/page.tsx
+++ b/apps/web/src/app/tax-prep/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { onAuthStateChanged } from 'firebase/auth';
-import { auth } from '@/app/src/lib/firebaseClient';
-import { apiTaxSummary, downloadTaxCsv } from '@/app/src/lib/taxClient';
+import { auth } from '@/lib/firebase';
+import { apiTaxSummary, downloadTaxCsv } from '../../lib/taxClient';
 
 function currentYear() { return new Date().getFullYear(); }
 function fmt(n: number) { try { return n.toLocaleString(undefined, { style:'currency', currency:'USD' }); } catch { return `$${n.toFixed(2)}`; } }

--- a/apps/web/src/lib/functionsClient.ts
+++ b/apps/web/src/lib/functionsClient.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { auth, FUNCTIONS_ORIGIN } from '@/app/src/lib/firebaseClient';
+import { auth, FUNCTIONS_ORIGIN } from '@/lib/firebase';
 
 async function idToken(): Promise<string> {
   const u = auth.currentUser;

--- a/apps/web/src/lib/taxClient.ts
+++ b/apps/web/src/lib/taxClient.ts
@@ -1,5 +1,5 @@
 'use client';
-import { auth, FUNCTIONS_ORIGIN } from '@/app/src/lib/firebaseClient';
+import { auth, FUNCTIONS_ORIGIN } from '@/lib/firebase';
 
 async function idToken(): Promise<string> { const u = auth.currentUser; if (!u) throw new Error('Not authenticated'); return u.getIdToken(true); }
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -23,6 +23,10 @@ let auth: ReturnType<typeof getAuth> | undefined;
 let db: ReturnType<typeof getFirestore> | undefined;
 let categoriesCollection: ReturnType<typeof collection> | undefined;
 
+export const FUNCTIONS_ORIGIN =
+  process.env.NEXT_PUBLIC_FUNCTIONS_ORIGIN ??
+  `https://us-central1-${process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID}.cloudfunctions.net`;
+
 
 export function initFirebase() {
   if (app) {


### PR DESCRIPTION
## Summary
- use shared firebase module instead of missing firebaseClient
- expose `FUNCTIONS_ORIGIN` from firebase config

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'dataStore' before initialization; TypeError: Cannot redefine property: getQueuedTransactions)*

------
https://chatgpt.com/codex/tasks/task_e_68b38e67782083318fd4070c4e1d57d2