### PR TITLE
feat: add internet time utility

### DIFF
--- a/src/lib/internet-time.ts
+++ b/src/lib/internet-time.ts
@@ -1,0 +1,14 @@
+export async function getCurrentTime(): Promise<Date> {
+  try {
+    const response = await fetch('https://worldtimeapi.org/api/ip');
+    if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+    const data = await response.json();
+    const date = new Date(data.datetime);
+    if (isNaN(date.getTime())) throw new Error('Invalid date');
+    return date;
+  } catch {
+    return new Date();
+  }
+}
+
+export default getCurrentTime;


### PR DESCRIPTION
## Summary
- add internet time helper with API fallback

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b44d11c5148331a5eaa8a53ad1c502