### PR TITLE
fix(functions): harden Plaid workers

### DIFF
--- a/packages/workers/src/plaid.ts
+++ b/packages/workers/src/plaid.ts
@@ -58,7 +58,10 @@ async function decrypt(ciphertextB64: string): Promise<string> {
 }
 
 function txFingerprint(accountId: string, amount: number, merchant: string | undefined, dateISO: string) {
-  return crypto.createHash('sha1').update(`${accountId}|${amount.toFixed(2)}|${merchant ?? ''}|${dateISO}`).digest('hex');
+  return crypto
+    .createHash('sha256')
+    .update(`${accountId}|${amount.toFixed(2)}|${merchant ?? ''}|${dateISO}`)
+    .digest('hex');
 }
 
 export const createLinkToken = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV] }, async (req, res) => {
@@ -74,7 +77,10 @@ export const createLinkToken = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECR
       language: 'en'
     });
     res.json({ link_token: resp.data.link_token });
-  } catch (e: any) { logger.error('createLinkToken error', e); res.status(400).json({ error: e.message }); }
+  } catch (e: any) {
+    logger.error('createLinkToken error', { message: e.message });
+    res.status(400).json({ error: e.message });
+  }
 });
 
 export const exchangePublicToken = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV, KMS_KEY] }, async (req, res) => {
@@ -105,7 +111,10 @@ export const exchangePublicToken = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_
 
     await runSync(uid, itemId, accessToken);
     res.json({ item_id: itemId, accounts: accs.data.accounts.length });
-  } catch (e: any) { logger.error('exchangePublicToken error', e); res.status(400).json({ error: e.message }); }
+  } catch (e: any) {
+    logger.error('exchangePublicToken error', { message: e.message });
+    res.status(400).json({ error: e.message });
+  }
 });
 
 export const syncItemNow = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV, KMS_KEY] }, async (req, res) => {
@@ -120,7 +129,10 @@ export const syncItemNow = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET, 
     const token = await decrypt(inst.get('plaid_access_token'));
     await runSync(uid, itemId, token);
     res.json({ ok: true });
-  } catch (e: any) { logger.error('syncItemNow error', e); res.status(400).json({ error: e.message }); }
+  } catch (e: any) {
+    logger.error('syncItemNow error', { message: e.message });
+    res.status(400).json({ error: e.message });
+  }
 });
 
 export const plaidWebhook = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV, KMS_KEY] }, async (req, res) => {
@@ -128,7 +140,7 @@ export const plaidWebhook = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET,
     // No CORS here; Plaid calls server-to-server
     const body = req.body || {}; const itemId = body.item_id as string | undefined;
     const type = body.webhook_type as string; const code = body.webhook_code as string;
-    logger.info('Plaid webhook', { type, code, itemId });
+    logger.info('Plaid webhook', { type, code });
 
     if (type === 'TRANSACTIONS' && code === 'SYNC_UPDATES_AVAILABLE' && itemId) {
       const inst = await db.collection('institutions').doc(itemId).get();
@@ -138,7 +150,10 @@ export const plaidWebhook = onRequest({ secrets: [PLAID_CLIENT_ID, PLAID_SECRET,
       }
     }
     res.status(200).send('ok');
-  } catch (e: any) { logger.error('webhook error', e); res.status(200).send('ok'); }
+  } catch (e: any) {
+    logger.error('webhook error', { message: e.message });
+    res.status(200).send('ok');
+  }
 });
 
 async function runSync(uid: string, itemId: string, accessToken: string) {
@@ -192,14 +207,18 @@ async function runSync(uid: string, itemId: string, accessToken: string) {
     addedCount += resp.data.added.length; modifiedCount += resp.data.modified.length; removedCount += resp.data.removed.length;
     cursor = resp.data.next_cursor; hasMore = !!resp.data.has_more;
   }
-  logger.info('sync complete', { itemId, addedCount, modifiedCount, removedCount });
+  logger.info('sync complete', { addedCount, modifiedCount, removedCount });
 }
 
-export const nightlySafetySync = onSchedule('0 5 * * *', async () => {
-  const insts = await db.collection('institutions').where('status', '==', 'active').get();
-  for (const docSnap of insts.docs) {
-    const uid = docSnap.get('user_id');
-    const token = await decrypt(docSnap.get('plaid_access_token'));
-    await runSync(uid, docSnap.id, token);
-  }
-});
+export const nightlySafetySync = onSchedule(
+  '0 5 * * *',
+  { secrets: [PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV, KMS_KEY] },
+  async () => {
+    const insts = await db.collection('institutions').where('status', '==', 'active').get();
+    for (const docSnap of insts.docs) {
+      const uid = docSnap.get('user_id');
+      const token = await decrypt(docSnap.get('plaid_access_token'));
+      await runSync(uid, docSnap.id, token);
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- strengthen tx fingerprint hashing and remove sensitive details from logs
- mount required secrets for nightly Plaid sync

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'dataStore' before initialization; TypeError: Cannot redefine property: getQueuedTransactions)*

------
https://chatgpt.com/codex/tasks/task_e_68b38e88e5d88331a437da4749ef121b