### PR TITLE
feat: add domain schemas package

### DIFF
--- a/packages/domain/__tests__/schemas.test.ts
+++ b/packages/domain/__tests__/schemas.test.ts
@@ -1,0 +1,80 @@
+import {
+  UserSchema,
+  TransactionSchema,
+  DebtAccountSchema,
+  RecurrenceValues,
+} from "../src";
+
+describe("domain schemas", () => {
+  it("parses a valid user", () => {
+    const input = { uid: "u1", email: "test@example.com", displayName: "Test" };
+    const user = UserSchema.parse(input);
+    expect(user).toEqual(input);
+    expect(JSON.parse(JSON.stringify(user))).toEqual(input);
+  });
+
+  it("rejects an invalid user", () => {
+    expect(() => UserSchema.parse({ uid: "u1", email: "not-an-email" })).toThrow();
+  });
+
+  it("parses a valid transaction", () => {
+    const input = {
+      id: "t1",
+      date: "2024-01-01",
+      description: "Test",
+      amount: 100,
+      currency: "USD",
+      type: "Income" as const,
+      category: "General",
+      isRecurring: true,
+    };
+    const tx = TransactionSchema.parse(input);
+    expect(tx).toEqual(input);
+    expect(JSON.parse(JSON.stringify(tx))).toEqual(input);
+  });
+
+  it("rejects an invalid transaction", () => {
+    const bad = {
+      id: "t1",
+      date: "2024-01-01",
+      description: "Test",
+      amount: "100",
+      currency: "USD",
+      type: "Income",
+      category: "General",
+    } as unknown;
+    expect(() => TransactionSchema.parse(bad)).toThrow();
+  });
+
+  it("parses a valid debt account", () => {
+    const input = {
+      id: "d1",
+      name: "Loan",
+      initialAmount: 1000,
+      currentAmount: 900,
+      interestRate: 5,
+      minimumPayment: 50,
+      dueDate: "2024-01-01",
+      recurrence: RecurrenceValues[1],
+      autopay: false,
+    };
+    const debt = DebtAccountSchema.parse(input);
+    expect(debt).toEqual(input);
+    expect(JSON.parse(JSON.stringify(debt))).toEqual(input);
+  });
+
+  it("rejects an invalid debt account", () => {
+    const bad = {
+      id: "d1",
+      name: "Loan",
+      initialAmount: 1000,
+      currentAmount: 900,
+      interestRate: 5,
+      minimumPayment: 50,
+      dueDate: "2024-01-01",
+      recurrence: "yearly",
+      autopay: false,
+    } as unknown;
+    expect(() => DebtAccountSchema.parse(bad)).toThrow();
+  });
+});

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@domain",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "zod": "^3.24.2"
+  }
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+export const RecurrenceValues = ["none", "weekly", "biweekly", "monthly"] as const;
+export const RecurrenceSchema = z.enum(RecurrenceValues);
+export type Recurrence = z.infer<typeof RecurrenceSchema>;
+
+export const UserSchema = z.object({
+  uid: z.string(),
+  email: z.string().email().optional(),
+  displayName: z.string().optional(),
+});
+export type User = z.infer<typeof UserSchema>;
+
+export const TransactionSchema = z.object({
+  id: z.string(),
+  date: z.string(),
+  description: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  type: z.enum(["Income", "Expense"]),
+  category: z.string(),
+  isRecurring: z.boolean().optional(),
+});
+export type Transaction = z.infer<typeof TransactionSchema>;
+
+export const GoalSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  targetAmount: z.number(),
+  currentAmount: z.number(),
+  deadline: z.string(),
+  importance: z.number(),
+});
+export type Goal = z.infer<typeof GoalSchema>;
+
+export const ChartPointSchema = z.object({
+  month: z.string(),
+  income: z.number(),
+  expenses: z.number(),
+});
+export type ChartPoint = z.infer<typeof ChartPointSchema>;
+
+export const DebtAccountSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  initialAmount: z.number(),
+  currentAmount: z.number(),
+  interestRate: z.number(),
+  minimumPayment: z.number(),
+  dueDate: z.string(),
+  recurrence: RecurrenceSchema,
+  autopay: z.boolean(),
+  notes: z.string().optional(),
+  color: z.string().optional(),
+  paidDates: z.array(z.string()).optional(),
+});
+export type DebtAccount = z.infer<typeof DebtAccountSchema>;
+

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,48 +1,8 @@
-
-export type Transaction = {
-  id: string;
-  date: string;
-  description: string;
-  amount: number;
-  currency: string; // ISO currency code
-  type: "Income" | "Expense";
-  category: string;
-  isRecurring?: boolean;
-};
-
-export type Goal = {
-  id: string;
-  name: string;
-  targetAmount: number;
-  currentAmount: number;
-  deadline: string;
-  importance: number; // New field: 1-5 rating
-};
-
-export interface ChartPoint {
-  month: string;
-  income: number;
-  expenses: number;
-}
-
-export const RecurrenceValues = ["none", "weekly", "biweekly", "monthly"] as const;
-export type Recurrence = typeof RecurrenceValues[number];
-
-// This is the unified, authoritative Debt type used across the app.
-export type Debt = {
-  id: string;
-  name: string;
-  initialAmount: number;
-  currentAmount: number;
-  interestRate: number;
-  minimumPayment: number;
-  // Due date handling:
-  // For recurring debts, this is the anchor date for recurrence calculation.
-  // For one-time debts, this is the specific due date.
-  dueDate: string; 
-  recurrence: Recurrence;
-  autopay: boolean;
-  notes?: string;
-  color?: string;
-  paidDates?: string[]; // ISO strings of dates where a payment was manually marked as paid
-};
+export {
+  type Transaction,
+  type Goal,
+  type ChartPoint,
+  RecurrenceValues,
+  type Recurrence,
+  type DebtAccount as Debt,
+} from "../../packages/domain/src";


### PR DESCRIPTION
## Summary
- extract core entity schemas (User, Transaction, DebtAccount, etc.) to new packages/domain module
- re-export domain types via src/lib/types.ts
- add unit tests covering schema parse/serialize behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3db31b07083319ed53637cf6fe614