### PR TITLE
fix: enforce user ownership on firestore updates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,8 +9,9 @@ service cloud.firestore {
     match /{c}/{id} where c in [
       'institutions','accounts','transactions','receipts','paystubs','rules','budgets','summaries','goals','tax_profiles'
     ] {
-      allow read, write: if owner(resource.data.user_id);
+      allow read: if owner(resource.data.user_id);
       allow create: if authed() && request.resource.data.user_id == request.auth.uid;
+      allow update, delete: if resource.data.user_id == request.auth.uid && request.resource.data.user_id == request.auth.uid;
     }
   }
 }


### PR DESCRIPTION
## Summary
- enforce `request.resource.data.user_id` during updates to prevent cross-tenant writes

## Testing
- `node scripts/check-placeholders.mjs`
- `NEXT_PUBLIC_FIREBASE_API_KEY=a NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=a NEXT_PUBLIC_FIREBASE_PROJECT_ID=a NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=a NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=a NEXT_PUBLIC_FIREBASE_APP_ID=a pnpm --filter web --if-present build`
- `pnpm --filter functions build`


------
https://chatgpt.com/codex/tasks/task_e_68b38ec15d2c83319668ebf408b3d193