### PR TITLE
test: mock getDb for firebase

### DIFF
--- a/src/__tests__/auth-provider.test.tsx
+++ b/src/__tests__/auth-provider.test.tsx
@@ -18,7 +18,9 @@ jest.mock('@/lib/firebase', () => ({
     currentUser: null,
     app: { options: { apiKey: 'test' }, name: '[DEFAULT]' },
   },
+  db: {},
   initFirebase: jest.fn(),
+  getDb: jest.fn(() => ({})),
 }));
 import { auth as authStub, initFirebase } from '@/lib/firebase';
 

--- a/src/__tests__/categoryService.test.ts
+++ b/src/__tests__/categoryService.test.ts
@@ -6,6 +6,7 @@ jest.mock("@/lib/firebase", () => ({
   db: {},
   categoriesCollection: {},
   initFirebase: jest.fn(),
+  getDb: jest.fn(() => ({})),
 }));
 import { initFirebase } from "@/lib/firebase";
 

--- a/src/__tests__/housekeeping-route.test.ts
+++ b/src/__tests__/housekeeping-route.test.ts
@@ -12,7 +12,11 @@ jest.mock("@/lib/internet-time", () => ({
   getCurrentTime: jest.fn(),
 }));
 
-jest.mock("@/lib/firebase", () => ({ db: {}, initFirebase: jest.fn() }));
+jest.mock("@/lib/firebase", () => ({
+  db: {},
+  initFirebase: jest.fn(),
+  getDb: jest.fn(() => ({})),
+}));
 import { initFirebase } from "@/lib/firebase";
 
 const secret = "test-secret";


### PR DESCRIPTION
## Summary
- mock `getDb` in housekeeping route test
- add `getDb` mock to other firebase-dependent tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4966b15c48331980b93cb274efe85