### PR TITLE
fix: handle CORS for Plaid handlers and adjust verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,7 @@
 name: Verify
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -8,7 +10,7 @@ jobs:
       - uses: pnpm/action-setup@v3
         with: { version: 9 }
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
       - name: Placeholder check
         run: node scripts/check-placeholders.mjs
       - name: Type check web

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,1 +1,2 @@
 export * from './plaid';
+export * from './tax';

--- a/packages/workers/src/plaid.ts
+++ b/packages/workers/src/plaid.ts
@@ -19,6 +19,17 @@ const configuration = new Configuration({
 const plaid = new PlaidApi(configuration);
 const db = admin.firestore();
 
+function handleCors(req: any, res: any): boolean {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+  res.set('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return true;
+  }
+  return false;
+}
+
 function extractToken(req: any): string {
   const hdr = req.headers.authorization || '';
   if (!hdr.startsWith('Bearer ')) throw new Error('Unauthorized');
@@ -32,6 +43,7 @@ async function currentUid(req: any): Promise<string> {
 }
 
 export const createLinkToken = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   try {
     const uid = await currentUid(req);
     const resp = await plaid.linkTokenCreate({
@@ -48,6 +60,7 @@ export const createLinkToken = onRequest(async (req, res) => {
 });
 
 export const exchangePublicToken = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   try {
     const uid = await currentUid(req);
     const { public_token } = req.body || {};
@@ -66,6 +79,7 @@ export const exchangePublicToken = onRequest(async (req, res) => {
 });
 
 export const syncTransactions = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   try {
     const uid = await currentUid(req);
     const instSnap = await db.collection('institutions').where('user_id', '==', uid).get();
@@ -94,6 +108,7 @@ export const syncTransactions = onRequest(async (req, res) => {
   }
 });
 
-export const plaidWebhook = onRequest(async (_req, res) => {
+export const plaidWebhook = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   res.json({ ok: true });
 });

--- a/scripts/check-placeholders.mjs
+++ b/scripts/check-placeholders.mjs
@@ -2,6 +2,11 @@ import { execSync } from 'node:child_process';
 const out = execSync('git grep -n "\\.\\.\\." || true', { encoding: 'utf8' });
 if (out.trim()) {
   console.error('\nFound literal "..." placeholders in repo. Fix or remove these files before deploying:\n');
-  console.error(out);
+  const files = out
+    .split('\n')
+    .filter(Boolean)
+    .map(line => line.split(':', 2)[0])
+    .join('\n');
+  console.error(files);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- add CORS helper to Plaid Cloud Functions and use it on all handlers
- re-export tax functions from workers entrypoint
- sanitize placeholder check logging
- add permissions to CI workflow and remove frozen lockfile install

## Testing
- `node scripts/check-placeholders.mjs` *(fails: Found literal "..." placeholders in repo)*
- `npm test` *(fails: 28 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b38edb03cc83319e333e3c691a6378