### PR TITLE
Enforce POST for tax functions and client

### DIFF
--- a/apps/web/src/lib/taxClient.ts
+++ b/apps/web/src/lib/taxClient.ts
@@ -14,9 +14,13 @@ export async function apiTaxSummary(year: number) {
 }
 
 export async function downloadTaxCsv(year: number) {
-  const res = await fetch(`${FUNCTIONS_ORIGIN}/taxYearCsv?year=${year}`, {
+  const res = await fetch(`${FUNCTIONS_ORIGIN}/taxYearCsv`, {
     method: 'POST',
-    headers: { 'Authorization': `Bearer ${await idToken()}` },
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${await idToken()}`
+    },
+    body: JSON.stringify({ year }),
   });
   if (!res.ok) throw new Error(await res.text());
   const blob = await res.blob();

--- a/packages/workers/src/tax.ts
+++ b/packages/workers/src/tax.ts
@@ -31,6 +31,10 @@ async function requireUser(req: any): Promise<string> {
 function toUSD(n: number) { return Math.round(n * 100) / 100; }
 
 export const taxYearSummary = onRequest(async (req, res) => {
+  if (req.method !== 'POST') {
+    res.set('Allow', 'POST').status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
   try {
     const uid = await requireUser(req);
     const year = Number(req.body?.year || req.query?.year || new Date().getUTCFullYear());
@@ -78,6 +82,10 @@ export const taxYearSummary = onRequest(async (req, res) => {
 });
 
 export const taxYearCsv = onRequest(async (req, res) => {
+  if (req.method !== 'POST') {
+    res.set('Allow', 'POST').status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
   try {
     const uid = await requireUser(req);
     const year = Number(req.body?.year || req.query?.year || new Date().getUTCFullYear());


### PR DESCRIPTION
## Summary
- return 405 for non-POST requests to `taxYearSummary` and `taxYearCsv`
- POST year in request body for `downloadTaxCsv`

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden in offline.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b394f61c448331ba2fff65e8d7fde5