### PR TITLE
test: stub lucide icons with proxy

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom'
 import { jest } from '@jest/globals'
 import { TextEncoder, TextDecoder } from 'node:util'
 
+// Stub all icons from lucide-react to empty components
 jest.mock(
   'lucide-react',
   () =>


### PR DESCRIPTION
## Summary
- stub all lucide-react icons with a Proxy that returns no-op components in Jest setup
- add explanatory comment while resolving merge conflict with main

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38f6db1b88331a14ab1a749419e92