### PR TITLE
feat: add service worker component for offline transaction sync

### DIFF
--- a/apps/web/src/components/service-worker.tsx
+++ b/apps/web/src/components/service-worker.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+import { getQueuedTransactions } from '@/lib/offline';
+import * as logger from '@/lib/logger';
+
+export default function ServiceWorker() {
+  useEffect(() => {
+    const id = setInterval(async () => {
+      try {
+        const queued = await getQueuedTransactions();
+        if (!queued.length) return;
+        await fetch('/api/transactions/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(queued),
+        });
+      } catch (e) {
+        logger.error('Failed to sync queued transactions', e);
+      }
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## Summary
- add ServiceWorker client component to periodically sync queued transactions

## Testing
- `pnpm test --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b44d110d988331919ab8eae513a7dc