### PR TITLE
Add internet time utility

### DIFF
--- a/apps/web/src/lib/internet-time.ts
+++ b/apps/web/src/lib/internet-time.ts
@@ -1,0 +1,19 @@
+const API_URL = 'https://worldtimeapi.org/api/ip';
+
+export async function getCurrentTime(): Promise<Date> {
+  try {
+    const response = await fetch(API_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch time: ${response.status} ${response.statusText}`);
+    }
+    const data: { datetime?: string } = await response.json();
+    if (data.datetime) {
+      return new Date(data.datetime);
+    }
+  } catch (error) {
+    // Ignore errors and fall back to local time below.
+  }
+  return new Date();
+}
+
+export default getCurrentTime;


### PR DESCRIPTION
## Summary
- add helper to get current time from worldtimeapi with local fallback

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b4968f814483319873a8813d3e249a