### PR TITLE
chore: enable stricter TS checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "nextn",
   "version": "0.1.0",
@@ -19,6 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@genkit-ai/googleai": "^1.18.0",
     "@genkit-ai/next": "^1.14.1",
     "@hookform/resolvers": "^4.1.3",
     "@radix-ui/react-accordion": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@genkit-ai/googleai':
+        specifier: ^1.18.0
+        version: 1.18.0(genkit@1.18.0(@google-cloud/firestore@7.11.3)(firebase-admin@13.5.0)(firebase@11.10.0))
       '@genkit-ai/next':
         specifier: ^1.14.1
         version: 1.18.0(genkit@1.18.0(@google-cloud/firestore@7.11.3)(firebase-admin@13.5.0)(firebase@11.10.0))(next@15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(zod@3.25.76)
@@ -895,6 +898,11 @@ packages:
     peerDependencies:
       genkit: ^1.18.0
 
+  '@genkit-ai/googleai@1.18.0':
+    resolution: {integrity: sha512-W9gNgkb5dA2CZYQ++CKekTR1Al99dMSvjBF73l1EPmDC211CCBbq1metj6QkeSkFfSGhVFLveKUCC7RxIsoPxA==}
+    peerDependencies:
+      genkit: ^1.18.0
+
   '@genkit-ai/next@1.18.0':
     resolution: {integrity: sha512-PYcp6RZWG1FK7TGqPsfECD4Do1PLLkCv2cjdOQFzsVjpKWNHQ6roVVNIGSO3S6JdwnfhClRy189dkQt+KQo5tA==}
     peerDependencies:
@@ -973,6 +981,10 @@ packages:
   '@google-cloud/storage@7.17.0':
     resolution: {integrity: sha512-5m9GoZqKh52a1UqkxDBu/+WVFDALNtHg5up5gNmNbXQWBcV813tzJKsyDtKjOPrlR1em1TxtD7NSPCrObH7koQ==}
     engines: {node: '>=14'}
+
+  '@google/generative-ai@0.24.1':
+    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
+    engines: {node: '>=18.0.0'}
 
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
@@ -7185,6 +7197,16 @@ snapshots:
       - supports-color
     optional: true
 
+  '@genkit-ai/googleai@1.18.0(genkit@1.18.0(@google-cloud/firestore@7.11.3)(firebase-admin@13.5.0)(firebase@11.10.0))':
+    dependencies:
+      '@google/generative-ai': 0.24.1
+      genkit: 1.18.0(@google-cloud/firestore@7.11.3)(firebase-admin@13.5.0)(firebase@11.10.0)
+      google-auth-library: 9.15.1
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@genkit-ai/next@1.18.0(genkit@1.18.0(@google-cloud/firestore@7.11.3)(firebase-admin@13.5.0)(firebase@11.10.0))(next@15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(zod@3.25.76)':
     dependencies:
       genkit: 1.18.0(@google-cloud/firestore@7.11.3)(firebase-admin@13.5.0)(firebase@11.10.0)
@@ -7385,6 +7407,8 @@ snapshots:
       - encoding
       - supports-color
     optional: true
+
+  '@google/generative-ai@0.24.1': {}
 
   '@grpc/grpc-js@1.13.4':
     dependencies:

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -60,4 +60,4 @@ export function getDb(): ReturnType<typeof getFirestore> {
   return db!;
 }
 
-export { app, auth, db, categoriesCollection, getDb };
+export { app, auth, db, categoriesCollection };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,10 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true
   },
   "include": [
     "src",


### PR DESCRIPTION
## Summary
- enable additional TypeScript safety checks
- remove duplicate Firebase export and add missing Google AI dependency

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4966996688331b1346f4b2f568d52