### PR TITLE
chore: migrate tests to vitest

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -4,21 +4,22 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { useAuth } from '../components/auth/auth-provider';
 import { ClientProviders } from '@/components/layout/client-providers';
+import { vi } from 'vitest';
 
 let mockPathname = '/';
-const pushMock = jest.fn();
+const pushMock = vi.fn();
 
-jest.mock('next/navigation', () => ({
+vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock }),
   usePathname: () => mockPathname,
 }));
 
-jest.mock('@/lib/firebase', () => ({
+vi.mock('@/lib/firebase', () => ({
   auth: {
     currentUser: null,
     app: { options: { apiKey: 'test' }, name: '[DEFAULT]' },
   },
-  initFirebase: jest.fn(),
+  initFirebase: vi.fn(),
 }));
 import { auth as authStub, initFirebase } from '@/lib/firebase';
 
@@ -34,15 +35,15 @@ beforeAll(() => {
 
 type User = { uid: string } | null;
 let mockUser: User = null;
-const onAuthStateChanged = jest.fn(
+const onAuthStateChanged = vi.fn(
   (_auth: unknown, cb: (u: User) => void) => {
     cb(mockUser);
     return () => {};
   }
 );
 
-jest.mock('firebase/auth', () => ({
-  ...jest.requireActual('firebase/auth'),
+vi.mock('firebase/auth', async () => ({
+  ...(await vi.importActual<typeof import('firebase/auth')>('firebase/auth')),
   onAuthStateChanged: (
     ...args: Parameters<typeof onAuthStateChanged>
   ) => onAuthStateChanged(...args),
@@ -54,7 +55,7 @@ function DisplayUser() {
 }
 
 // Mock the ServiceWorker component as it's not relevant to this test
-jest.mock('@/components/service-worker', () => ({
+vi.mock('@/components/service-worker', () => ({
   ServiceWorker: () => null,
 }));
 

--- a/src/__tests__/carousel.test.tsx
+++ b/src/__tests__/carousel.test.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Carousel } from '@/components/ui/carousel';
+import { vi, type Mock } from 'vitest';
 
-const onMock = jest.fn();
-const offMock = jest.fn();
+const onMock = vi.fn();
+const offMock = vi.fn();
 type MockEmblaApi = {
-  on: jest.Mock;
-  off: jest.Mock;
-  canScrollPrev: jest.Mock;
-  canScrollNext: jest.Mock;
-  scrollPrev: jest.Mock;
-  scrollNext: jest.Mock;
+  on: Mock;
+  off: Mock;
+  canScrollPrev: Mock;
+  canScrollNext: Mock;
+  scrollPrev: Mock;
+  scrollNext: Mock;
 };
 let emblaApi: MockEmblaApi;
 
@@ -18,15 +19,15 @@ function mockUseEmbla() {
   emblaApi = {
     on: onMock,
     off: offMock,
-    canScrollPrev: jest.fn().mockReturnValue(false),
-    canScrollNext: jest.fn().mockReturnValue(false),
-    scrollPrev: jest.fn(),
-    scrollNext: jest.fn(),
+    canScrollPrev: vi.fn().mockReturnValue(false),
+    canScrollNext: vi.fn().mockReturnValue(false),
+    scrollPrev: vi.fn(),
+    scrollNext: vi.fn(),
   };
-  return [jest.fn(), emblaApi];
+  return [vi.fn(), emblaApi];
 }
 
-jest.mock('embla-carousel-react', () => ({
+vi.mock('embla-carousel-react', () => ({
   __esModule: true,
   default: mockUseEmbla,
   useEmblaCarousel: mockUseEmbla,
@@ -34,7 +35,7 @@ jest.mock('embla-carousel-react', () => ({
 
 describe('Carousel', () => {
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('removes event listeners on unmount', () => {

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -3,16 +3,17 @@
  */
 import { runHousekeeping } from "@/lib/housekeeping";
 import { getCurrentTime } from "@/lib/internet-time";
+import { vi, type Mock } from "vitest";
 
-jest.mock("@/lib/housekeeping", () => ({
-  runHousekeeping: jest.fn().mockResolvedValue(undefined),
+vi.mock("@/lib/housekeeping", () => ({
+  runHousekeeping: vi.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock("@/lib/internet-time", () => ({
-  getCurrentTime: jest.fn(),
+vi.mock("@/lib/internet-time", () => ({
+  getCurrentTime: vi.fn(),
 }));
 
-jest.mock("@/lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
+vi.mock("@/lib/firebase", () => ({ db: {}, initFirebase: vi.fn() }));
 import { initFirebase } from "@/lib/firebase";
 
 const secret = "test-secret";
@@ -33,7 +34,7 @@ beforeAll(async () => {
   resetRateLimit = mod.resetRateLimit;
 });
 
-jest.mock("firebase/firestore", () => {
+vi.mock("firebase/firestore", () => {
   const store: { lastRun?: number } = {};
   interface Tx {
     get: () => Promise<{
@@ -45,7 +46,7 @@ jest.mock("firebase/firestore", () => {
   return {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     doc: (_db: unknown, _col: string, _id: string) => ({}),
-    runTransaction: jest.fn(
+    runTransaction: vi.fn(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       async (_db: unknown, updateFn: (tx: Tx) => Promise<unknown>) => {
         // eslint-disable-next-line no-constant-condition
@@ -73,7 +74,7 @@ jest.mock("firebase/firestore", () => {
         }
       }
     ),
-    setDoc: jest.fn(async (_ref: unknown, data: { lastRun: number }) => {
+    setDoc: vi.fn(async (_ref: unknown, data: { lastRun: number }) => {
       store.lastRun = data.lastRun;
     }),
     __store: store,
@@ -84,8 +85,8 @@ describe("/api/cron/housekeeping", () => {
   beforeEach(async () => {
     process.env.CRON_SECRET = secret;
     await resetRateLimit();
-    (runHousekeeping as jest.Mock).mockClear();
-    (getCurrentTime as jest.Mock).mockResolvedValue(new Date(61_000));
+    (runHousekeeping as Mock).mockClear();
+    (getCurrentTime as Mock).mockResolvedValue(new Date(61_000));
   });
 
   it("returns 401 when secret is missing or invalid", async () => {

--- a/src/__tests__/importTransactions.test.ts
+++ b/src/__tests__/importTransactions.test.ts
@@ -1,17 +1,20 @@
 import { importTransactions } from "../lib/transactions";
 import { getDocs } from "firebase/firestore";
+import { vi, type Mock } from "vitest";
 
-jest.mock("firebase/firestore", () => {
-  const actual = jest.requireActual("firebase/firestore");
+vi.mock("firebase/firestore", async () => {
+  const actual = await vi.importActual<typeof import("firebase/firestore")>(
+    "firebase/firestore",
+  );
   return {
     ...actual,
-    getDocs: jest.fn(),
+    getDocs: vi.fn(),
   };
 });
 
 describe("importTransactions", () => {
   it("throws a descriptive error when fetching categories fails", async () => {
-    (getDocs as jest.Mock).mockRejectedValue(new Error("network failure"));
+    (getDocs as Mock).mockRejectedValue(new Error("network failure"));
     await expect(importTransactions([])).rejects.toThrow(
       /Failed to fetch categories: network failure/
     );

--- a/src/__tests__/internet-time.test.ts
+++ b/src/__tests__/internet-time.test.ts
@@ -3,25 +3,26 @@ import {
   getCurrentTime,
   __resetInternetTimeOffset,
 } from "@/lib/internet-time";
+import { vi, type Mock } from "vitest";
 
 describe("internet time", () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     __resetInternetTimeOffset();
-    (globalThis as { fetch: jest.Mock }).fetch = jest.fn();
+    (globalThis as { fetch: Mock }).fetch = vi.fn();
     delete process.env.DEFAULT_TZ;
   });
 
   afterEach(() => {
-    jest.useRealTimers();
-    jest.restoreAllMocks();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("calculates offset and adjusts current time", async () => {
     const deviceNow = new Date("2024-01-01T00:00:00Z").getTime();
-    jest.setSystemTime(deviceNow);
+    vi.setSystemTime(deviceNow);
     const networkTime = new Date(deviceNow + 5000).toISOString();
-    (fetch as jest.Mock).mockResolvedValue({
+    (fetch as Mock).mockResolvedValue({
       ok: true,
       json: async () => ({ datetime: networkTime }),
     });
@@ -29,7 +30,7 @@ describe("internet time", () => {
     const fetched = await fetchInternetTime("Etc/UTC");
     expect(fetched.toISOString()).toBe(networkTime);
 
-    jest.setSystemTime(deviceNow + 1000);
+    vi.setSystemTime(deviceNow + 1000);
     const current = await getCurrentTime("Etc/UTC");
     expect(current.getTime()).toBe(deviceNow + 1000 + 5000);
     expect(fetch).toHaveBeenCalledTimes(1);
@@ -37,8 +38,8 @@ describe("internet time", () => {
 
   it("falls back to device time when fetch fails", async () => {
     const deviceNow = 123456;
-    jest.setSystemTime(deviceNow);
-    (fetch as jest.Mock).mockRejectedValue(new Error("fail"));
+    vi.setSystemTime(deviceNow);
+    (fetch as Mock).mockRejectedValue(new Error("fail"));
 
     const current = await getCurrentTime("Etc/UTC");
     expect(current.getTime()).toBe(deviceNow);
@@ -48,30 +49,30 @@ describe("internet time", () => {
   it("uses environment timezone by default", async () => {
     process.env.DEFAULT_TZ = "Etc/UTC";
     const deviceNow = 0;
-    jest.setSystemTime(deviceNow);
-    (fetch as jest.Mock).mockResolvedValue({
+    vi.setSystemTime(deviceNow);
+    (fetch as Mock).mockResolvedValue({
       ok: true,
       json: async () => ({ datetime: new Date(deviceNow).toISOString() }),
     });
 
     await getCurrentTime();
-    expect((fetch as jest.Mock).mock.calls[0][0]).toContain("/Etc/UTC");
+    expect((fetch as Mock).mock.calls[0][0]).toContain("/Etc/UTC");
   });
 
   it("allows overriding timezone", async () => {
     const deviceNow = 0;
-    jest.setSystemTime(deviceNow);
-    (fetch as jest.Mock).mockResolvedValue({
+    vi.setSystemTime(deviceNow);
+    (fetch as Mock).mockResolvedValue({
       ok: true,
       json: async () => ({ datetime: new Date(deviceNow).toISOString() }),
     });
 
     await getCurrentTime("Asia/Tokyo");
-    expect((fetch as jest.Mock).mock.calls[0][0]).toContain("/Asia/Tokyo");
+    expect((fetch as Mock).mock.calls[0][0]).toContain("/Asia/Tokyo");
   });
 
   it("times out after 5s", async () => {
-    (fetch as jest.Mock).mockImplementation(
+    (fetch as Mock).mockImplementation(
       (_url: string, opts: { signal: AbortSignal }) =>
         new Promise((_resolve, reject) => {
           opts.signal.addEventListener("abort", () => {
@@ -83,12 +84,12 @@ describe("internet time", () => {
     );
 
     const promise = fetchInternetTime("Etc/UTC");
-    jest.advanceTimersByTime(5000);
+    vi.advanceTimersByTime(5000);
     await expect(promise).rejects.toThrow("timed out");
   });
 
   it("throws detailed error for non-200 responses", async () => {
-    (fetch as jest.Mock).mockResolvedValue({
+    (fetch as Mock).mockResolvedValue({
       ok: false,
       status: 500,
       statusText: "Internal Error",

--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -1,4 +1,6 @@
-jest.mock("idb", () => {
+import { vi, type Mock } from "vitest"
+
+vi.mock("idb", () => {
   const store: unknown[] = []
   const createCursor = (index: number) => ({
     async delete() {
@@ -9,7 +11,7 @@ jest.mock("idb", () => {
     },
   })
   return {
-    openDB: jest.fn(async () => ({
+    openDB: vi.fn(async () => ({
       add: async (_store: string, value: unknown) => {
         store.push(value)
       },
@@ -28,16 +30,18 @@ jest.mock("idb", () => {
   }
 })
 
-jest.mock("../lib/firebase", () => ({
-  auth: { currentUser: { getIdToken: jest.fn().mockResolvedValue("token") } },
-  initFirebase: jest.fn(),
+vi.mock("../lib/firebase", () => ({
+  auth: { currentUser: { getIdToken: vi.fn().mockResolvedValue("token") } },
+  initFirebase: vi.fn(),
 }))
 
-jest.mock("../lib/offline", () => {
-  const actual = jest.requireActual("../lib/offline")
+vi.mock("../lib/offline", async () => {
+  const actual = await vi.importActual<typeof import("../lib/offline")>(
+    "../lib/offline",
+  )
   return {
     ...actual,
-    getQueuedTransactions: jest.fn(actual.getQueuedTransactions),
+    getQueuedTransactions: vi.fn(actual.getQueuedTransactions),
   }
 })
 
@@ -118,30 +122,30 @@ describe("offline fallbacks", () => {
 
 describe("ServiceWorker", () => {
   it("handles queued transaction retrieval errors gracefully", async () => {
-    jest.useFakeTimers()
-    const getQueuedMock = offline.getQueuedTransactions as jest.Mock
+    vi.useFakeTimers()
+    const getQueuedMock = offline.getQueuedTransactions as Mock
     getQueuedMock.mockClear()
     getQueuedMock.mockResolvedValueOnce({
       ok: false,
       error: new Error("failed"),
     })
 
-    const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {})
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {})
 
-    const fetchMock = jest.fn()
+    const fetchMock = vi.fn()
     globalAny.fetch = fetchMock as unknown as typeof fetch
 
     const { ServiceWorker } = require("../components/service-worker")
     render(React.createElement(ServiceWorker))
 
     await act(async () => {
-      jest.runOnlyPendingTimers()
+      vi.runOnlyPendingTimers()
     })
 
     expect(getQueuedMock).toHaveBeenCalled()
     expect(fetchMock).not.toHaveBeenCalled()
 
-    jest.useRealTimers()
+    vi.useRealTimers()
     delete globalAny.fetch
     errorSpy.mockRestore()
   })

--- a/src/__tests__/service-worker.test.tsx
+++ b/src/__tests__/service-worker.test.tsx
@@ -1,18 +1,19 @@
 import { render, act } from "@testing-library/react"
 import { ServiceWorker } from "../components/service-worker"
+import { vi, type Mock } from "vitest"
 
-jest.mock("../lib/offline", () => ({
-  getQueuedTransactions: jest
+vi.mock("../lib/offline", () => ({
+  getQueuedTransactions: vi
     .fn()
     .mockResolvedValue({ ok: true, value: [{ id: 1 }] }),
-  clearQueuedTransactions: jest
+  clearQueuedTransactions: vi
     .fn()
     .mockResolvedValue({ ok: true, value: undefined }),
 }))
 
-jest.mock("../lib/firebase", () => ({
-  auth: { currentUser: { getIdToken: jest.fn().mockResolvedValue("token") } },
-  initFirebase: jest.fn(),
+vi.mock("../lib/firebase", () => ({
+  auth: { currentUser: { getIdToken: vi.fn().mockResolvedValue("token") } },
+  initFirebase: vi.fn(),
 }))
 import { initFirebase } from "../lib/firebase"
 
@@ -26,21 +27,21 @@ beforeAll(() => {
   initFirebase()
 })
 
-jest.mock("../hooks/use-toast", () => ({ toast: jest.fn() }))
+vi.mock("../hooks/use-toast", () => ({ toast: vi.fn() }))
 
 describe("ServiceWorker aborts in-flight sync", () => {
-  beforeEach(() => {
-    jest.useFakeTimers()
-    ;(fetch as jest.Mock).mockReset()
-  })
+beforeEach(() => {
+  vi.useFakeTimers()
+  ;(fetch as Mock).mockReset()
+})
 
   afterEach(() => {
-    jest.useRealTimers()
+    vi.useRealTimers()
   })
 
   it("aborts fetch on unmount", async () => {
     let signal: AbortSignal | undefined
-    ;(fetch as jest.Mock).mockImplementation(
+    ;(fetch as Mock).mockImplementation(
       (_url: string, options: { signal: AbortSignal }) => {
         signal = options.signal
         return new Promise(() => {})
@@ -55,7 +56,7 @@ describe("ServiceWorker aborts in-flight sync", () => {
     const { unmount } = render(<ServiceWorker />)
 
     await act(async () => {
-      jest.runOnlyPendingTimers()
+      vi.runOnlyPendingTimers()
     })
 
     expect(signal).toBeDefined()
@@ -67,7 +68,7 @@ describe("ServiceWorker aborts in-flight sync", () => {
 
   it("aborts previous fetch when new sync starts", async () => {
     const signals: AbortSignal[] = []
-    ;(fetch as jest.Mock).mockImplementation(
+    ;(fetch as Mock).mockImplementation(
       (_url: string, options: { signal: AbortSignal }) => {
         signals.push(options.signal)
         return new Promise(() => {})
@@ -82,7 +83,7 @@ describe("ServiceWorker aborts in-flight sync", () => {
     render(<ServiceWorker />)
 
     await act(async () => {
-      jest.runOnlyPendingTimers()
+      vi.runOnlyPendingTimers()
     })
 
     expect(signals[0].aborted).toBe(false)
@@ -94,7 +95,7 @@ describe("ServiceWorker aborts in-flight sync", () => {
     expect(signals[0].aborted).toBe(true)
 
     await act(async () => {
-      jest.runOnlyPendingTimers()
+      vi.runOnlyPendingTimers()
     })
 
     expect(signals[1]).toBeDefined()
@@ -105,7 +106,7 @@ describe("ServiceWorker aborts in-flight sync", () => {
 describe("Service worker registration", () => {
   it("registers with module type", async () => {
     Object.defineProperty(navigator, "serviceWorker", {
-      value: { register: jest.fn().mockResolvedValue(undefined) },
+      value: { register: vi.fn().mockResolvedValue(undefined) },
       configurable: true,
     })
     Object.defineProperty(navigator, "onLine", {
@@ -130,9 +131,9 @@ describe("Service worker registration", () => {
   })
 
   it("updates existing registration when controller is missing", async () => {
-    const register = jest.fn().mockResolvedValue(undefined)
-    const update = jest.fn().mockResolvedValue(undefined)
-    const getRegistration = jest.fn().mockResolvedValue({ update })
+    const register = vi.fn().mockResolvedValue(undefined)
+    const update = vi.fn().mockResolvedValue(undefined)
+    const getRegistration = vi.fn().mockResolvedValue({ update })
     Object.defineProperty(navigator, "serviceWorker", {
       value: {
         register,

--- a/src/__tests__/transactions-sync.test.ts
+++ b/src/__tests__/transactions-sync.test.ts
@@ -2,11 +2,15 @@
  * @jest-environment node
  */
 
-jest.mock("@/lib/transactions", () => {
-  const actual = jest.requireActual("@/lib/transactions")
+import { vi, type Mock } from "vitest"
+
+vi.mock("@/lib/transactions", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/transactions")>(
+    "@/lib/transactions",
+  )
   return {
     ...actual,
-    saveTransactions: jest.fn().mockResolvedValue(undefined),
+    saveTransactions: vi.fn().mockResolvedValue(undefined),
   }
 })
 
@@ -25,7 +29,7 @@ const baseTx = {
 
 describe("/api/transactions/sync persistence", () => {
   beforeEach(() => {
-    (saveTransactions as jest.Mock).mockClear()
+    (saveTransactions as Mock).mockClear()
   })
 
   it("saves transactions via saveTransactions", async () => {
@@ -45,7 +49,7 @@ describe("/api/transactions/sync persistence", () => {
   })
 
   it("propagates persistence errors", async () => {
-    (saveTransactions as jest.Mock).mockRejectedValueOnce(
+    (saveTransactions as Mock).mockRejectedValueOnce(
       Object.assign(new Error("db failed"), { status: 503 }),
     )
 

--- a/src/jest-compat.d.ts
+++ b/src/jest-compat.d.ts
@@ -1,0 +1,8 @@
+import { vi } from 'vitest'
+
+declare global {
+  // eslint-disable-next-line no-var
+  var jest: typeof vi & { requireActual: typeof vi.importActual }
+}
+
+export {}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -54,5 +54,5 @@ process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'test'
 
 // Provide Jest compatibility for existing tests
 // eslint-disable-next-line no-var
-var jest = vi
-globalThis.jest = vi
+var jest = Object.assign(vi, { requireActual: vi.importActual })
+globalThis.jest = jest


### PR DESCRIPTION
## Summary
- replace `jest.Mock` casts with Vitest `Mock`
- polyfill `jest.requireActual` through setup and global typings
- add global `jest` type alias for Vitest

## Testing
- `npm test` *(fails: React is not defined // Cannot find module '../components/service-worker')*
- `npm run build` *(fails: Duplicate export 'getDb')*


------
https://chatgpt.com/codex/tasks/task_e_68b3e50225688331b842b881c80d5a18