### PR TITLE
fix: update paths and stabilize tests

### DIFF
--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -28,6 +28,14 @@ jest.mock("idb", () => {
   }
 })
 
+jest.mock("../lib/offline", () => {
+  const actual = jest.requireActual("../lib/offline")
+  return {
+    ...actual,
+    getQueuedTransactions: jest.fn(actual.getQueuedTransactions),
+  }
+})
+
 import {
   queueTransaction,
   getQueuedTransactions,
@@ -107,9 +115,10 @@ describe("offline fallbacks", () => {
 describe("ServiceWorker", () => {
   it("handles queued transaction retrieval errors gracefully", async () => {
     jest.useFakeTimers()
-    const getQueuedSpy = jest
-      .spyOn(offline, "getQueuedTransactions")
-      .mockResolvedValueOnce({ ok: false, error: new Error("failed") })
+    const getQueuedSpy = (offline.getQueuedTransactions as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      error: new Error("failed"),
+    })
 
     const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {})
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,9 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["apps/web/src/*"]
+      "@/*": ["src/*"]
     },
     "skipLibCheck": true
   },
-  "include": ["apps/web", "packages"]
+  "include": ["src", "packages"]
 }


### PR DESCRIPTION
## Summary
- point TypeScript alias to `src` and include new sources
- refactor Firestore mock in housekeeping tests
- mock offline queue helper for reliable service worker tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b44cdab87883318241a0d800d7dc41