### PR TITLE
fix: resolve test imports and mocks

### DIFF
--- a/src/__tests__/housekeeping.test.ts
+++ b/src/__tests__/housekeeping.test.ts
@@ -6,13 +6,7 @@ process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'test';
 process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'test';
 
 import { logger } from "../lib/logger";
-const dataStore: Record<string, Map<string, unknown>> = {
-  transactions: new Map(),
-  transactions_archive: new Map(),
-  debts: new Map(),
-  goals: new Map(),
-  backups: new Map(),
-};
+var dataStore: Record<string, Map<string, unknown>>;
 
 jest.mock('firebase/app', () => ({
   initializeApp: jest.fn(() => ({})),
@@ -29,6 +23,14 @@ jest.mock('../lib/internet-time', () => ({
 }));
 
 jest.mock('firebase/firestore', () => {
+  dataStore = {
+    transactions: new Map(),
+    transactions_archive: new Map(),
+    debts: new Map(),
+    goals: new Map(),
+    backups: new Map(),
+  };
+
   interface QueryConstraint {
     type: string;
     [key: string]: unknown;
@@ -165,7 +167,9 @@ import {
   runWithRetry,
 } from '../services/housekeeping';
 import * as firestore from 'firebase/firestore';
-const store = (firestore as unknown as { __dataStore: typeof dataStore }).__dataStore;
+const store = (
+  firestore as unknown as { __dataStore: Record<string, Map<string, unknown>> }
+).__dataStore;
 
 beforeEach(() => {
   for (const col of Object.values(store)) {

--- a/src/__tests__/offline.test.ts
+++ b/src/__tests__/offline.test.ts
@@ -28,6 +28,14 @@ jest.mock("idb", () => {
   }
 })
 
+jest.mock("../lib/offline", () => {
+  const actual = jest.requireActual("../lib/offline")
+  return {
+    ...actual,
+    getQueuedTransactions: jest.fn(actual.getQueuedTransactions),
+  }
+})
+
 import {
   queueTransaction,
   getQueuedTransactions,
@@ -107,9 +115,9 @@ describe("offline fallbacks", () => {
 describe("ServiceWorker", () => {
   it("handles queued transaction retrieval errors gracefully", async () => {
     jest.useFakeTimers()
-    const getQueuedSpy = jest
-      .spyOn(offline, "getQueuedTransactions")
-      .mockResolvedValueOnce({ ok: false, error: new Error("failed") })
+    const getQueuedSpy = (
+      offline.getQueuedTransactions as jest.Mock
+    ).mockResolvedValueOnce({ ok: false, error: new Error("failed") })
 
     const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {})
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["apps/web/src/*"]
+      "@/*": ["src/*", "apps/web/src/*"]
     },
     "skipLibCheck": true
   },

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "module": "commonjs"
+    "module": "commonjs",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- map `@` alias to both src and app paths for tests
- mock offline queue retrieval for service worker tests
- initialize Firestore datastore in housekeeping tests to avoid hoisting errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4969897b4833186aad62a43aca50f