### PR TITLE
refactor: mock offline retrieval

### DIFF
--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -118,6 +118,7 @@ describe("ServiceWorker", () => {
     const getQueuedMock = offline.getQueuedTransactions as jest.MockedFunction<
       typeof offline.getQueuedTransactions
     >
+    getQueuedMock.mockClear()
     getQueuedMock.mockResolvedValueOnce({
       ok: false,
       error: new Error("failed"),


### PR DESCRIPTION
## Summary
- replace spy with jest.mock for offline transaction retrieval
- validate ServiceWorker handles queued retrieval errors
- clear offline retrieval mock history before ServiceWorker assertion

## Testing
- `npm test src/__tests__/offline.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b38ea659048331963c39b3f6495494