### PR TITLE
fix: add CORS support and cleanup scripts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,15 +1,19 @@
 name: Verify
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: npm ci
       - name: Placeholder check
         run: node scripts/check-placeholders.mjs
       - name: Type check web
-        run: pnpm --filter web build --if-present
+        run: npm run build --workspace web --if-present

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,1 +1,2 @@
 export * from './plaid';
+export * from './tax';

--- a/packages/workers/src/plaid.ts
+++ b/packages/workers/src/plaid.ts
@@ -31,7 +31,19 @@ async function currentUid(req: any): Promise<string> {
   return decoded.uid;
 }
 
+function handleCors(req: any, res: any): boolean {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+  res.set('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return true;
+  }
+  return false;
+}
+
 export const createLinkToken = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   try {
     const uid = await currentUid(req);
     const resp = await plaid.linkTokenCreate({
@@ -48,6 +60,7 @@ export const createLinkToken = onRequest(async (req, res) => {
 });
 
 export const exchangePublicToken = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   try {
     const uid = await currentUid(req);
     const { public_token } = req.body || {};
@@ -66,6 +79,7 @@ export const exchangePublicToken = onRequest(async (req, res) => {
 });
 
 export const syncTransactions = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   try {
     const uid = await currentUid(req);
     const instSnap = await db.collection('institutions').where('user_id', '==', uid).get();
@@ -94,6 +108,7 @@ export const syncTransactions = onRequest(async (req, res) => {
   }
 });
 
-export const plaidWebhook = onRequest(async (_req, res) => {
+export const plaidWebhook = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   res.json({ ok: true });
 });

--- a/scripts/check-placeholders.mjs
+++ b/scripts/check-placeholders.mjs
@@ -1,7 +1,12 @@
 import { execSync } from 'node:child_process';
-const out = execSync('git grep -n "\\.\\.\\." || true', { encoding: 'utf8' });
-if (out.trim()) {
+const out = execSync('git grep -n "\\.\\.\\." -- . ":!scripts/check-placeholders.mjs" || true', {
+  encoding: 'utf8',
+}).trim();
+if (out) {
   console.error('\nFound literal "..." placeholders in repo. Fix or remove these files before deploying:\n');
-  console.error(out);
+  for (const line of out.split('\n')) {
+    const [file, lineNo] = line.split(':', 2);
+    console.error(`${file}:${lineNo}`);
+  }
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- re-export tax handlers and add CORS middleware for Plaid functions
- sanitize placeholder check script output
- switch verify workflow to npm with limited token permissions

## Testing
- `node scripts/check-placeholders.mjs` (fails: Found literal "..." placeholders in repo)
- `npm test` (fails: 28 failed, 13 passed)


------
https://chatgpt.com/codex/tasks/task_e_68b38ee723d48331925aa04bc9835e7d