### PR TITLE
chore: standardize node 20 and pnpm usage

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# This workflow installs dependencies, caches them, builds the source, and runs tests with Node.js 20.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-npm test
+pnpm test
 if git diff --cached --name-only | xargs grep -nE '^\\.{3}$'; then
   echo "Error: file contains standalone '...'" >&2
   exit 1

--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -35,7 +35,7 @@
       enable = true;
       previews = {
         web = {
-          command = ["npm" "run" "dev" "--" "--port" "$PORT" "--hostname" "0.0.0.0"];
+          command = ["pnpm" "run" "dev" "--" "--port" "$PORT" "--hostname" "0.0.0.0"];
           manager = "web";
         };
       };

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This is a NextJS starter in Firebase Studio.
-This project uses pnpm as the canonical package manager. Use pnpm for all dependency management tasks.
+Requires Node.js 20 (see `.nvmrc` and `.node-version`) and uses pnpm as the canonical package manager. Use pnpm for all dependency management tasks.
 To get started, take a look at src/app/page.tsx.
 
 ## Development


### PR DESCRIPTION
## Summary
- document Node.js 20 requirement and enforce pnpm usage
- run pnpm tests in pre-commit and dev environment
- pin GitHub workflows to Node.js 20

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b49670d45483319593daa14964976d