### PR TITLE
test(domain): add goal and chart point schema tests

### DIFF
--- a/packages/domain/__tests__/schemas.test.ts
+++ b/packages/domain/__tests__/schemas.test.ts
@@ -2,6 +2,8 @@ import {
   UserSchema,
   TransactionSchema,
   DebtAccountSchema,
+  GoalSchema,
+  ChartPointSchema,
   RecurrenceValues,
 } from "../src";
 
@@ -76,5 +78,43 @@ describe("domain schemas", () => {
       autopay: false,
     } as unknown;
     expect(() => DebtAccountSchema.parse(bad)).toThrow();
+  });
+
+  it("parses a valid goal", () => {
+    const input = {
+      id: "g1",
+      name: "Save",
+      targetAmount: 1000,
+      currentAmount: 200,
+      deadline: "2024-12-31",
+      importance: 3,
+    };
+    const goal = GoalSchema.parse(input);
+    expect(goal).toEqual(input);
+    expect(JSON.parse(JSON.stringify(goal))).toEqual(input);
+  });
+
+  it("rejects an invalid goal", () => {
+    const bad = {
+      id: "g1",
+      name: "Save",
+      targetAmount: "1000",
+      currentAmount: 200,
+      deadline: "2024-12-31",
+      importance: 3,
+    } as unknown;
+    expect(() => GoalSchema.parse(bad)).toThrow();
+  });
+
+  it("parses a valid chart point", () => {
+    const input = { month: "2024-01", income: 5000, expenses: 3000 };
+    const point = ChartPointSchema.parse(input);
+    expect(point).toEqual(input);
+    expect(JSON.parse(JSON.stringify(point))).toEqual(input);
+  });
+
+  it("rejects an invalid chart point", () => {
+    const bad = { month: "2024-01", income: "5000", expenses: 3000 } as unknown;
+    expect(() => ChartPointSchema.parse(bad)).toThrow();
   });
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 export {
+  type User,
   type Transaction,
   type Goal,
   type ChartPoint,


### PR DESCRIPTION
## Summary
- re-export `User` type from domain package
- expand domain schema tests to cover goals and chart points

## Testing
- `pnpm test packages/domain/__tests__/schemas.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b496743e148331b2140d5f7d1366e8