### PR TITLE
chore: address review feedback

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,15 +1,19 @@
 name: Verify
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: npm ci
       - name: Placeholder check
         run: node scripts/check-placeholders.mjs
       - name: Type check web
-        run: pnpm --filter web build --if-present
+        run: npm --prefix apps/web run build --if-present

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,1 +1,2 @@
 export * from './plaid';
+export * from './tax';

--- a/packages/workers/src/plaid.ts
+++ b/packages/workers/src/plaid.ts
@@ -19,6 +19,19 @@ const configuration = new Configuration({
 const plaid = new PlaidApi(configuration);
 const db = admin.firestore();
 
+function withCors(handler: any) {
+  return async (req: any, res: any) => {
+    res.set('Access-Control-Allow-Origin', '*');
+    res.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+    res.set('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+    if (req.method === 'OPTIONS') {
+      res.status(204).end();
+      return;
+    }
+    return handler(req, res);
+  };
+}
+
 function extractToken(req: any): string {
   const hdr = req.headers.authorization || '';
   if (!hdr.startsWith('Bearer ')) throw new Error('Unauthorized');
@@ -31,7 +44,7 @@ async function currentUid(req: any): Promise<string> {
   return decoded.uid;
 }
 
-export const createLinkToken = onRequest(async (req, res) => {
+export const createLinkToken = onRequest(withCors(async (req, res) => {
   try {
     const uid = await currentUid(req);
     const resp = await plaid.linkTokenCreate({
@@ -45,9 +58,9 @@ export const createLinkToken = onRequest(async (req, res) => {
   } catch (e: any) {
     res.status(400).json({ error: e.message });
   }
-});
+}));
 
-export const exchangePublicToken = onRequest(async (req, res) => {
+export const exchangePublicToken = onRequest(withCors(async (req, res) => {
   try {
     const uid = await currentUid(req);
     const { public_token } = req.body || {};
@@ -63,9 +76,9 @@ export const exchangePublicToken = onRequest(async (req, res) => {
   } catch (e: any) {
     res.status(400).json({ error: e.message });
   }
-});
+}));
 
-export const syncTransactions = onRequest(async (req, res) => {
+export const syncTransactions = onRequest(withCors(async (req, res) => {
   try {
     const uid = await currentUid(req);
     const instSnap = await db.collection('institutions').where('user_id', '==', uid).get();
@@ -92,8 +105,8 @@ export const syncTransactions = onRequest(async (req, res) => {
   } catch (e: any) {
     res.status(400).json({ error: e.message });
   }
-});
+}));
 
-export const plaidWebhook = onRequest(async (_req, res) => {
+export const plaidWebhook = onRequest(withCors(async (_req, res) => {
   res.json({ ok: true });
-});
+}));

--- a/scripts/check-placeholders.mjs
+++ b/scripts/check-placeholders.mjs
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
 const out = execSync('git grep -n "\\.\\.\\." || true', { encoding: 'utf8' });
 if (out.trim()) {
-  console.error('\nFound literal "..." placeholders in repo. Fix or remove these files before deploying:\n');
-  console.error(out);
+  console.error('\nFound literal "..." placeholders in repo.');
+  console.error('Run `git grep -n "..."` locally to list affected files.');
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- restrict token permissions and use npm in verify workflow
- sanitize placeholder check output
- add CORS to Plaid HTTP handlers and re-export tax functions

## Testing
- `node scripts/check-placeholders.mjs` *(fails: Found literal "..." placeholders)*
- `npm test` *(fails: Test Suites: 28 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b38ed6c2b88331bb96ed217b796b2c