### PR TITLE
feat: add firebase client module

### DIFF
--- a/apps/web/src/app/tax-prep/page.tsx
+++ b/apps/web/src/app/tax-prep/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { onAuthStateChanged } from 'firebase/auth';
-import { auth } from '@/app/src/lib/firebaseClient';
-import { apiTaxSummary, downloadTaxCsv } from '@/app/src/lib/taxClient';
+import { auth } from '@/lib/firebaseClient';
+import { apiTaxSummary, downloadTaxCsv } from '@/lib/taxClient';
 
 function currentYear() { return new Date().getFullYear(); }
 function fmt(n: number) { try { return n.toLocaleString(undefined, { style:'currency', currency:'USD' }); } catch { return `$${n.toFixed(2)}`; } }

--- a/apps/web/src/lib/taxClient.ts
+++ b/apps/web/src/lib/taxClient.ts
@@ -1,5 +1,5 @@
 'use client';
-import { auth, FUNCTIONS_ORIGIN } from '@/app/src/lib/firebaseClient';
+import { auth, FUNCTIONS_ORIGIN } from '@/lib/firebaseClient';
 
 async function idToken(): Promise<string> { const u = auth.currentUser; if (!u) throw new Error('Not authenticated'); return u.getIdToken(true); }
 

--- a/src/lib/firebaseClient.ts
+++ b/src/lib/firebaseClient.ts
@@ -1,0 +1,7 @@
+import { initFirebase } from './firebase';
+
+const { auth } = initFirebase();
+
+export { auth };
+
+export const FUNCTIONS_ORIGIN = process.env.NEXT_PUBLIC_FUNCTIONS_ORIGIN;


### PR DESCRIPTION
## Summary
- add firebaseClient helper to expose auth and FUNCTIONS_ORIGIN
- fix tax-prep imports to use new firebase client

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b394f363d08331ae2af431eac619aa