### PR TITLE
fix: address review comments for Plaid functions and workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,15 +1,19 @@
 name: Verify
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: npm ci
       - name: Placeholder check
         run: node scripts/check-placeholders.mjs
       - name: Type check web
-        run: pnpm --filter web build --if-present
+        run: npm --prefix apps/web run build --if-present

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,1 +1,2 @@
 export * from './plaid';
+export * from './tax';

--- a/packages/workers/src/plaid.ts
+++ b/packages/workers/src/plaid.ts
@@ -31,7 +31,19 @@ async function currentUid(req: any): Promise<string> {
   return decoded.uid;
 }
 
+function handleCors(req: any, res: any): boolean {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Headers', 'Authorization,Content-Type');
+  if (req.method === 'OPTIONS') {
+    res.set('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+    res.status(204).end();
+    return true;
+  }
+  return false;
+}
+
 export const createLinkToken = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   try {
     const uid = await currentUid(req);
     const resp = await plaid.linkTokenCreate({
@@ -48,6 +60,7 @@ export const createLinkToken = onRequest(async (req, res) => {
 });
 
 export const exchangePublicToken = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   try {
     const uid = await currentUid(req);
     const { public_token } = req.body || {};
@@ -66,6 +79,7 @@ export const exchangePublicToken = onRequest(async (req, res) => {
 });
 
 export const syncTransactions = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   try {
     const uid = await currentUid(req);
     const instSnap = await db.collection('institutions').where('user_id', '==', uid).get();
@@ -94,6 +108,7 @@ export const syncTransactions = onRequest(async (req, res) => {
   }
 });
 
-export const plaidWebhook = onRequest(async (_req, res) => {
+export const plaidWebhook = onRequest(async (req, res) => {
+  if (handleCors(req, res)) return;
   res.json({ ok: true });
 });

--- a/scripts/check-placeholders.mjs
+++ b/scripts/check-placeholders.mjs
@@ -1,7 +1,14 @@
 import { execSync } from 'node:child_process';
-const out = execSync('git grep -n "\\.\\.\\." || true', { encoding: 'utf8' });
+// Look for lines that are exactly "..." and list only the file paths.
+const out = execSync(
+  "git grep -l -E '^\\s*\\.\\.\\.\\s*$' || true",
+  { encoding: 'utf8' }
+);
+
 if (out.trim()) {
-  console.error('\nFound literal "..." placeholders in repo. Fix or remove these files before deploying:\n');
+  console.error(
+    '\nFound literal "..." placeholders in repo. Fix or remove these files before deploying:\n'
+  );
   console.error(out);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- sanitize placeholder script to only flag standalone ellipsis markers
- restore tax function exports and add CORS handling for Plaid HTTP handlers
- switch verify workflow to npm with minimal token permissions

## Testing
- `node scripts/check-placeholders.mjs`
- `npm --prefix apps/web run build --if-present` *(fails: Configuring Next.js via `next.config.ts` is not supported)*
- `npm test` *(fails: Cannot find module '../../apps/web/src/components/transactions/add-transaction-dialog' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b38ed4e6708331909396613e41eedb