### PR TITLE
fix: retain ts-jest for CommonJS tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,25 +1,17 @@
-const nextJest = require('next/jest');
-
-const createJestConfig = nextJest({
-  dir: './',
-});
-
-/** @type {import('jest').Config} */
-const customJestConfig = {
+module.exports = {
+  preset: 'ts-jest',
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-};
-
-module.exports = async () => {
-  const jestConfig = await createJestConfig(customJestConfig)();
-  jestConfig.transformIgnorePatterns = [
+  transform: {
+    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+  },
+  transformIgnorePatterns: [
     '/node_modules/(?!lucide-react|d3-.*|recharts|embla-carousel-react)',
     '^.+\\.module\\.(css|sass|scss)$',
-  ];
-  return jestConfig;
+  ],
 };
 


### PR DESCRIPTION
## Summary
- restore ts-jest configuration so tests run in CommonJS
- keep transform ignore for ESM dependencies and css modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38f352c3c8331bd161e048ad63f51