### PR TITLE
fix tax client imports

### DIFF
--- a/apps/web/src/app/tax-prep/page.tsx
+++ b/apps/web/src/app/tax-prep/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { onAuthStateChanged } from 'firebase/auth';
-import { auth } from '@/app/src/lib/firebaseClient';
-import { apiTaxSummary, downloadTaxCsv } from '@/app/src/lib/taxClient';
+import { auth } from '@/lib/firebaseClient';
+import { apiTaxSummary, downloadTaxCsv } from '@/lib/taxClient';
 
 function currentYear() { return new Date().getFullYear(); }
 function fmt(n: number) { try { return n.toLocaleString(undefined, { style:'currency', currency:'USD' }); } catch { return `$${n.toFixed(2)}`; } }

--- a/apps/web/src/lib/firebaseClient.ts
+++ b/apps/web/src/lib/firebaseClient.ts
@@ -1,0 +1,4 @@
+import { auth } from '../../../../src/lib/firebase';
+
+export { auth };
+export const FUNCTIONS_ORIGIN = process.env.NEXT_PUBLIC_FUNCTIONS_ORIGIN as string;

--- a/apps/web/src/lib/taxClient.ts
+++ b/apps/web/src/lib/taxClient.ts
@@ -1,5 +1,5 @@
 'use client';
-import { auth, FUNCTIONS_ORIGIN } from '@/app/src/lib/firebaseClient';
+import { auth, FUNCTIONS_ORIGIN } from '@/lib/firebaseClient';
 
 async function idToken(): Promise<string> { const u = auth.currentUser; if (!u) throw new Error('Not authenticated'); return u.getIdToken(true); }
 


### PR DESCRIPTION
## Summary
- add firebase client wrapper exporting auth and FUNCTIONS_ORIGIN
- correct import paths for tax utilities and auth in tax prep page

## Testing
- `npm test` (fails: ReferenceError: Cannot access 'dataStore' before initialization; TypeError: Cannot redefine property: getQueuedTransactions)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b38f032c348331a8b030cc7bee3af7