### PR TITLE
fix: enforce user ownership on firestore updates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -11,7 +11,8 @@ service cloud.firestore {
     ] {
       allow read: if owner(resource.data.user_id);
       allow create: if authed() && request.resource.data.user_id == request.auth.uid;
-      allow update, delete: if resource.data.user_id == request.auth.uid && request.resource.data.user_id == request.auth.uid;
+      allow update: if resource.data.user_id == request.auth.uid && request.resource.data.user_id == request.auth.uid;
+      allow delete: if resource.data.user_id == request.auth.uid;
     }
   }
 }


### PR DESCRIPTION
## Summary
- split delete rule to avoid request.resource null errors

## Testing
- `node scripts/check-placeholders.mjs`
- `NEXT_PUBLIC_FIREBASE_API_KEY=a NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=a NEXT_PUBLIC_FIREBASE_PROJECT_ID=a NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=a NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=a NEXT_PUBLIC_FIREBASE_APP_ID=a pnpm --filter web --if-present build`
- `pnpm --filter functions build`


------
https://chatgpt.com/codex/tasks/task_e_68b3956cc1a08331b46ac94c844a4f63