### PR TITLE
Document CRON secret for housekeeping schedule

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ NEXT_PUBLIC_FIREBASE_APP_ID=REPLACE_WITH_VALUE
 RETENTION_DAYS=REPLACE_WITH_VALUE
 
 # Shared secret expected in the `X-CRON-SECRET` header for housekeeping runs.
-CRON_SECRET=REPLACE_WITH_VALUE
+CRON_SECRET=
 
 # Optional IANA timezone used when synchronizing time with the network. Defaults to the system timezone.
 # DEFAULT_TZ=Etc/UTC

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The housekeeping service removes outdated files from Cloud Storage to manage cos
 ### Scheduled deployment
 - Deploy the service with `firebase deploy --only run.housekeeping`.
 - A Cloud Scheduler job triggers the service nightly at 03:00 UTC.
-- Include an `X-CRON-SECRET` header in the job using the `CRON_SECRET` value to authenticate requests.
+- Set a `CRON_SECRET` environment variable and configure the Cloud Scheduler job to send an `X-CRON-SECRET` header with the same value to authenticate requests and prevent unauthorized triggers.
 - Update the schedule in the Firebase console if a different cadence is required.
 - The endpoint enforces a rate limit and rejects rapid repeated calls with HTTP 429.
 

--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -131,7 +131,7 @@ describe("ServiceWorker", () => {
     const fetchMock = jest.fn()
     globalAny.fetch = fetchMock as unknown as typeof fetch
 
-    const { ServiceWorker } = require("../components/service-worker")
+    const { ServiceWorker } = await import("../components/service-worker")
     render(React.createElement(ServiceWorker))
 
     await act(async () => {


### PR DESCRIPTION
## Summary
- add CRON_SECRET placeholder to `.env.example`
- explain how CRON_SECRET authenticates Cloud Scheduler requests in README
- switch offline test to dynamic import to satisfy lint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b394faa47c83319025fa2a476824ad