### PR TITLE
fix: sanitize placeholder check logging

### DIFF
--- a/scripts/check-placeholders.mjs
+++ b/scripts/check-placeholders.mjs
@@ -16,15 +16,15 @@ for (const file of files) {
   const lines = content.split(/\r?\n/);
   lines.forEach((line, idx) => {
     if (ellipsisRegex.test(line)) {
-      offenders.push(`${file}:${idx + 1}: ${line.trim()}`);
+      offenders.push({ file, line: idx + 1 });
     }
   });
 }
 
 if (offenders.length) {
   console.error('Found standalone ellipsis placeholders:');
-  for (const o of offenders) {
-    console.error(` - ${o}`);
+  for (const { file, line } of offenders) {
+    console.error(' - %s:%d', file, line);
   }
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- avoid logging entire source line when reporting ellipsis placeholders to prevent leaking sensitive info

## Testing
- `node scripts/check-placeholders.mjs`
- `npm run lint`
- `npm test` *(fails: Cannot access 'dataStore' before initialization; TypeError: Cannot redefine property: getQueuedTransactions)*

------
https://chatgpt.com/codex/tasks/task_e_68b38eb048188331a97fa033ca48d02f