### PR TITLE
test: add chunkTransactions splitting tests

### DIFF
--- a/src/__tests__/chunkTransactions.test.ts
+++ b/src/__tests__/chunkTransactions.test.ts
@@ -6,4 +6,12 @@ describe("chunkTransactions", () => {
       /chunkSize must be greater than 0/
     );
   });
+
+  it("splits large arrays into default-size chunks", () => {
+    const arr = Array.from({ length: 1500 }, (_, i) => i);
+    const chunks = chunkTransactions(arr);
+    expect(chunks).toHaveLength(3);
+    chunks.forEach((chunk) => expect(chunk).toHaveLength(500));
+    expect(chunks.flat()).toEqual(arr);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure chunkTransactions throws on chunkSize <= 0
- verify large arrays are split into default-size chunks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b394fb2ed48331b4aa9cf3598bf96d