### PR TITLE
Initialize Firebase auth explicitly

### DIFF
--- a/src/components/auth/auth-provider.tsx
+++ b/src/components/auth/auth-provider.tsx
@@ -12,8 +12,6 @@ import { auth, initFirebase } from "@/lib/firebase";
 import { usePathname, useRouter } from "next/navigation";
 import { z } from "zod";
 
-initFirebase();
-
 interface AuthContextType {
   user: User | null;
 }
@@ -23,6 +21,8 @@ const AuthContext = createContext<AuthContextType>({ user: null });
 export const useAuth = () => useContext(AuthContext);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  initFirebase();
+
   // Attempts to restore a previously signed-in user directly from
   // Firebase's localStorage entry. The SDK stores authenticated users under
   // a key that includes the app's API key and name, allowing us to read it
@@ -49,7 +49,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Keep the `user` state in sync with Firebase auth changes. This runs once
   // on mount and updates whenever the user's sign-in state changes.
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+    const unsubscribe = onAuthStateChanged(auth!, (currentUser) => {
       setUser(currentUser);
     });
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -19,7 +19,7 @@ const firebaseConfigSchema = z.object({
 });
 
 let app: ReturnType<typeof initializeApp> | undefined;
-let auth: ReturnType<typeof getAuth> | undefined;
+let auth!: ReturnType<typeof getAuth>;
 let db: ReturnType<typeof getFirestore> | undefined;
 let categoriesCollection: ReturnType<typeof collection> | undefined;
 
@@ -46,10 +46,15 @@ export function initFirebase() {
     appId: env.NEXT_PUBLIC_FIREBASE_APP_ID,
   };
   
-  app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
-  auth = getAuth(app);
-  db = getFirestore(app);
-  categoriesCollection = collection(db, "categories");
+  try {
+    app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+    auth = getAuth(app);
+    db = getFirestore(app);
+    categoriesCollection = collection(db, "categories");
+  } catch (error) {
+    console.error("Firebase initialization error:", error);
+    throw new Error("Failed to initialize Firebase");
+  }
   return { app, auth, db, categoriesCollection };
 }
 
@@ -60,4 +65,4 @@ export function getDb(): ReturnType<typeof getFirestore> {
   return db!;
 }
 
-export { app, auth, db, categoriesCollection, getDb };
+export { app, auth, db, categoriesCollection };


### PR DESCRIPTION
## Summary
- ensure Firebase initialization throws on failure and `auth` is non-optional
- call `initFirebase` before using `auth` and assert its presence in auth provider

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b49669e9e08331aee70d8772e2038f